### PR TITLE
ci: Add cross-branch Go build cache to build and test workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,6 +21,14 @@ jobs:
           go-version-file: src/go.mod
           cache-dependency-path: src/go.sum
 
+      - name: Restore Go build cache
+        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
+        with:
+          path: ~/.cache/go-build
+          key: go-build-${{ runner.os }}-${{ hashFiles('src/**/*.go', 'src/go.sum') }}
+          restore-keys: |
+            go-build-${{ runner.os }}-
+
       - uses: arduino/setup-task@b91d5d2c96a56797b48ac1e0e89220bf64044611 # v2.0.0
         with:
           version: 3.x

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,13 +19,21 @@ jobs:
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version-file: src/go.mod
-          cache-dependency-path: src/go.sum
+          cache: false
+
+      - name: Restore Go module cache
+        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
+        with:
+          path: ~/go/pkg/mod
+          key: go-mod-${{ runner.os }}-${{ hashFiles('src/go.sum') }}
+          restore-keys: |
+            go-mod-${{ runner.os }}-
 
       - name: Restore Go build cache
         uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
         with:
           path: ~/.cache/go-build
-          key: go-build-${{ runner.os }}-${{ hashFiles('src/**/*.go', 'src/go.sum') }}
+          key: go-build-${{ runner.os }}-${{ hashFiles('src/go.sum') }}
           restore-keys: |
             go-build-${{ runner.os }}-
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -45,9 +45,8 @@ jobs:
         uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
         with:
           path: ~/.cache/go-build
-          key: go-build-${{ runner.os }}-build-${{ hashFiles('src/go.sum') }}-${{ github.sha }}
+          key: go-build-${{ runner.os }}-build-${{ hashFiles('src/go.sum') }}
           restore-keys: |
-            go-build-${{ runner.os }}-build-${{ hashFiles('src/go.sum') }}-
             go-build-${{ runner.os }}-
 
       - uses: arduino/setup-task@b91d5d2c96a56797b48ac1e0e89220bf64044611 # v2.0.0

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,9 +37,8 @@ jobs:
         uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
         with:
           path: ~/go/pkg/mod
-          key: go-mod-${{ runner.os }}-build-${{ hashFiles('src/go.sum') }}-${{ github.sha }}
+          key: go-mod-${{ runner.os }}-build-${{ hashFiles('src/go.sum') }}
           restore-keys: |
-            go-mod-${{ runner.os }}-build-${{ hashFiles('src/go.sum') }}-
             go-mod-${{ runner.os }}-
 
       - name: Restore Go build cache

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,16 +37,18 @@ jobs:
         uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
         with:
           path: ~/go/pkg/mod
-          key: go-mod-${{ runner.os }}-${{ hashFiles('src/go.sum') }}
+          key: go-mod-${{ runner.os }}-build-${{ hashFiles('src/go.sum') }}-${{ github.sha }}
           restore-keys: |
+            go-mod-${{ runner.os }}-build-${{ hashFiles('src/go.sum') }}-
             go-mod-${{ runner.os }}-
 
       - name: Restore Go build cache
         uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
         with:
           path: ~/.cache/go-build
-          key: go-build-${{ runner.os }}-${{ hashFiles('src/go.sum') }}
+          key: go-build-${{ runner.os }}-build-${{ hashFiles('src/go.sum') }}-${{ github.sha }}
           restore-keys: |
+            go-build-${{ runner.os }}-build-${{ hashFiles('src/go.sum') }}-
             go-build-${{ runner.os }}-
 
       - uses: arduino/setup-task@b91d5d2c96a56797b48ac1e0e89220bf64044611 # v2.0.0

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,13 +24,21 @@ jobs:
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version-file: src/go.mod
-          cache-dependency-path: src/go.sum
+          cache: false
+
+      - name: Restore Go module cache
+        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
+        with:
+          path: ~/go/pkg/mod
+          key: go-mod-${{ runner.os }}-${{ hashFiles('src/go.sum') }}
+          restore-keys: |
+            go-mod-${{ runner.os }}-
 
       - name: Restore Go build cache
         uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
         with:
           path: ~/.cache/go-build
