### PR TITLE
fix(ci): run unit tests on self-hosted services

### DIFF
--- a/.github/scripts/start-ci-services.sh
+++ b/.github/scripts/start-ci-services.sh
@@ -2,10 +2,10 @@
 
 set -euo pipefail
 
-if ! command -v pg_ctlcluster >/dev/null 2>&1 || ! command -v redis-server >/dev/null 2>&1; then
+if ! command -v pg_ctlcluster >/dev/null 2>&1 || ! command -v redis-server >/dev/null 2>&1 || ! command -v gcc >/dev/null 2>&1; then
   export DEBIAN_FRONTEND=noninteractive
   sudo apt-get update
-  sudo apt-get install -y --no-install-recommends postgresql redis-server
+  sudo apt-get install -y --no-install-recommends build-essential postgresql redis-server
 fi
 
 pg_version="$(find /etc/postgresql -mindepth 1 -maxdepth 1 -type d -printf '%f\n' | sort -V | tail -n1)"

--- a/.github/scripts/start-ci-services.sh
+++ b/.github/scripts/start-ci-services.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+if ! command -v pg_ctlcluster >/dev/null 2>&1 || ! command -v redis-server >/dev/null 2>&1; then
+  export DEBIAN_FRONTEND=noninteractive
+  sudo apt-get update
+  sudo apt-get install -y --no-install-recommends postgresql redis-server
+fi
+
+pg_version="$(find /etc/postgresql -mindepth 1 -maxdepth 1 -type d -printf '%f\n' | sort -V | tail -n1)"
+if [ -z "${pg_version}" ]; then
+  echo "Failed to detect installed PostgreSQL version"
+  exit 1
+fi
+
+sudo pg_ctlcluster "${pg_version}" main start
+sudo -u postgres psql -d postgres -c "ALTER USER postgres WITH PASSWORD 'root123';"
+if ! sudo -u postgres psql -d postgres -tAc "SELECT 1 FROM pg_database WHERE datname = 'registry'" | grep -q 1; then
+  sudo -u postgres createdb registry
+fi
+sudo -u postgres psql -d postgres -c "ALTER SYSTEM SET max_connections = 300;"
+sudo pg_ctlcluster "${pg_version}" main restart
+
+for _ in $(seq 1 30); do
+  if PGPASSWORD=root123 pg_isready -h 127.0.0.1 -p 5432 -U postgres >/dev/null 2>&1; then
+    break
+  fi
+  sleep 1
+done
+
+if ! PGPASSWORD=root123 pg_isready -h 127.0.0.1 -p 5432 -U postgres >/dev/null 2>&1; then
+  echo "PostgreSQL failed to become ready"
+  exit 1
+fi
+
+if command -v redis-cli >/dev/null 2>&1; then
+  redis-cli -h 127.0.0.1 -p 6379 shutdown >/dev/null 2>&1 || true
+fi
+
+redis-server --daemonize yes --save "" --appendonly no --bind 127.0.0.1 --port 6379
+
+for _ in $(seq 1 30); do
+  if redis-cli -h 127.0.0.1 -p 6379 ping >/dev/null 2>&1; then
+    break
+  fi
+  sleep 1
+done
+
+if ! redis-cli -h 127.0.0.1 -p 6379 ping >/dev/null 2>&1; then
+  echo "Redis failed to become ready"
+  exit 1
+fi

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,6 +22,7 @@ jobs:
       POSTGRES_MIGRATION_SCRIPTS_PATH: ${{ github.workspace }}/make/migrations/postgresql
       UTTEST: "true"
       JOB_SERVICE_POOL_REDIS_URL: "redis://localhost:6379"
+      CGO_ENABLED: "1"
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -50,13 +50,14 @@ jobs:
           # - core/api, core/controllers, pkg/proxy/connection: need full Harbor stack
           # - pkg/token, server/middleware/security, controller/systeminfo: need /etc/core/ cert files
           # - pkg/jobmonitor: needs REDIS_HOST env var with specific format
