### PR TITLE
fix(jobservice): retry config loading when core is not ready

### DIFF
--- a/src/jobservice/main.go
+++ b/src/jobservice/main.go
@@ -19,6 +19,7 @@ import (
 	"errors"
 	"flag"
 	"fmt"
+	"time"
 
 	"github.com/goharbor/harbor/src/common"
 	"github.com/goharbor/harbor/src/jobservice/common/utils"
@@ -29,6 +30,8 @@ import (
 	"github.com/goharbor/harbor/src/jobservice/runtime"
 	"github.com/goharbor/harbor/src/lib"
 	cfgLib "github.com/goharbor/harbor/src/lib/config"
+	"github.com/goharbor/harbor/src/lib/log"
+	"github.com/goharbor/harbor/src/lib/retry"
 	tracelib "github.com/goharbor/harbor/src/lib/trace"
 	_ "github.com/goharbor/harbor/src/pkg/accessory/model/base"
 	_ "github.com/goharbor/harbor/src/pkg/accessory/model/cosign"
@@ -46,7 +49,16 @@ func main() {
 	lib.StartPprof()
 
 	cfgLib.DefaultCfgManager = common.RestCfgManager
-	if err := cfgLib.DefaultMgr().Load(context.Background()); err != nil {
+	if err := retry.Retry(func() error {
+		return cfgLib.DefaultMgr().Load(context.Background())
+	},
+		retry.InitialInterval(500*time.Millisecond),
+		retry.MaxInterval(10*time.Second),
+		retry.Timeout(5*time.Minute),
+		retry.Callback(func(err error, sleep time.Duration) {
+			log.Debugf("failed to load configuration from core, retry after %s: %v", sleep, err)
+		}),
+	); err != nil {
 		panic(fmt.Sprintf("failed to load configuration, error: %v", err))
 	}
 


### PR DESCRIPTION
Cherry-pick of #14 to main. JobService panics on startup when Core is not ready yet (connection refused on REST config load). Wraps config loading in retry.Retry() with exponential backoff (500ms initial, 10s max, 5min timeout), mirroring the pattern Core uses to wait for JobService. Closes #13

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add retry with exponential backoff around JobService config loading from Core to prevent startup panics when Core isn’t ready. This makes startup resilient and avoids failures on first boot.

- Bug Fixes
  - Wrap config load in retry.Retry with 500ms initial, 10s max interval, 5min timeout.
  - Log each retry with the next sleep duration.
  - Mirrors Core’s existing wait pattern for JobService, preventing connection-refused panics.

<sup>Written for commit 8f1e9a18755e7f043b7b7fe6e12e8882ca945b2c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced configuration loading with retry logic to improve system resilience and stability during startup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->