### PR TITLE
Fix proxy.config.mjs not found

### DIFF
--- a/devenv/docker-compose.yml
+++ b/devenv/docker-compose.yml
@@ -214,7 +214,7 @@ services:
       - ../src/portal/angular.json:/app/angular.json:ro
       - ../src/portal/tsconfig.json:/app/tsconfig.json:ro
       - ../src/portal/tsconfig.app.json:/app/tsconfig.app.json:ro
-      - ../src/portal/proxy.config.mjs.temp:/app/proxy.config.mjs:ro
+      - ../src/portal/proxy.config.mjs.local:/app/proxy.config.mjs:ro
       - ../src/portal/ng-swagger-gen:/app/ng-swagger-gen:ro
       - portal-angular-cache:/app/.angular
     ports:

--- a/devenv/docker-compose.yml
+++ b/devenv/docker-compose.yml
@@ -214,7 +214,7 @@ services:
       - ../src/portal/angular.json:/app/angular.json:ro
       - ../src/portal/tsconfig.json:/app/tsconfig.json:ro
       - ../src/portal/tsconfig.app.json:/app/tsconfig.app.json:ro
-      - ../src/portal/proxy.config.mjs:/app/proxy.config.mjs:ro
+      - ../src/portal/proxy.config.mjs.temp:/app/proxy.config.mjs:ro
       - ../src/portal/ng-swagger-gen:/app/ng-swagger-gen:ro
       - portal-angular-cache:/app/.angular
     ports:

--- a/src/portal/proxy.config.mjs.local
+++ b/src/portal/proxy.config.mjs.local
@@ -1,0 +1,45 @@
+import HttpsProxyAgent from 'https-proxy-agent';
+// Proxy target - configurable for Docker (core:8080) vs local (localhost:8080)
+const proxyTarget = process.env.HARBOR_PROXY_TARGET || "http://localhost:8080";
+// Define the proxy configuration
+const HarborProxyConfig = [
+  {
+    "context": [
+      "/api",
+      "/c",
+      "/i18n",
+      "/chartrepo",
+      "/LICENSE",
+      "/swagger.json",
+      "/swagger2.json",
+      "/devcenter-api-2.0",
+      "/swagger-ui.bundle.js",
+      "/v2",
+      "/service"
+    ],
+    "target": proxyTarget,
+    "secure": false,
+    "changeOrigin": false,
+    "logLevel": "debug"
+  }
+];
+// Define if you use agent
+const useAgent = false;
+// Specify an agent server, if empty, will read it from environment variable http_proxy or HTTP_PROXY
+const specifiedAgentServer = "${An agent server}";
+
+function setupForCorporateProxy(proxyConfig) {
+  if (useAgent) {
+    const agentServer = process.env.http_proxy || process.env.HTTP_PROXY || specifiedAgentServer;
+    if (agentServer) {
+      const agent = new HttpsProxyAgent(agentServer);
+      console.log('Using corporate agent server: ' + agentServer);
+      proxyConfig.forEach(function(entry) {
+        entry.agent = agent;
+      });
+    }
+  }
+  return proxyConfig;
+}
+
+export default setupForCorporateProxy(HarborProxyConfig);


### PR DESCRIPTION
Fixes `task dev:up` where the portal fails to start.

Errors in logs without it:

```
- Generating browser application bundles (phase: setup)...
An unhandled exception occurred: Directory import '/app/proxy.config.mjs' is not supported resolving ES modules imported from /app/node_modules/@angular-devkit/build-angular/src/utils/load-esm.js
See "/tmp/ng-JeeHdp/angular-errors.log" for further details.
Warning: Running a server with --disable-host-check is a security risk. See https://medium.com/webpack/webpack-dev-server-middleware-security-issues-1489d950874a for more information.
NOTICE: Hot Module Replacement (HMR) is enabled for the dev server.
See https://webpack.js.org/guides/hot-module-replacement for information on working with HMR for Webpack.
```

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix dev portal startup in task dev:up by mounting a local proxy config with local defaults. This prevents the Angular dev server ES module error so the portal boots.

- **Bug Fixes**
  - Mount src/portal/proxy.config.mjs.local to /app/proxy.config.mjs in devenv/docker-compose.yml.
  - Add src/portal/proxy.config.mjs.local with default target http://localhost:8080 and HARBOR_PROXY_TARGET override; corporate agent disabled by default.

<sup>Written for commit e0b94d1286475c1876ce51624b6f577bf8bec956. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Development environment now uses an alternate local proxy configuration for the portal, swapping the runtime source while keeping the deployed container path unchanged.
* **New Features**
  * Proxy config gains optional corporate-proxy agent support (enabled via environment), a sensible default target, and enhanced debug logging for proxy activity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->