### PR TITLE
ci: Fix test.yml workflow failure from invalid job context

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -73,12 +73,10 @@ jobs:
     env:
       POSTGRESQL_HOST: localhost
       POSTGRESQL_USR: postgres
-      POSTGRESQL_PORT: ${{ job.services.postgres.ports[5432] }}
       POSTGRESQL_PWD: root123
       POSTGRESQL_DATABASE: registry
       POSTGRES_MIGRATION_SCRIPTS_PATH: ${{ github.workspace }}/make/migrations/postgresql
       UTTEST: "true"
-      JOB_SERVICE_POOL_REDIS_URL: "redis://localhost:${{ job.services.redis.ports[6379] }}"
       CGO_ENABLED: "1"
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -95,6 +93,11 @@ jobs:
 
       - name: Ensure C toolchain for race detector
         run: command -v gcc >/dev/null || sudo apt-get update && sudo apt-get install -y --no-install-recommends gcc
+
+      - name: Export service ports
+        run: |
+          echo "POSTGRESQL_PORT=${{ job.services.postgres.ports['5432'] }}" >> "$GITHUB_ENV"
+          echo "JOB_SERVICE_POOL_REDIS_URL=redis://localhost:${{ job.services.redis.ports['6379'] }}" >> "$GITHUB_ENV"
 
       - name: Generate API code
         run: task build:gen-apis


### PR DESCRIPTION
## Summary
- Move `POSTGRESQL_PORT` and `JOB_SERVICE_POOL_REDIS_URL` from job-level `env:` to a step that writes them to `$GITHUB_ENV`
- The `job` context (for service container dynamic ports) is only available within steps, not in job-level `env:` blocks
- This parse-time error caused every test workflow run to fail with 0 jobs created

## Related Issues
<!-- Fixes #123 -->

## Type of Change
- [ ] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` / `fix!:`)
- [ ] Documentation (`docs:`)
- [ ] Refactoring (`refactor:`)
- [x] CI/CD or build changes (`ci:` / `build:`)
- [ ] Dependencies update (`chore:`)
- [ ] Tests (`test:`)

## Release Notes
<!-- ci: change — no release notes needed -->

## Testing
- [ ] Unit tests added/updated
- [x] Manual testing performed

Validated with `actionlint` — the `job` context error is resolved. The `job.services.*.ports['5432']` syntax (string key) is also correct per actionlint's secondary warning.

## Checklist
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] Commits are signed off (`git commit -s`)
- [x] No new warnings introduced