### PR TITLE
fix: add -trimpath to go build flags to prevent local path leaks

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -19,7 +19,7 @@ vars:
 
   GOPATH_BIN:
     sh: echo "${GOBIN:-$(go env GOPATH)/bin}"
-  GOBUILD_FLAGS: "-buildvcs=false"
+  GOBUILD_FLAGS: "-buildvcs=false -trimpath"
   DISTRIBUTION_SRC: "https://github.com/distribution/distribution.git"
   NPM_REGISTRY: "https://registry.npmjs.org/"
 


### PR DESCRIPTION
**Resolves #90**

### Summary
Production logs were showing absolute local build machine filesystem paths (e.g., `/home/user/.../main.go`) instead of clean, module-relative paths. This PR adds the missing `-trimpath` compiler flag to the build scripts to ensure local environments do not leak into the compiled binaries and stack traces.


### Testing Performed
1. **Binary Verification**: Ran `go version -m bin/linux-amd64/core` and verified that `build -trimpath=true` is successfully embedded in the binary metadata.
```
aloui@hp:~/Desktop/harbor-next$ go version -m bin/linux-amd64/core | grep trimpath
	build	-trimpath=true

```
2. **Execution Verification**: Executed the `core` binary locally to trigger a startup failure. Verified the panic logs now show clean, trimmed paths (e.g., `[./main.go:170]`) instead of absolute local paths.
```
aloui@hp:~/Desktop/harbor-next$ ./bin/linux-amd64/core
init global config instance failed. If you do not use this, just ignore it.  open conf/app.conf: no such file or directory
2026-03-25T16:39:48+01:00 [INFO] [/controller/artifact/annotation/parser.go:85]: the annotation parser to parser artifact annotation version v1alpha1 registered
2026-03-25T16:39:48+01:00 [INFO] [/controller/artifact/processor/processor.go:59]: the processor to process media type application/vnd.cncf.helm.config.v1+json registered
2026-03-25T16:39:48+01:00 [INFO] [/controller/artifact/processor/processor.go:59]: the processor to process media type application/vnd.cnab.manifest.v1 registered
2026-03-25T16:39:48+01:00 [INFO] [/controller/artifact/processor/processor.go:59]: the processor to process media type application/vnd.cnai.model.manifest.v1+json registered
2026-03-25T16:39:48+01:00 [INFO] [/controller/artifact/processor/processor.go:59]: the processor to process media type application/vnd.oci.image.index.v1+json registered
2026-03-25T16:39:48+01:00 [INFO] [/controller/artifact/processor/processor.go:59]: the processor to process media type application/vnd.docker.distribution.manifest.list.v2+json registered
2026-03-25T16:39:48+01:00 [INFO] [/controller/artifact/processor/processor.go:59]: the processor to process media type application/vnd.docker.distribution.manifest.v1+prettyjws registered
2026-03-25T16:39:48+01:00 [INFO] [/controller/artifact/processor/processor.go:59]: the processor to process media type application/vnd.oci.image.config.v1+json registered
2026-03-25T16:39:48+01:00 [INFO] [/controller/artifact/processor/processor.go:59]: the processor to process media type application/vnd.docker.container.image.v1+json registered
2026-03-25T16:39:48+01:00 [INFO] [/controller/artifact/processor/processor.go:59]: the processor to process media type application/vnd.goharbor.harbor.sbom.v1 registered
2026-03-25T16:39:48+01:00 [INFO] [/controller/artifact/processor/processor.go:59]: the processor to process media type application/vnd.wasm.config.v1+json registered
2026-03-25T16:39:48+01:00 [INFO] [/pkg/reg/adapter/native/adapter.go:36]: the factory for adapter docker-registry registered
2026-03-25T16:39:48+01:00 [INFO] [/pkg/reg/adapter/aliacr/adapter.go:54]: the factory for adapter ali-acr registered
2026-03-25T16:39:48+01:00 [INFO] [/pkg/reg/adapter/awsecr/adapter.go:44]: the factory for adapter aws-ecr registered
2026-03-25T16:39:48+01:00 [INFO] [/pkg/reg/adapter/azurecr/adapter.go:33]: Factory for adapter azure-acr registered
2026-03-25T16:39:48+01:00 [INFO] [/pkg/reg/adapter/dockerhub/adapter.go:40]: Factory for adapter docker-hub registered
2026-03-25T16:39:48+01:00 [INFO] [/pkg/reg/adapter/dtr/adapter.go:36]: the factory of dtr adapter was registered
2026-03-25T16:39:48+01:00 [INFO] [/pkg/reg/adapter/githubcr/adapter.go:43]: the factory for adapter github-ghcr registered
2026-03-25T16:39:48+01:00 [INFO] [/pkg/reg/adapter/gitlab/adapter.go:33]: the factory for adapter gitlab registered
2026-03-25T16:39:48+01:00 [INFO] [/pkg/reg/adapter/googlegcr/adapter.go:38]: the factory for adapter google-gcr registered
2026-03-25T16:39:48+01:00 [INFO] [/pkg/reg/adapter/huawei/huawei_adapter.go:40]: the factory of Huawei adapter was registered
2026-03-25T16:39:48+01:00 [INFO] [/pkg/reg/adapter/jfrog/adapter.go:43]: the factory of jfrog artifactory adapter was registered
2026-03-25T16:39:48+01:00 [INFO] [/pkg/reg/adapter/quay/adapter.go:53]: the factory of Quay adapter was registered
2026-03-25T16:39:48+01:00 [INFO] [/pkg/reg/adapter/tencentcr/adapter.go:58]: the factory for adapter tencent-tcr registered
2026-03-25T16:39:48+01:00 [INFO] [/pkg/reg/adapter/volcenginecr/adapter.go:40]: the factory for adapter volcengine-cr registered
2026-03-25T16:39:48+01:00 [INFO] [/pkg/reg/adapter/harbor/adapter.go:31]: the factory for adapter harbor registered
2026-03-25T16:39:48+01:00 [INFO] [./main.go:159]: initializing cache ...
2026-03-25T16:39:48+01:00 [FATAL] [./main.go:170]: failed to initialize cache: cache type  not support
aloui@hp:~/Desktop/harbor-next$ 


```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build configuration to streamline the build process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->