### PR TITLE
feat: Randomise Seconds When Scheduling Jobs

### DIFF
--- a/src/pkg/scheduler/scheduler.go
+++ b/src/pkg/scheduler/scheduler.go
@@ -18,6 +18,8 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"math/rand"
+	"strings"
 	"time"
 
 	"github.com/goharbor/harbor/src/common/utils"
@@ -97,6 +99,7 @@ func (s *scheduler) Schedule(ctx context.Context, vendorType string, vendorID in
 	if len(vendorType) == 0 {
 		return 0, fmt.Errorf("empty vendor type")
 	}
+	cron = fmt.Sprintf("%d %s", rand.Intn(60), strings.Join(strings.Split(cron, " ")[1:], " "))
 	if _, err := utils.CronParser().Parse(cron); err != nil {
 		return 0, errors.New(nil).WithCode(errors.BadRequestCode).
 			WithMessagef("invalid cron %s: %v", cron, err)


### PR DESCRIPTION
## Summary
- Randomises the seconds component when scheduling jobs in the Harbor scheduler to avoid thundering herd effect when many jobs start simultaneously.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Randomizes the seconds in cron schedules to spread job start times and reduce thundering herd load. The scheduler now prefixes a random 0–59 second to the provided cron before parsing.

- **New Features**
  - Overrides the cron seconds field with a random value while preserving minute and higher fields.

<sup>Written for commit 94499ef97177e1c34afafe588ee4c6a525e737f3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

