### PR TITLE
ci: Restrict spellcheck to markdown and YAML/Go comments

### DIFF
--- a/.github/workflows/spellcheck.yml
+++ b/.github/workflows/spellcheck.yml
@@ -5,14 +5,12 @@ on:
     branches: [main]
     paths:
       - '**.md'
-      - '**.txt'
       - '**.yml'
       - '**.yaml'
       - '.typos.toml'
   pull_request:
     paths:
       - '**.md'
-      - '**.txt'
       - '**.yml'
       - '**.yaml'
       - '.typos.toml'
@@ -41,5 +39,22 @@ jobs:
 
           install_dir="$(mktemp -d)"
           curl -fsSL "https://github.com/crate-ci/typos/releases/download/v${TYPOS_VERSION}/typos-v${TYPOS_VERSION}-${target}.tar.gz" -o /tmp/typos.tar.gz
-          tar -xzf /tmp/typos.tar.gz -C "$install_dir" --strip-components=1 --no-same-owner --no-same-permissions ./typos
-          "$install_dir/typos" --config .typos.toml
+          tar -xzf /tmp/typos.tar.gz -C "$install_dir" --strip-components=1 --no-same-owner --no-same-permissions
+          typos="$install_dir/typos"
+
+          # 1) Check markdown files directly
+          find . -type f -name '*.md' -not -path './.git/*' \
+            | "$typos" --config .typos.toml --file-list - --force-exclude
+
+          # 2) Check only comments in YAML files.
+          #    Extract comment lines preserving line numbers (non-comment lines
+          #    become empty so typos reports correct positions).
+          comment_dir="$(mktemp -d)"
+          find . -type f \( -name '*.yml' -o -name '*.yaml' \) \
+            -not -path './.git/*' | while IFS= read -r f; do
+            dest="$comment_dir/$f"
+            mkdir -p "$(dirname "$dest")"
+            awk '/^[[:space:]]*#/ { sub(/^[[:space:]]*#[[:space:]]?/, ""); print; next } { print "" }' "$f" > "$dest"
+          done
+          find "$comment_dir" -type f \( -name '*.yml' -o -name '*.yaml' \) \
+            | "$typos" --config .typos.toml --file-list - --force-exclude

--- a/.github/workflows/spellcheck.yml
+++ b/.github/workflows/spellcheck.yml
@@ -28,6 +28,8 @@ jobs:
         env:
           TYPOS_VERSION: "1.44.0"
         run: |
+          set -o pipefail
+
           case "$(uname -m)" in
             x86_64|amd64) target="x86_64-unknown-linux-musl" ;;
             aarch64|arm64) target="aarch64-unknown-linux-musl" ;;
@@ -47,14 +49,36 @@ jobs:
             | "$typos" --config .typos.toml --file-list - --force-exclude
 
           # 2) Check only comments in YAML files.
-          #    Extract comment lines preserving line numbers (non-comment lines
-          #    become empty so typos reports correct positions).
+          #    Extract comment text (full-line and inline) preserving line numbers.
+          #    Non-comment lines become empty so typos reports correct positions.
           comment_dir="$(mktemp -d)"
           find . -type f \( -name '*.yml' -o -name '*.yaml' \) \
             -not -path './.git/*' | while IFS= read -r f; do
             dest="$comment_dir/$f"
             mkdir -p "$(dirname "$dest")"
-            awk '/^[[:space:]]*#/ { sub(/^[[:space:]]*#[[:space:]]?/, ""); print; next } { print "" }' "$f" > "$dest"
+            awk '{
+              # Full-line comment (most common)
+              if (/^[[:space:]]*#/) {
+                sub(/^[[:space:]]*#[[:space:]]?/, ""); print; next
+              }
+              # Inline comment: walk line tracking quotes, find " #" outside strings
+              n = length($0); dq = 0; sq = 0; cs = 0
+              for (j = 1; j <= n; j++) {
+                c = substr($0, j, 1)
+                if (c == "\"" && !sq) dq = !dq
+                else if (c == "\047" && !dq) sq = !sq
+                else if (c == "#" && !dq && !sq && j > 1 && substr($0, j-1, 1) == " ") {
+                  cs = j; break
+                }
+              }
+              if (cs) { s = substr($0, cs + 1); sub(/^[[:space:]]?/, "", s); print s }
+              else print ""
+            }' "$f" > "$dest"
           done
-          find "$comment_dir" -type f \( -name '*.yml' -o -name '*.yaml' \) \
-            | "$typos" --config .typos.toml --file-list - --force-exclude
+          # Run from inside comment_dir so paths are repo-relative,
+          # matching extend-exclude patterns in .typos.toml.
+          (
+            cd "$comment_dir"
+            find . -type f \( -name '*.yml' -o -name '*.yaml' \) \
+              | "$typos" --config "$GITHUB_WORKSPACE/.typos.toml" --file-list - --force-exclude
+          )

