### PR TITLE
ci: Install envsubst for cosign-installer v4

### DIFF
--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -188,7 +188,7 @@ jobs:
         run: go install github.com/google/go-containerregistry/cmd/crane@v0.20.3
 
       - name: Install envsubst
-        run: command -v envsubst || sudo apt-get install -y gettext-base
+        run: command -v envsubst || (sudo apt-get update && sudo apt-get install -y gettext-base)
 
       - name: Install cosign
         uses: sigstore/cosign-installer@cad07c2e89fa2edd6e2d7bab4c1aa38e53f76003 # v4.1.1

--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -187,6 +187,9 @@ jobs:
       - name: Install crane
         run: go install github.com/google/go-containerregistry/cmd/crane@v0.20.3
 
+      - name: Install envsubst
+        run: command -v envsubst || sudo apt-get install -y gettext-base
+
       - name: Install cosign
         uses: sigstore/cosign-installer@cad07c2e89fa2edd6e2d7bab4c1aa38e53f76003 # v4.1.1
 

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -207,6 +207,9 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
+      - name: Install envsubst
+        run: command -v envsubst || sudo apt-get install -y gettext-base
+
       - name: Install cosign
         uses: sigstore/cosign-installer@cad07c2e89fa2edd6e2d7bab4c1aa38e53f76003 # v4.1.1
 

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -208,7 +208,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Install envsubst
-        run: command -v envsubst || sudo apt-get install -y gettext-base
+        run: command -v envsubst || (sudo apt-get update && sudo apt-get install -y gettext-base)
 
       - name: Install cosign
         uses: sigstore/cosign-installer@cad07c2e89fa2edd6e2d7bab4c1aa38e53f76003 # v4.1.1


### PR DESCRIPTION
## Summary
- cosign-installer v4.1.1 uses `envsubst` to resolve `$HOME` in its `install-dir` input, but the self-hosted runner lacks `gettext-base`
- Add a step before cosign-installer in both `pr-ci.yml` and `release-please.yml` to install `gettext-base` if `envsubst` is not already available

## Related Issues
Fixes the "Sign preview images" job failure: `envsubst: command not found`

## Type of Change
- [x] CI/CD or build changes (`ci:` / `build:`)

## Testing
- [x] Manual testing performed

## Checklist
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] Commits are signed off (`git commit -s`)
- [x] No new warnings introduced

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CI/CD signing workflows updated to check for and install envsubst (gettext-base) when missing, ensuring required tooling is available during signing steps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->