### PR TITLE
fix(portal): stabilize test runner

### DIFF
--- a/src/portal/karma.conf.js
+++ b/src/portal/karma.conf.js
@@ -56,12 +56,12 @@ module.exports = function (config) {
     logLevel: config.LOG_INFO,
     autoWatch: true,
     singleRun: true,
-    browsers: ['ChromeHeadlessNoSandbox'],
+    browsers: ['ChromiumHeadlessNoSandbox'],
     browserDisconnectTolerance: 2,
     browserNoActivityTimeout: 50000,
     customLaunchers: {
-      ChromeHeadlessNoSandbox: {
-        base: 'ChromeHeadless',
+      ChromiumHeadlessNoSandbox: {
+        base: 'ChromiumHeadless',
         flags: ['--no-sandbox']
       }
     },

--- a/src/portal/package.json
+++ b/src/portal/package.json
@@ -12,7 +12,7 @@
     "lint_fix": "ng lint --fix",
     "lint:style": "npx stylelint \"**/*.scss\"",
     "lint_fix:style": "npx stylelint \"**/*.scss\" --fix",
-    "test": "bun ./node_modules/@angular/cli/bin/ng test --code-coverage",
+    "test": "node ./node_modules/@angular/cli/bin/ng test --code-coverage",
     "test:watch": "ng test --code-coverage --watch",
     "test:debug": "ng test --code-coverage --source-map false",
     "test:chrome": "ng test --code-coverage --browsers Chrome",

--- a/src/portal/src/app/base/project/repository/artifact/artifact-list-page/artifact-list/artifact-list-tab/pull-command/pull-command.component.html
+++ b/src/portal/src/app/base/project/repository/artifact/artifact-list-page/artifact-list/artifact-list-tab/pull-command/pull-command.component.html
@@ -45,8 +45,7 @@
 
 <clr-dropdown
     class="mr-1"
-    *ngIf="isTagMode && !isTopModel"
-    [disabled]="!hasPullCommandForTag(artifact)">
+    *ngIf="isTagMode && !isTopModel && hasPullCommandForTag(artifact)">
     <hbr-copy-input
         *ngIf="isImage(artifact)"
         [title]="getPullCommandForRuntimeByTag(artifact)"


### PR DESCRIPTION
## Summary
- run the Angular test command with Node instead of wrapping the CLI in Bun
- use Chromium for Karma in this environment
- hide unsupported pull-command actions instead of binding an invalid disabled input

## Testing
- bun run test

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved artifact list user experience: the tag-mode dropdown now completely hides when pull command support is unavailable, rather than appearing in a disabled state to provide clearer interface feedback.

* **Chores**
  * Updated test infrastructure: enhanced browser compatibility in test configuration.
  * Updated test execution: optimized test runner for improved environment compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->