--- a/.typos.toml
+++ b/.typos.toml
@@ -1,5 +1,9 @@
 # Configuration for typos spell checker
 # https://github.com/crate-ci/typos
+#
+# Scope: markdown files (full content) and YAML files (comments only).
+# Go comments are checked by misspell via golangci-lint (src/.golangci.yaml).
+# The workflow extracts YAML comment lines into temp files before running typos.
 
 [default]
 extend-ignore-identifiers-re = [
@@ -8,62 +12,31 @@ extend-ignore-identifiers-re = [
 ]
 
 [default.extend-words]
-# Common Go short variable names flagged as false positives
-pn  = "pn"
-ba  = "ba"
-ot  = "ot"
-lik = "lik"
-fo  = "fo"
-ure = "ure"
-# Harbor-specific identifiers
-cfg          = "cfg"
-ctx          = "ctx"
-req          = "req"
-resp         = "resp"
-impl         = "impl"
+# Harbor service names (appear in docs and comments)
 registryctl  = "registryctl"
 jobservice   = "jobservice"
 # Container/OCI terminology
 oci  = "oci"
 oras = "oras"
-# in-toto normalized label segment
 intoto = "intoto"
-# Upstream beego ORM function name (typo is in beego, not our code)
-Wth = "Wth"
-# Intentional SQL typo in integration tests (testing error handling)
-SELCT = "SELCT"
-# Public API field names - fixing would be a breaking API change
-unknow    = "unknow"
-unsupport = "unsupport"
-parms     = "parms"
-applys    = "applys"
-togglable = "togglable"
-serach    = "serach"
-paylod    = "paylod"
-resoruce  = "resoruce"
-# Valid Go plural variable names (not typos - Go uses these as slice suffixes)
-Datas    = "Datas"
-sortings = "sortings"
-# Short variable names used as abbreviations in logger/options code
-ois = "ois"
+# Common Go abbreviations referenced in docs
+cfg  = "cfg"
+ctx  = "ctx"
 
 [files]
 extend-exclude = [
     # Non-English i18n translation files
     "src/portal/src/i18n/",
 
-    # Upstream test suite
-    "tests/",
-
     # Upstream files with company names, non-English brands
     "ADOPTERS.md",
     "CONTRIBUTORS.md",
 
-    # Lock files and dependency hashes
-    "go.sum",
-    "src/go.mod",
-    "bun.lock",
-    "package-lock.json",
+    # Upstream test suite (robot framework, testcase filenames have typos)
+    "tests/",
+
+    # Claude Code agent/plan files (auto-generated, not shipped)
+    ".claude/",
 
     # Build and vendor artifacts
     "vendor/",
@@ -71,13 +44,11 @@ extend-exclude = [
     "dist/",
     "bin/",
 
-    # Keys and certs
-    "*.pem",
-    "*.crt",
-    "*.key",
+    # Patch files contain git diff metadata and i18n translations
+    "8gcr-ee/patches/",
 
-    # SQL migration files contain SQL aliases (fo = filter_objects, eto = event_type_objects)
-    "make/migrations/",
+    # OpenAPI spec — field names are API contracts, can't be fixed
+    "api/v2.0/swagger.yaml",
 ]
 
 [type.md]


### PR DESCRIPTION
## Summary
- Narrows typos spellcheck scope to only check prose, not code
- Markdown files: checked in full (with code blocks/URLs excluded via regex)
- YAML files: only `#` comment lines are extracted and checked (via awk)
- Go files: already covered by `misspell` linter in golangci-lint
- Removes 16 Go-specific word exceptions that are no longer needed

Fixes false positives like `AddAliasWthDB` (function name) and `SELCT` (intentional test string) from https://github.com/container-registry/harbor-next/actions/runs/24287341313/job/70918784406

## Type of Change
- [x] CI/CD or build changes (`ci:`)

## Testing
- [x] Verified locally: `find . -name '*.md' | typos --file-list -` passes clean
- [x] Verified locally: YAML comment extraction + typos passes clean
- [x] Confirmed Go misspell linter already enabled in `src/.golangci.yaml`

## Checklist
- [x] PR title follows Conventional Commits format
- [x] Commits are signed off (`git commit -s`)
- [x] No new warnings introduced

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Spellchecking now runs in two targeted passes: full Markdown and YAML comment-only checks.
  * Workflow triggers narrowed to fewer path patterns.
  * YAML comments are linted via temporary comment-only mirrors to preserve original files.
  * Allowed/ignored word lists tightened to service/protocol terms.
  * Exclusions updated to skip auto-generated and patch/metadata files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->