### PR TITLE
build: Replace PAT with GitHub App for cross-repo auth

### DIFF
--- a/.github/workflows/notify-fork-sync.yml
+++ b/.github/workflows/notify-fork-sync.yml
@@ -4,9 +4,11 @@ on:
   push:
     branches: [main]
 
+permissions: {}
+
 jobs:
   dispatch:
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.RUNNER || 'ubuntu-latest' }}
     steps:
       - name: Generate GitHub App token
         id: app-token
@@ -21,6 +23,8 @@ jobs:
         run: |
           curl -f -X POST \
             -H "Accept: application/vnd.github+json" \
+            -H "Content-Type: application/json" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
             -H "Authorization: Bearer ${{ steps.app-token.outputs.token }}" \
             "https://api.github.com/repos/container-registry/8gcr/dispatches" \
             -d '{"event_type":"upstream-sync","client_payload":{"sha":"${{ github.sha }}"}}'

--- a/.github/workflows/notify-fork-sync.yml
+++ b/.github/workflows/notify-fork-sync.yml
@@ -1,0 +1,26 @@
+name: Notify Fork Sync
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  dispatch:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349 # v2
+        with:
+          app-id: ${{ vars.SYNC_APP_ID }}
+          private-key: ${{ secrets.SYNC_APP_PRIVATE_KEY }}
+          owner: container-registry
+          repositories: 8gcr
+
+      - name: Trigger sync
+        run: |
+          curl -f -X POST \
+            -H "Accept: application/vnd.github+json" \
+            -H "Authorization: Bearer ${{ steps.app-token.outputs.token }}" \
+            "https://api.github.com/repos/container-registry/8gcr/dispatches" \
+            -d '{"event_type":"upstream-sync","client_payload":{"sha":"${{ github.sha }}"}}'

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -55,9 +55,18 @@ jobs:
         with:
           ref: ${{ needs.release-please.outputs.tag_name }}
 
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349 # v2
+        with:
+          app-id: ${{ vars.SYNC_APP_ID }}
+          private-key: ${{ secrets.SYNC_APP_PRIVATE_KEY }}
+          owner: container-registry
+          repositories: 8gcr
+
       - name: Apply enterprise patches
         env:
-          PATCHES_TOKEN: ${{ secrets.REPO_READ_TOKEN_8GCR }}
+          PATCHES_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
           git clone --depth=1 \
             "https://x-access-token:${PATCHES_TOKEN}@github.com/container-registry/8gcr" \
@@ -227,10 +236,19 @@ jobs:
               "${REGISTRY_ADDRESS}/${REGISTRY_PROJECT}/harbor-${image}:${VERSION}"
           done
 
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349 # v2
+        with:
+          app-id: ${{ vars.SYNC_APP_ID }}
+          private-key: ${{ secrets.SYNC_APP_PRIVATE_KEY }}
+          owner: container-registry
+          repositories: 8gcr
+
       - name: Collect enterprise patch descriptions
         id: patches
         env:
-          PATCHES_TOKEN: ${{ secrets.REPO_READ_TOKEN_8GCR }}
+          PATCHES_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
           git clone --depth=1 \
             "https://x-access-token:${PATCHES_TOKEN}@github.com/container-registry/8gcr" \

--- a/.typos.toml
+++ b/.typos.toml
@@ -28,6 +28,10 @@ oci  = "oci"
 oras = "oras"
 # in-toto normalized label segment
 intoto = "intoto"
+# Upstream beego ORM function name (typo is in beego, not our code)
+Wth = "Wth"
+# Intentional SQL typo in integration tests (testing error handling)
+SELCT = "SELCT"
 # Public API field names - fixing would be a breaking API change
 unknow    = "unknow"
 unsupport = "unsupport"


### PR DESCRIPTION
## Summary
- Replace long-lived `REPO_READ_TOKEN_8GCR` PAT with short-lived tokens from the `8gcr-sync` GitHub App (`actions/create-github-app-token`)
- Add `notify-fork-sync.yml` workflow that triggers `repository_dispatch` to `container-registry/8gcr` on push to main (replaces 2h cron polling)
- Update `release-please.yml` to use app tokens in both `build` and `sign` jobs for cloning 8gcr patches

## Related Issues
N/A

## Type of Change
- [ ] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` / `fix!:`)
- [ ] Documentation (`docs:`)
- [ ] Refactoring (`refactor:`)
- [x] CI/CD or build changes (`ci:` / `build:`)
- [ ] Dependencies update (`chore:`)
- [ ] Tests (`test:`)

## Release Notes
<!--
Optional. Fill in for user-facing changes (new features, breaking changes, deprecations).
Leave blank for ci:/chore:/refactor:/test: PRs.
-->

## Testing
- [ ] Verify `SYNC_APP_ID` variable and `SYNC_APP_PRIVATE_KEY` secret are configured
- [ ] Push a commit to main after merge — verify `notify-fork-sync` runs and triggers sync in 8gcr
- [ ] Trigger a release — verify `release-please` patch clone works with app token
- [ ] Delete `REPO_READ_TOKEN_8GCR` secret after verification

## Checklist
- [x] PR title follows Conventional Commits format
- [x] Commits are signed off (`git commit -s`)
- [x] No new warnings introduced

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a new workflow to notify and trigger upstream fork syncs on main-branch updates.
  * Improved release automation by switching to a generated GitHub App installation token for authenticated patch and release operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->