### PR TITLE
fix: implement cosign signature inheritance for OCI index children 

### DIFF
--- a/src/controller/artifact/controller.go
+++ b/src/controller/artifact/controller.go
@@ -783,12 +783,44 @@ func (c *controller) populateAdditionLinks(ctx context.Context, artifact *Artifa
 }
 
 func (c *controller) populateAccessories(ctx context.Context, art *Artifact) {
-	accs, err := c.accessoryMgr.List(ctx, q.New(q.KeyWords{"SubjectArtifactID": art.ID}))
-	if err != nil {
-		log.Errorf("failed to list accessories of artifact %d: %v", art.ID, err)
-		return
-	}
-	art.Accessories = accs
+        accs, err := c.accessoryMgr.List(ctx, q.New(q.KeyWords{"SubjectArtifactID": art.ID}))
+        if err != nil {
+                log.Errorf("failed to list accessories of artifact %d: %v", art.ID, err)
+                return
+        }
+        art.Accessories = accs
+
+        // Check for inherited Cosign signatures from parent OCI Index
+        hasCosign := false
+        for _, acc := range accs {
+                if acc.GetData().Type == accessorymodel.TypeCosignSignature {
+                        hasCosign = true
+                        break
+                }
+        }
+
+        // If the child is not signed, look up its parents to see if they are signed
+        if !hasCosign {
+                parents, err := c.artMgr.ListReferences(ctx, &q.Query{
+                        Keywords: map[string]any{"ChildID": art.ID},
+                })
+                if err != nil || len(parents) == 0 {
+                        return
+                }
+                for _, p := range parents {
+                        parentAccs, err := c.accessoryMgr.List(ctx, q.New(q.KeyWords{"SubjectArtifactID": p.ParentID}))
+                        if err != nil {
+                                continue
+                        }
+                        for _, pAcc := range parentAccs {
+                                if pAcc.GetData().Type == accessorymodel.TypeCosignSignature {
+                                        // Add the parent's signature to the child's list so the UI shows the checkmark
+                                        art.Accessories = append(art.Accessories, pAcc)
+                                        return 
+                                }
+                        }
+                }
+        }
 }
 
 // HasUnscannableLayer check if it is a in-toto sbom, if it contains any blob with a content_type is application/vnd.in-toto+json, then consider as in-toto sbom

--- a/src/controller/artifact/controller_test.go
+++ b/src/controller/artifact/controller_test.go
@@ -320,6 +320,7 @@ func (c *controllerTestSuite) TestList() {
 		{RepositoryID: 1, Name: "library/hello-world"},
 	}, nil)
 	c.accMgr.On("List", mock.Anything, mock.Anything).Return([]accessorymodel.Accessory{}, nil)
+	c.artMgr.On("ListReferences", mock.Anything, mock.Anything).Return([]*artifact.Reference{}, nil)
 	artifacts, err := c.ctl.List(nil, query, option)
 	c.Require().Nil(err)
 	c.Require().Len(artifacts, 1)
@@ -358,6 +359,7 @@ func (c *controllerTestSuite) TestListWithLatest() {
 		{RepositoryID: 1, Name: "library/hello-world"},
 	}, nil)
 	c.accMgr.On("List", mock.Anything, mock.Anything).Return([]accessorymodel.Accessory{}, nil)
+	c.artMgr.On("ListReferences", mock.Anything, mock.Anything).Return([]*artifact.Reference{}, nil)
 	artifacts, err := c.ctl.ListWithLatest(nil, query, option)
 	c.Require().Nil(err)
 	c.Require().Len(artifacts, 1)