-          key: go-build-${{ runner.os }}-${{ hashFiles('src/**/*.go', 'src/go.sum') }}
+          key: go-build-${{ runner.os }}-${{ hashFiles('src/go.sum') }}
           restore-keys: |
             go-build-${{ runner.os }}-
 
@@ -94,13 +102,21 @@ jobs:
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version-file: src/go.mod
-          cache-dependency-path: src/go.sum
+          cache: false
+
+      - name: Restore Go module cache
+        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
+        with:
+          path: ~/go/pkg/mod
+          key: go-mod-${{ runner.os }}-${{ hashFiles('src/go.sum') }}
+          restore-keys: |
+            go-mod-${{ runner.os }}-
 
       - name: Restore Go build cache
         uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
         with:
           path: ~/.cache/go-build
-          key: go-build-${{ runner.os }}-${{ hashFiles('src/**/*.go', 'src/go.sum') }}
+          key: go-build-${{ runner.os }}-${{ hashFiles('src/go.sum') }}
           restore-keys: |
             go-build-${{ runner.os }}-
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,6 +26,14 @@ jobs:
           go-version-file: src/go.mod
           cache-dependency-path: src/go.sum
 
+      - name: Restore Go build cache
+        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
+        with:
+          path: ~/.cache/go-build
+          key: go-build-${{ runner.os }}-${{ hashFiles('src/**/*.go', 'src/go.sum') }}
+          restore-keys: |
+            go-build-${{ runner.os }}-
+
       - uses: arduino/setup-task@b91d5d2c96a56797b48ac1e0e89220bf64044611 # v2.0.0
         with:
           version: 3.x
@@ -87,6 +95,14 @@ jobs:
         with:
           go-version-file: src/go.mod
           cache-dependency-path: src/go.sum
+
+      - name: Restore Go build cache
+        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
+        with:
+          path: ~/.cache/go-build
+          key: go-build-${{ runner.os }}-${{ hashFiles('src/**/*.go', 'src/go.sum') }}
+          restore-keys: |
+            go-build-${{ runner.os }}-
 
       - uses: arduino/setup-task@b91d5d2c96a56797b48ac1e0e89220bf64044611 # v2.0.0
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -42,9 +42,8 @@ jobs:
         uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
         with:
           path: ~/go/pkg/mod
-          key: go-mod-${{ runner.os }}-test-unit-${{ hashFiles('src/go.sum') }}-${{ github.sha }}
+          key: go-mod-${{ runner.os }}-test-unit-${{ hashFiles('src/go.sum') }}
           restore-keys: |
-            go-mod-${{ runner.os }}-test-unit-${{ hashFiles('src/go.sum') }}-
             go-mod-${{ runner.os }}-
 
       - name: Restore Go build cache
@@ -120,9 +119,8 @@ jobs:
         uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
         with:
           path: ~/go/pkg/mod
-          key: go-mod-${{ runner.os }}-test-db-${{ hashFiles('src/go.sum') }}-${{ github.sha }}
+          key: go-mod-${{ runner.os }}-test-db-${{ hashFiles('src/go.sum') }}
           restore-keys: |
-            go-mod-${{ runner.os }}-test-db-${{ hashFiles('src/go.sum') }}-
             go-mod-${{ runner.os }}-
 
       - name: Restore Go build cache

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -42,16 +42,18 @@ jobs:
         uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
         with:
           path: ~/go/pkg/mod
-          key: go-mod-${{ runner.os }}-${{ hashFiles('src/go.sum') }}
+          key: go-mod-${{ runner.os }}-test-unit-${{ hashFiles('src/go.sum') }}-${{ github.sha }}
           restore-keys: |
+            go-mod-${{ runner.os }}-test-unit-${{ hashFiles('src/go.sum') }}-
             go-mod-${{ runner.os }}-
 
       - name: Restore Go build cache
         uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
         with:
           path: ~/.cache/go-build
-          key: go-build-${{ runner.os }}-${{ hashFiles('src/go.sum') }}
+          key: go-build-${{ runner.os }}-test-unit-${{ hashFiles('src/go.sum') }}-${{ github.sha }}
           restore-keys: |
