### PR TITLE
fix(devenv): use openssl genrsa -traditional to generate PKCS#1 RSA key

### DIFF
--- a/taskfile/dev.yml
+++ b/taskfile/dev.yml
@@ -82,7 +82,7 @@ tasks:
     status:
       - test -f {{.TOKEN_KEY_FILE}}
     cmds:
-      - openssl genpkey -algorithm RSA -out {{.TOKEN_KEY_FILE}} -pkeyopt rsa_keygen_bits:4096
+      - openssl genrsa -traditional -out {{.TOKEN_KEY_FILE}} 4096
       - chmod 600 {{.TOKEN_KEY_FILE}}
       - echo "Generated {{.TOKEN_KEY_FILE}}"
 


### PR DESCRIPTION
## Problem

`task dev:gen:private-key` generates a PKCS#8 key (`BEGIN PRIVATE KEY`) 
but Harbor token service requires PKCS#1 (`BEGIN RSA PRIVATE KEY`), 
causing `docker login` to fail with 500 Internal Server Error.

## Change

In `taskfile/dev.yml`, changed:
```bash
openssl genpkey -algorithm RSA -out {{.TOKEN_KEY_FILE}} -pkeyopt rsa_keygen_bits:4096
```
to:
```bash
openssl genrsa -traditional -out {{.TOKEN_KEY_FILE}} 4096
```

## Testing

1. `task dev:clean`
2. `task dev:gen:private-key`
3. Verified `head -1 devenv/token_service_key.pem` shows `-----BEGIN RSA PRIVATE KEY-----`
```
root@PC:/home/ikram/harbor-next# head -1 devenv/token_service_key.pem
-----BEGIN RSA PRIVATE KEY-----
```
4. `docker login localhost:8080 -u admin -p Harbor12345` → `Login Succeeded`
```
root@PC:/home/ikram/harbor-next# docker login localhost:8080 -u admin -p Harbor12345
WARNING! Using --password via the CLI is insecure. Use --password-stdin.
Login Succeeded
root@PC:/home/ikram/harbor-next#
```
FIxes #29

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Generate a PKCS#1 RSA private key in the dev environment to match Harbor token service requirements and stop docker login 500 errors. Replaced openssl genpkey with openssl genrsa -traditional 4096 in taskfile/dev.yml.

<sup>Written for commit 1112e3fdec17f36edb056c95c9ceb0321ce49864. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated development task configuration for improved key generation process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->