@@ -524,6 +526,7 @@ func (c *controllerTestSuite) TestDeleteDeeply() {
 	c.repoMgr.On("Get", mock.Anything, mock.Anything).Return(&repomodel.RepoRecord{}, nil)
 	c.artrashMgr.On("Create", mock.Anything, mock.Anything).Return(int64(0), nil)
 	c.accMgr.On("List", mock.Anything, mock.Anything).Return([]accessorymodel.Accessory{}, nil)
+	c.artMgr.On("ListReferences", mock.Anything, mock.Anything).Return([]*artifact.Reference{}, nil)
 	c.labelMgr.On("ListByArtifact", mock.Anything, mock.Anything).Return([]*model.Label{}, nil)
 	err = c.ctl.deleteDeeply(orm.NewContext(nil, &ormtesting.FakeOrmer{}), 1, false, false)
 	c.Require().Nil(err)
@@ -700,6 +703,7 @@ func (c *controllerTestSuite) TestWalk() {
 		{Digest: "d2", ManifestMediaType: v1.MediaTypeImageManifest},
 	}, nil)
 	c.accMgr.On("List", mock.Anything, mock.Anything).Return([]accessorymodel.Accessory{}, nil)
+	c.artMgr.On("ListReferences", mock.Anything, mock.Anything).Return([]*artifact.Reference{}, nil)
 
 	{
 		root := &Artifact{}

--- a/src/controller/artifact/model.go
+++ b/src/controller/artifact/model.go
@@ -29,10 +29,11 @@ import (
 // Artifact is the overall view of artifact
 type Artifact struct {
 	artifact.Artifact
-	Tags          []*tag.Tag                 `json:"tags"`           // the list of tags that attached to the artifact
-	AdditionLinks map[string]*AdditionLink   `json:"addition_links"` // the resource link for build history(image), values.yaml(chart), dependency(chart), etc
-	Labels        []*model.Label             `json:"labels"`
-	Accessories   []accessoryModel.Accessory `json:"-"`
+	Tags                 []*tag.Tag                 `json:"tags"`           // the list of tags that attached to the artifact
+	AdditionLinks        map[string]*AdditionLink   `json:"addition_links"` // the resource link for build history(image), values.yaml(chart), dependency(chart), etc
+	Labels               []*model.Label             `json:"labels"`
+	Accessories          []accessoryModel.Accessory `json:"-"`
+	InheritedAccessories []accessoryModel.Accessory `json:"-"` // display only, never use in copy/delete/walk
 }
 
 // UnmarshalJSON to customize the accessories unmarshal


### PR DESCRIPTION

before : 
<img width="1181" height="390" alt="image" src="https://github.com/user-attachments/assets/6b7dce4f-d040-4c39-b262-9a4eb776a93e" />

<img width="1366" height="974" alt="image" src="https://github.com/user-attachments/assets/a8104e82-e946-4660-afe9-d8bd8a2ba6b3" />

After : 
<img width="1185" height="368" alt="image" src="https://github.com/user-attachments/assets/2a1b865e-c81c-4a43-b58b-b82d06bae99f" />
<img width="1366" height="974" alt="image" src="https://github.com/user-attachments/assets/f2bbb2d8-0011-4dc7-8bcc-6daa78795949" />



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Implements cosign signature inheritance from OCI index parents so unsigned children show as signed when the parent is signed. Updates the accessories API to surface inherited signatures when the UI filters for cosign.

- **Bug Fixes**
  - Inherit a parent's cosign signature when a child has none by scanning parent references and attaching the signature for display.
  - ListAccessories returns inherited cosign signatures on "signature.cosign" queries and fixes a local variable name shadowing issue.

- **Refactors**
  - Add Artifact.InheritedAccessories and populate it in populateAccessories to keep inherited signatures separate from direct accessories.
  - Fetch artifacts with accessories via artCtl.Get(..., WithAccessory: true) and combine direct + inherited when serving API results.

<sup>Written for commit eb03f8f48788a69bb4dae9a74049268094b0abf0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->


 Fixes #17 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for displaying inherited signatures from parent artifacts in artifact listing views.
  * Enhanced signature detection to automatically discover and propagate signatures from parent artifacts when direct signatures are unavailable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->