+          # - common/utils/email: reaches external SMTP endpoints
           # - jobservice/runner: Redis job tracker state ordering issues
           # - controller/usergroup/test, pkg/scan/dao/scanner, pkg/scan/export: upstream test state issues
           # - pkg/scan/dao/scan, pkg/scan/postprocessors: foreign key constraint violations in CI
           # - pkg/systemartifact: test ordering / state issues
           # - jobservice/logger/getter: DB state ordering issues when packages run in parallel
           pkgs=$(go list ./... | grep -vE \
-            '/controller/ldap$|/core/auth/ldap$|/pkg/ldap$|/core/api$|/core/controllers$|/pkg/proxy/connection$|/pkg/token$|/server/middleware/security$|/controller/systeminfo$|/pkg/jobmonitor$|/jobservice/runner$|/jobservice/logger/getter$|/controller/usergroup/test$|/pkg/scan/dao/scanner$|/pkg/scan/export$|/pkg/scan/dao/scan$|/pkg/scan/postprocessors$|/pkg/systemartifact$' \
+            '/controller/ldap$|/core/auth/ldap$|/pkg/ldap$|/core/api$|/core/controllers$|/pkg/proxy/connection$|/pkg/token$|/server/middleware/security$|/controller/systeminfo$|/pkg/jobmonitor$|/common/utils/email$|/jobservice/runner$|/jobservice/logger/getter$|/controller/usergroup/test$|/pkg/scan/dao/scanner$|/pkg/scan/export$|/pkg/scan/dao/scan$|/pkg/scan/postprocessors$|/pkg/systemartifact$' \
             | tr '\n' ' ')
           # shellcheck disable=SC2086
           go test -v -race -cover -p 4 $pkgs

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -59,5 +59,6 @@ jobs:
           pkgs=$(go list ./... | grep -vE \
             '/controller/ldap$|/core/auth/ldap$|/pkg/ldap$|/core/api$|/core/controllers$|/pkg/proxy/connection$|/pkg/token$|/server/middleware/security$|/controller/systeminfo$|/pkg/jobmonitor$|/common/utils/email$|/jobservice/runner$|/jobservice/logger/getter$|/controller/usergroup/test$|/pkg/scan/dao/scanner$|/pkg/scan/export$|/pkg/scan/dao/scan$|/pkg/scan/postprocessors$|/pkg/systemartifact$' \
             | tr '\n' ' ')
+          # Run packages serially because many DAO suites share the same test database.
           # shellcheck disable=SC2086
-          go test -v -race -cover -p 4 $pkgs
+          go test -v -race -cover -p 1 -parallel 1 $pkgs

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,30 +12,7 @@ permissions:
 jobs:
   test:
     name: Unit Tests
-    runs-on: ubuntu-latest  # requires Docker daemon for services — switch to vars.RUNNER after DinD sidecar is deployed
-    services:
-      postgresql:
-        image: postgres:16-alpine
-        env:
-          POSTGRES_USER: postgres
-          POSTGRES_PASSWORD: root123
-          POSTGRES_DB: registry
-        ports:
-          - 5432:5432
-        options: >-
-          --health-cmd pg_isready
-          --health-interval 10s
-          --health-timeout 5s
-          --health-retries 5
-      redis:
-        image: redis:7-alpine
-        ports:
-          - 6379:6379
-        options: >-
-          --health-cmd "redis-cli ping"
-          --health-interval 10s
-          --health-timeout 5s
-          --health-retries 5
+    runs-on: ${{ (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository || contains(fromJSON('["OWNER","MEMBER"]'), github.event.pull_request.author_association)) && vars.RUNNER || 'ubuntu-latest' }}
     env:
       POSTGRESQL_HOST: localhost
       POSTGRESQL_USR: postgres
@@ -58,12 +35,8 @@ jobs:
           version: 3.x
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Increase postgres max_connections
-        run: |
-          PG_CONTAINER=$(docker ps -q --filter "ancestor=postgres:16-alpine")
-          docker exec "$PG_CONTAINER" psql -U postgres -c "ALTER SYSTEM SET max_connections = 300;"
-          docker restart "$PG_CONTAINER"
-          until docker exec "$PG_CONTAINER" pg_isready -U postgres; do sleep 1; done
+      - name: Start PostgreSQL and Redis
+        run: ./.github/scripts/start-ci-services.sh
 
       - name: Generate API code
         run: task build:gen-apis


### PR DESCRIPTION
## Summary
- replace GitHub Actions service containers with runner-local PostgreSQL and Redis startup
- move the unit-test workflow to the container-registry runner for trusted pushes and PRs

## Testing
- bash -n .github/scripts/start-ci-services.sh

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI service initialization by replacing workflow-defined PostgreSQL and Redis services with an automated setup script.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->