### PR TITLE
feat(portal): Add Repository-Level Pull Command to Artifact List Tab

### DIFF
--- a/src/portal/src/app/base/project/repository/artifact/artifact-list-page/artifact-list/artifact-list-tab/artifact-list-tab.component.html
+++ b/src/portal/src/app/base/project/repository/artifact/artifact-list-page/artifact-list/artifact-list-tab/artifact-list-tab.component.html
@@ -180,6 +180,12 @@
                     </clr-dropdown>
                 </div>
                 <div class="right-pos">
+                    <app-pull-command
+                        [registryUrl]="registryUrl"
+                        [projectName]="projectName"
+                        [repoName]="repoName"
+                        [isTopModel]="true"
+                        class="mr-1"></app-pull-command>
                     <app-artifact-filter
                         [withDivider]="true"
                         (filterEvent)="filterEvent($event)"

--- a/src/portal/src/app/base/project/repository/artifact/artifact-list-page/artifact-list/artifact-list-tab/pull-command/pull-command.component.html
+++ b/src/portal/src/app/base/project/repository/artifact/artifact-list-page/artifact-list/artifact-list-tab/pull-command/pull-command.component.html
@@ -1,4 +1,13 @@
-<clr-dropdown *ngIf="!isTagMode">
+<div *ngIf="isTopModel" class="form-group">
+    <hbr-copy-input
+        #copyInputComponent
+        (onCopySuccess)="onCpSuccess(getPullCommandForTopModel())"
+        inputSize="55"
+        headerTitle=""
+        defaultValue="{{ getPullCommandForTopModel() }}"></hbr-copy-input>
+</div>
+
+<clr-dropdown *ngIf="!isTopModel && !isTagMode">
     <hbr-copy-input
         *ngIf="isImage(artifact)"
         [title]="getPullCommandForRuntimeByDigest(artifact)"
@@ -36,7 +45,7 @@
 
 <clr-dropdown
     class="mr-1"
-    *ngIf="isTagMode"
+    *ngIf="isTagMode && !isTopModel"
     [disabled]="!hasPullCommandForTag(artifact)">
     <hbr-copy-input
         *ngIf="isImage(artifact)"

--- a/src/portal/src/app/base/project/repository/artifact/artifact-list-page/artifact-list/artifact-list-tab/pull-command/pull-command.component.ts
+++ b/src/portal/src/app/base/project/repository/artifact/artifact-list-page/artifact-list/artifact-list-tab/pull-command/pull-command.component.ts
@@ -19,6 +19,7 @@ import {
     Clients,
     getPullCommandByDigest,
     getPullCommandByTag,
+    getPullCommandForTop,
     hasPullCommand,
 } from '../../../../artifact';
 import { getContainerRuntime } from 'src/app/shared/units/shared.utils';
@@ -31,6 +32,8 @@ import { TranslateService } from '@ngx-translate/core';
     styleUrls: ['./pull-command.component.scss'],
 })
 export class PullCommandComponent {
+    @Input()
+    isTopModel: boolean = false; // TopModel is for tab top component,
     @Input()
     isTagMode: boolean = false; // tagMode is for tag list datagrid,
     @Input()
@@ -75,6 +78,15 @@ export class PullCommandComponent {
         const client = Object.values(Clients).find(client => client == runtime);
         // return client if match found otherwise return (DOCKER)
         return client ? client : Clients.DOCKER;
+    }
+
+    getPullCommandForTopModel(): string {
+        return getPullCommandForTop(
+            `${this.registryUrl ? this.registryUrl : location.hostname}/${
+                this.projectName
+            }/${this.repoName}`,
+            this.getSelectedClient()
+        );
     }
 
     getPullCommandForRuntimeByDigest(artifact: Artifact): string {

--- a/src/portal/src/app/base/project/repository/artifact/artifact-list-page/artifact-list/artifact-list-tab/pull-command/pull-command.component.ts
+++ b/src/portal/src/app/base/project/repository/artifact/artifact-list-page/artifact-list/artifact-list-tab/pull-command/pull-command.component.ts
@@ -86,7 +86,7 @@ export class PullCommandComponent {
                 this.projectName
             }/${this.repoName}`,
             this.getSelectedClient()
-        );
+        ) || '';
     }
 
     getPullCommandForRuntimeByDigest(artifact: Artifact): string {

--- a/src/portal/src/app/base/project/repository/artifact/artifact.ts
+++ b/src/portal/src/app/base/project/repository/artifact/artifact.ts
@@ -115,6 +115,18 @@ export function hasPullCommand(artifact: Artifact): boolean {
     );
 }
 
+export function getPullCommandForTop(url: string, client: Clients): string {
+    if (url) {
+        if (Object.values(Clients).includes(client)) {
+            if (client == 'custom') {
+                return `${getCustomContainerRuntime()} pull ${url}`;
+            }
+            return `${client} pull ${url}`;
+        }
+    }
+    return null;
+}
+
 export function getPullCommandByDigest(
     artifactType: string,
     url: string,

--- a/src/portal/src/app/base/project/repository/artifact/artifact.ts
+++ b/src/portal/src/app/base/project/repository/artifact/artifact.ts
@@ -115,7 +115,7 @@ export function hasPullCommand(artifact: Artifact): boolean {
     );
 }
 
-export function getPullCommandForTop(url: string, client: Clients): string {
+export function getPullCommandForTop(url: string, client: Clients): string | null {
     if (url) {
         if (Object.values(Clients).includes(client)) {
             if (client == 'custom') {


### PR DESCRIPTION
## Summary
  - Adds a copy-able pull command input at the top of the artifact list tab, scoped to the repository (not a specific
  artifact/digest)
  - Introduces an isTopModel flag on PullCommandComponent to render a flat hbr-copy-input instead of the per-artifact dropdown
  - Adds getPullCommandForTop() helper in artifact.ts that builds the pull command from registry URL, project, and repo name, respecting the selected container runtime (including custom)
  - Hides the existing per-artifact dropdowns when isTopModel is active to avoid duplication

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a repository-level copyable pull command at the top of the Artifact List tab. Uses the selected container runtime and hides per-artifact dropdowns to avoid duplication.

- **New Features**
  - PullCommandComponent: added isTopModel to render a flat hbr-copy-input at the tab top and suppress per-artifact menus.
  - Command generation: getPullCommandForTop builds "client pull <registry/project/repo>" and supports custom runtime.

<sup>Written for commit dda7874218982d6bca6bc583b14714e688a63d59. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a pull-command control for top-level artifacts in the artifact list so users can view and copy a top-model-specific pull command.
  * Updated pull-command UI to prioritize top-model display and adjust visibility of other copy options (runtime-by-digest, CNAB, chart, tag-mode) accordingly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->