### PR TITLE
fix(ci): move maintenance workflows to self-hosted runners

### DIFF
--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -10,7 +10,7 @@ permissions:
 
 jobs:
   dependency-review:
-    runs-on: ubuntu-latest
+    runs-on: ${{ (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository || contains(fromJSON('["OWNER","MEMBER"]'), github.event.pull_request.author_association)) && vars.RUNNER || 'ubuntu-latest' }}
     # Requires Dependency Graph to be enabled in repo settings
     if: github.event.repository.private == false || always()
     continue-on-error: true

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -10,7 +10,7 @@ permissions:
 
 jobs:
   labeler:
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.RUNNER || 'ubuntu-latest' }}
     steps:
       - uses: actions/labeler@8558fd74291d67161a8a78ce36a881fa63b766a9 # v5
         with:

--- a/.github/workflows/lint-actions.yml
+++ b/.github/workflows/lint-actions.yml
@@ -15,7 +15,7 @@ permissions:
 jobs:
   pinned-actions:
     name: Check Pinned Action SHAs
-    runs-on: ubuntu-latest
+    runs-on: ${{ (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository || contains(fromJSON('["OWNER","MEMBER"]'), github.event.pull_request.author_association)) && vars.RUNNER || 'ubuntu-latest' }}
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -9,7 +9,7 @@ permissions:
 
 jobs:
   lint:
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.RUNNER || 'ubuntu-latest' }}
     steps:
       - uses: amannn/action-semantic-pull-request@e32d7e603df1aa1ba07e981f2a23455dee596825 # v5
         env:

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -13,7 +13,7 @@ permissions: read-all
 jobs:
   analysis:
     name: Scorecard Analysis
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.RUNNER || 'ubuntu-latest' }}
     permissions:
       security-events: write
       id-token: write

--- a/.github/workflows/spellcheck.yml
+++ b/.github/workflows/spellcheck.yml
@@ -22,9 +22,24 @@ permissions:
 
 jobs:
   typos:
-    runs-on: ubuntu-latest
+    runs-on: ${{ (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository || contains(fromJSON('["OWNER","MEMBER"]'), github.event.pull_request.author_association)) && vars.RUNNER || 'ubuntu-latest' }}
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
-      - uses: crate-ci/typos@a8d8e187146634c459c27ade2d3e338569378720 # v1.44.0
-        with:
-          config: .typos.toml
+
+      - name: Run typos
+        env:
+          TYPOS_VERSION: "1.44.0"
+        run: |
+          case "$(uname -m)" in
+            x86_64|amd64) target="x86_64-unknown-linux-musl" ;;
+            aarch64|arm64) target="aarch64-unknown-linux-musl" ;;
+            *)
+              echo "Unsupported architecture: $(uname -m)"
+              exit 1
+              ;;
+          esac
+
+          install_dir="$(mktemp -d)"
+          curl -fsSL "https://github.com/crate-ci/typos/releases/download/v${TYPOS_VERSION}/typos-v${TYPOS_VERSION}-${target}.tar.gz" -o /tmp/typos.tar.gz
+          tar -xzf /tmp/typos.tar.gz -C "$install_dir" --strip-components=1 --no-same-owner --no-same-permissions ./typos
+          "$install_dir/typos" --config .typos.toml

--- a/.github/workflows/welcome.yml
+++ b/.github/workflows/welcome.yml
@@ -14,10 +14,9 @@ jobs:
   welcome:
     runs-on: ${{ vars.RUNNER || 'ubuntu-latest' }}
     steps:
-      - uses: actions/first-interaction@fb2402657b4a28582200150d0a145671d0e50597 # v1
-        with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-          issue-message: |
+      - uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
+        env:
+          ISSUE_MESSAGE: |
             Thanks for opening your first issue!
 
             A maintainer will review this soon. In the meantime:
@@ -25,8 +24,7 @@ jobs:
             - Search [existing issues](https://github.com/${{ github.repository }}/issues) for similar reports
 
             If this is a question rather than a bug, consider opening a [Discussion](https://github.com/${{ github.repository }}/discussions) instead.
-
-          pr-message: |
+          PR_MESSAGE: |
             Thanks for your first pull request!
 
             A maintainer will review this soon. Please ensure:
@@ -35,3 +33,26 @@ jobs:
             - [ ] PR title follows [Conventional Commits](https://www.conventionalcommits.org/)
 
             Check our [Contributing Guide](https://github.com/${{ github.repository }}/blob/main/CONTRIBUTING.md) for details.
+        with:
+          script: |
+            const isPullRequest = context.eventName === "pull_request_target";
+            const issueNumber = isPullRequest ? context.payload.pull_request.number : context.payload.issue.number;
+            const author = isPullRequest ? context.payload.pull_request.user.login : context.payload.issue.user.login;
+            const type = isPullRequest ? "pr" : "issue";
+
+            const { data } = await github.rest.search.issuesAndPullRequests({
+              q: `repo:${context.repo.owner}/${context.repo.repo} author:${author} type:${type}`,
+              per_page: 2,
+            });
+
+            if (data.total_count !== 1) {
+              core.info(`${author} is not a first-time ${type} author`);
+              return;
+            }
+
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: issueNumber,
+              body: isPullRequest ? process.env.PR_MESSAGE : process.env.ISSUE_MESSAGE,
+            });

--- a/.github/workflows/welcome.yml
+++ b/.github/workflows/welcome.yml
@@ -12,7 +12,7 @@ permissions:
 
 jobs:
   welcome:
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.RUNNER || 'ubuntu-latest' }}
     steps:
       - uses: actions/first-interaction@fb2402657b4a28582200150d0a145671d0e50597 # v1
         with:


### PR DESCRIPTION
## Summary
- route the remaining lightweight maintenance workflows to the container-registry runner
- keep forked pull_request workflows on ubuntu-latest fallback where they execute untrusted code
- replace the spellcheck action with a direct typos binary download so it works on the self-hosted runner

## Testing
- workflow YAML review

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD workflow configurations across multiple jobs to support dynamic runner selection with fallback options
  * Enhanced spell-checking workflow implementation for improved compatibility and execution reliability

<!-- end of auto-generated comment: release notes by coderabbit.ai -->