### PR TITLE
fix(devenv): registryctl crashes on startup , missing config file argument

### DIFF
--- a/devenv/air.registryctl.toml
+++ b/devenv/air.registryctl.toml
@@ -10,7 +10,7 @@ tmp_dir = "tmp"
   cmd = "cd src && CGO_ENABLED=0 go build -gcflags=all='-N -l' -trimpath -o ../tmp/registryctl ./registryctl/main.go"
 
   bin = "tmp/registryctl"
-  args_bin = []
+  args_bin = ["-c", "devenv/registryctl.config.yml"]
 
   # Delve debugger on port 2347, starts immediately (--continue)
   # Attach anytime with: dlv connect localhost:2347

--- a/devenv/air.registryctl.toml
+++ b/devenv/air.registryctl.toml
@@ -10,7 +10,7 @@ tmp_dir = "tmp"
   cmd = "cd src && CGO_ENABLED=0 go build -gcflags=all='-N -l' -trimpath -o ../tmp/registryctl ./registryctl/main.go"
 
   bin = "tmp/registryctl"
-  args_bin = ["-c", "devenv/registryctl.config.yml"]
+  args_bin = ["-c", "config/registryctl.yml"]
 
   # Delve debugger on port 2347, starts immediately (--continue)
   # Attach anytime with: dlv connect localhost:2347


### PR DESCRIPTION
## Problem
when runing task `dev:infra:up`  or `task dev:up` egistryctl exits immediately with:
```
2026-02-22T08:10:35Z warn layer=rpc Listening for remote connections (connections are not authenticated nor encrypted)
2026-02-22T08:10:37Z [DEBUG] [/lib/pprof.go:32]: pprof not enabled; set PPROF_ENABLED=true to enable
Usage of /app/tmp/registryctl:
  -c string
        Specify registryCtl configuration file path
2026-02-22T08:10:37Z [FATAL] [./main.go:103]: Config file should be specified
Stop reason: exited
```
## Change

In `devenv/air.registryctl.toml`, changed:
```toml
args_bin = []
```
to:
```toml
args_bin = ["-c", "devenv/registryctl.config.yml"]
```

## Testing

Verified registryctl starts successfully and responds to health checks:
```
"GET /api/health HTTP/1.1" 200
```


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes registryctl exiting on startup in the dev environment by passing the missing config file argument. dev:infra:up and dev:up now start successfully, and the health check returns 200.

- **Bug Fixes**
  - Set args_bin to ["-c", "devenv/registryctl.config.yml"] in devenv/air.registryctl.toml.

<sup>Written for commit df63ab3e08d63ffbc67eb1ef6bf191ea74a03b7a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated build/startup configuration for the registry control tool so it now supplies a specific configuration file path at runtime.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->