### PR TITLE
fix(ci): run scorecard on github-hosted ubuntu

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -13,7 +13,8 @@ permissions: read-all
 jobs:
   analysis:
     name: Scorecard Analysis
-    runs-on: ${{ vars.RUNNER || 'ubuntu-latest' }}
+    # Scorecard result publishing requires a single GitHub-hosted Ubuntu runner.
+    runs-on: ubuntu-latest
     permissions:
       security-events: write
       id-token: write


### PR DESCRIPTION
## Summary
- run the OpenSSF Scorecard workflow on GitHub-hosted Ubuntu instead of the shared self-hosted runner variable
- document why this workflow must not inherit 

## Why
The failing run at https://github.com/container-registry/harbor-next/actions/runs/24059061815/job/70171357004 shows Scorecard rejecting result publication with:



This repository sets , so the previous  made the Scorecard job run on a self-hosted runner. Pinning this workflow to  restores the environment expected by  when  is enabled.

## Validation
- 
- verified the workflow change is limited to 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CI workflow updated to use a fixed GitHub-hosted Ubuntu runner, ensuring deterministic runner selection for relevant checks and uploads.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->