### PR TITLE
fix: Proxy Cache Fallback Local - Even When Remote Does Not Exist

### DIFF
--- a/src/controller/proxy/controller.go
+++ b/src/controller/proxy/controller.go
@@ -188,6 +188,11 @@ func (c *controller) UseLocalManifest(ctx context.Context, art lib.ArtifactInfo,
 		return false, nil, err
 	}
 	if !exist || desc == nil {
+		if a != nil { // if not found, use local if it exists, because a exist, otherwise return error
+			log.Debugf("Artifact not found in remote registry but exists in local cache, serving from local: %v:%v", art.Repository, art.Tag)
+			return true, nil, nil
+		}
+
 		dig, err := c.getManifestDigestInLocal(ctx, art)
 		if err != nil {
 			// skip to delete when error, use debug level log to avoid too many logs when the manifest is removed from upstream

--- a/src/controller/proxy/controller_test.go
+++ b/src/controller/proxy/controller_test.go
@@ -147,15 +147,15 @@ func (p *proxyControllerTestSuite) TestUseLocalManifest_429ToLocal() {
 	p.Assert().True(result)
 }
 
-func (p *proxyControllerTestSuite) TestUseLocalManifestWithTag_False() {
+func (p *proxyControllerTestSuite) TestUseLocalManifestWithTag_True() {
 	ctx := context.Background()
 	art := lib.ArtifactInfo{Repository: "library/hello-world", Tag: "latest"}
 	desc := &distribution.Descriptor{}
 	p.local.On("GetManifest", mock.Anything, mock.Anything).Return(&artifact.Artifact{}, nil)
 	p.remote.On("ManifestExist", mock.Anything, mock.Anything).Return(false, desc, nil)
 	result, _, err := p.ctr.UseLocalManifest(ctx, art, p.remote)
-	p.Assert().True(errors.IsNotFoundErr(err))
-	p.Assert().False(result)
+	p.Assert().Nil(err)
+	p.Assert().True(result)
 }
 
 func (p *proxyControllerTestSuite) TestUseLocalBlob_True() {


### PR DESCRIPTION
## Summary
- Return a cached image from the proxy cache controller even if the remote registry is unreachable or does not exist
- Update controller tests to reflect the new behavior

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Serve cached images from the proxy cache when the remote registry is missing or unreachable, instead of returning a NotFound error. This improves resilience and keeps pulls working from the local cache.

- **Bug Fixes**
  - Updated UseLocalManifest to fall back to local when the remote manifest doesn’t exist.
  - Adjusted controller tests to expect a successful local fallback (nil error, true result).

<sup>Written for commit e9237fe715c551fedc96b29b201d1c6ec04d7cb2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

