### PR TITLE
build(portal): Use Native Platform for Angular Build Stage

### DIFF
--- a/dockerfile/portal.dockerfile
+++ b/dockerfile/portal.dockerfile
@@ -6,7 +6,7 @@ ARG LPROBE_VERSION=MISSING-BUILD-ARG
 
 #
 # Build Angular application and Swagger UI
-FROM oven/bun:${BUN_VERSION}-alpine AS builder
+FROM --platform=$BUILDPLATFORM oven/bun:${BUN_VERSION}-alpine AS builder
 # nodejs required: bun hangs on Angular/webpack build inside Docker (oven-sh/bun#15226)
 RUN apk add --no-cache nodejs
 WORKDIR /harbor/src/portal


### PR DESCRIPTION
## Summary
- Add `--platform=$BUILDPLATFORM` to the portal Dockerfile builder stage so the Angular/Bun compilation runs natively instead of under QEMU emulation
- The build output is static HTML/CSS/JS (platform-independent), so only the runtime nginx stage needs the target platform
- Reduces portal arm64 build time from ~25min+ down to ~2-3min

## Related Issues
<!-- Fixes # -->

## Type of Change
- [ ] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` / `fix!:`)
- [ ] Documentation (`docs:`)
- [ ] Refactoring (`refactor:`)
- [x] CI/CD or build changes (`ci:` / `build:`)
- [ ] Dependencies update (`chore:`)
- [ ] Tests (`test:`)

## Release Notes
<!-- CI-only change, no user-facing release notes needed. -->

## Testing
- [ ] Unit tests added/updated
- [x] Manual testing performed

## Checklist
- [x] PR title follows Conventional Commits format
- [x] Commits are signed off (`git commit -s`)
- [x] No new warnings introduced