+            go-build-${{ runner.os }}-test-unit-${{ hashFiles('src/go.sum') }}-
             go-build-${{ runner.os }}-
 
       - uses: arduino/setup-task@b91d5d2c96a56797b48ac1e0e89220bf64044611 # v2.0.0
@@ -118,16 +120,18 @@ jobs:
         uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
         with:
           path: ~/go/pkg/mod
-          key: go-mod-${{ runner.os }}-${{ hashFiles('src/go.sum') }}
+          key: go-mod-${{ runner.os }}-test-db-${{ hashFiles('src/go.sum') }}-${{ github.sha }}
           restore-keys: |
+            go-mod-${{ runner.os }}-test-db-${{ hashFiles('src/go.sum') }}-
             go-mod-${{ runner.os }}-
 
       - name: Restore Go build cache
         uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
         with:
           path: ~/.cache/go-build
-          key: go-build-${{ runner.os }}-${{ hashFiles('src/go.sum') }}
+          key: go-build-${{ runner.os }}-test-db-${{ hashFiles('src/go.sum') }}-${{ github.sha }}
           restore-keys: |
+            go-build-${{ runner.os }}-test-db-${{ hashFiles('src/go.sum') }}-
             go-build-${{ runner.os }}-
 
       - uses: arduino/setup-task@b91d5d2c96a56797b48ac1e0e89220bf64044611 # v2.0.0

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -50,9 +50,8 @@ jobs:
         uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
         with:
           path: ~/.cache/go-build
-          key: go-build-${{ runner.os }}-test-unit-${{ hashFiles('src/go.sum') }}-${{ github.sha }}
+          key: go-build-${{ runner.os }}-test-unit-${{ hashFiles('src/go.sum') }}
           restore-keys: |
-            go-build-${{ runner.os }}-test-unit-${{ hashFiles('src/go.sum') }}-
             go-build-${{ runner.os }}-
 
       - uses: arduino/setup-task@b91d5d2c96a56797b48ac1e0e89220bf64044611 # v2.0.0
@@ -127,9 +126,8 @@ jobs:
         uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
         with:
           path: ~/.cache/go-build
-          key: go-build-${{ runner.os }}-test-db-${{ hashFiles('src/go.sum') }}-${{ github.sha }}
+          key: go-build-${{ runner.os }}-test-db-${{ hashFiles('src/go.sum') }}
           restore-keys: |
-            go-build-${{ runner.os }}-test-db-${{ hashFiles('src/go.sum') }}-
             go-build-${{ runner.os }}-
 
       - uses: arduino/setup-task@b91d5d2c96a56797b48ac1e0e89220bf64044611 # v2.0.0


### PR DESCRIPTION
## Summary
Replace `actions/setup-go` built-in caching with explicit `actions/cache` for both Go module and build caches. Key improvements:

- **Disable setup-go cache** (`cache: false`) to eliminate duplicate restore/save — `setup-go` uses exact key match only (no `restore-keys`), so its caching misses when the key differs even slightly.
- **Explicit module cache** (`~/go/pkg/mod`) with stable keys based on `go.sum` hash.
- **Explicit build cache** (`~/.cache/go-build`) with stable keys based on `go.sum` hash. Go's build cache is internally content-addressed, so a stable key caches all dependency compilations (the expensive part) while source recompilation is fast.
- **`restore-keys` prefix fallback** broadens key matching within eligible caches (current branch + default branch), so PR branches can restore from `main`'s cache even when the exact key differs.
- **Job-specific key suffixes** (`-build`, `-test-unit`, `-test-db`) prevent concurrent jobs from racing on immutable cache saves.

Expected impact: cold-cache builds drop from ~343s to ~20s by reliably restoring dependency compilations from `main`.

## Related Issues
<!-- none -->

## Type of Change
- [ ] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` / `fix!:`)
- [ ] Documentation (`docs:`)
- [ ] Refactoring (`refactor:`)
- [x] CI/CD or build changes (`ci:` / `build:`)
- [ ] Dependencies update (`chore:`)
- [ ] Tests (`test:`)

## Release Notes


## Testing
- [ ] Unit tests added/updated
- [x] Manual testing performed

## Checklist
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] Commits are signed off (`git commit -s`)
- [x] No new warnings introduced