### PR TITLE
fix(jobservice): retry config loading when core is not ready

### DIFF
--- a/src/jobservice/main.go
+++ b/src/jobservice/main.go
@@ -19,6 +19,7 @@ import (
 	"errors"
 	"flag"
 	"fmt"
+	"time"
 
 	"github.com/goharbor/harbor/src/common"
 	"github.com/goharbor/harbor/src/jobservice/common/utils"
@@ -29,6 +30,8 @@ import (
 	"github.com/goharbor/harbor/src/jobservice/runtime"
 	"github.com/goharbor/harbor/src/lib"
 	cfgLib "github.com/goharbor/harbor/src/lib/config"
+	"github.com/goharbor/harbor/src/lib/log"
+	"github.com/goharbor/harbor/src/lib/retry"
 	tracelib "github.com/goharbor/harbor/src/lib/trace"
 	_ "github.com/goharbor/harbor/src/pkg/accessory/model/base"
 	_ "github.com/goharbor/harbor/src/pkg/accessory/model/cosign"
@@ -46,7 +49,16 @@ func main() {
 	lib.StartPprof()
 
 	cfgLib.DefaultCfgManager = common.RestCfgManager
-	if err := cfgLib.DefaultMgr().Load(context.Background()); err != nil {
+	if err := retry.Retry(func() error {
+		return cfgLib.DefaultMgr().Load(context.Background())
+	},
+		retry.InitialInterval(500*time.Millisecond),
+		retry.MaxInterval(10*time.Second),
+		retry.Timeout(5*time.Minute),
+		retry.Callback(func(err error, sleep time.Duration) {
+			log.Infof("failed to load configuration from core, retry after %s: %v", sleep, err)
+		}),
+	); err != nil {
 		panic(fmt.Sprintf("failed to load configuration, error: %v", err))
 	}
 


### PR DESCRIPTION
## Summary

- JobService panics on startup when Core's HTTP server isn't ready yet (`connection refused` on REST config load)
- Wraps config loading in `retry.Retry()` with exponential backoff (500ms initial, 10s max, 5min timeout)
- Mirrors the exact pattern Core already uses to wait for JobService at startup (`src/core/main.go` ~L289)

Closes #13

## Test plan

- [ ] `go build` / `go_build_check` passes (verified)
- [ ] `task dev:up` — JobService logs retries and connects once Core is ready
- [ ] Kill Core, restart both — JobService retries gracefully instead of panicking

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevent JobService from panicking on startup by retrying config loading until Core is ready. This makes startup resilient when Core’s HTTP server isn’t up yet.

- **Bug Fixes**
  - Wrapped configuration load in retry with exponential backoff (500ms initial, 10s max, 5min timeout).
  - Logs each retry and only panics after timeout.
  - Mirrors Core’s existing startup wait pattern.

<sup>Written for commit 93a9bd4b5d4007b50e46a32213642f3230e76622. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

