### PR TITLE
ci: Install gh CLI on Self-Hosted Runner for PR Comment Job

### DIFF
--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -222,6 +222,16 @@ jobs:
     permissions:
       pull-requests: write
     steps:
+      - name: Install gh CLI
+        run: |
+          if ! command -v gh &>/dev/null; then
+            curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \
+              | sudo dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg
+            echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" \
+              | sudo tee /etc/apt/sources.list.d/github-cli.list > /dev/null
+            sudo apt-get update && sudo apt-get install -y gh
+          fi
+
       - name: Create or update PR comment
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- The `pr-comment` job in `pr-ci.yml` fails on self-hosted runners because `gh` CLI is not installed
- Adds a step to install `gh` CLI if it's not already available on the runner

## Related Issues
- Fixes the `Comment preview image refs` check failure seen in PR #88

## Type of Change
- [x] CI/CD or build changes (`ci:` / `build:`)

## Testing
- [x] Manual testing performed

## Checklist
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] Commits are signed off (`git commit -s`)
- [x] No new warnings introduced

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced continuous integration pipeline reliability by ensuring required command-line tools are available during automated workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->