### PR TITLE
ci: Overhaul test CI — host-persistent Go cache, shared DinD, taskfile proxy

### DIFF
--- a/.github/actions/setup-go-cached/action.yml
+++ b/.github/actions/setup-go-cached/action.yml
@@ -1,0 +1,39 @@
+name: 'Setup Go with Smart Caching'
+description: 'Uses persistent host cache on self-hosted, actions/cache on GitHub-hosted.'
+
+inputs:
+  go-version-file:
+    description: 'Path to go.mod for version detection'
+    required: true
+  go-sum-path:
+    description: 'Path to go.sum for cache key hashing'
+    required: true
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Setup Go toolchain
+      uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+      with:
+        go-version-file: ${{ inputs.go-version-file }}
+        cache: false
+
+    # GitHub-hosted only: restore module cache from GitHub's cache storage
+    - name: Restore Go module cache
+      if: runner.environment != 'self-hosted'
+      uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
+      with:
+        path: ~/go/pkg/mod
+        key: go-mod-${{ runner.os }}-${{ hashFiles(inputs.go-sum-path) }}
+        restore-keys: go-mod-${{ runner.os }}-
+
+    # GitHub-hosted only: restore build cache from GitHub's cache storage
+    - name: Restore Go build cache
+      if: runner.environment != 'self-hosted'
+      uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
+      with:
+        path: ~/.cache/go-build
+        key: go-build-${{ runner.os }}-${{ hashFiles(inputs.go-sum-path) }}-${{ github.sha }}
+        restore-keys: |
+          go-build-${{ runner.os }}-${{ hashFiles(inputs.go-sum-path) }}-
+          go-build-${{ runner.os }}-

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,10 +28,10 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+      - uses: ./.github/actions/setup-go-cached
         with:
           go-version-file: src/go.mod
-          cache-dependency-path: src/go.sum
+          go-sum-path: src/go.sum
 
       - uses: arduino/setup-task@b91d5d2c96a56797b48ac1e0e89220bf64044611 # v2.0.0
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,8 +38,5 @@ jobs:
           version: 3.x
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Generate API code
-        run: task build:gen-apis
-
       - name: Build binaries (linux/amd64)
         run: PLATFORMS=linux/amd64 task build

--- a/.github/workflows/cache-cleanup.yml
+++ b/.github/workflows/cache-cleanup.yml
@@ -14,7 +14,7 @@ jobs:
     name: Trim host caches
     runs-on: ${{ vars.RUNNER || 'ubuntu-latest' }}
     steps:
-      - name: Trim Go build cache (files not accessed in 7 days)
+      - name: Trim Go build cache (files not modified in 7 days)
         run: |
           if [ -z "$GOCACHE" ] || [ ! -d "$GOCACHE" ]; then
             echo "No GOCACHE directory found at '${GOCACHE:-<unset>}'"
@@ -39,7 +39,7 @@ jobs:
           echo "Module cache: ${size_mb}MB"
           if [ "$size_mb" -gt 2048 ]; then
             echo "Exceeds 2GB threshold, clearing..."
-            chmod -R u+w "$GOMODCACHE" && rm -rf "$GOMODCACHE"
+            chmod -R u+w "$GOMODCACHE" && rm -rf "${GOMODCACHE:?}"/* 2>/dev/null || true
           fi
 
       - name: Report tool cache size

--- a/.github/workflows/cache-cleanup.yml
+++ b/.github/workflows/cache-cleanup.yml
@@ -23,7 +23,7 @@ jobs:
           case "$GOCACHE" in /home/*|/opt/ci-cache/*) ;; *)
             echo "ERROR: GOCACHE='$GOCACHE' not under /home or /opt/ci-cache, skipping"; exit 0 ;; esac
           echo "Build cache before: $(du -sh "$GOCACHE" | cut -f1)"
-          find "$GOCACHE" -type f -atime +7 -delete 2>/dev/null || true
+          find "$GOCACHE" -type f -mtime +7 -delete 2>/dev/null || true
           find "$GOCACHE" -type d -empty -delete 2>/dev/null || true
           echo "Build cache after: $(du -sh "$GOCACHE" | cut -f1)"
 

--- a/.github/workflows/cache-cleanup.yml
+++ b/.github/workflows/cache-cleanup.yml
@@ -16,26 +16,30 @@ jobs:
     steps:
       - name: Trim Go build cache (files not accessed in 7 days)
         run: |
-          if [ -n "$GOCACHE" ] && [ -d "$GOCACHE" ]; then
-            echo "Build cache before: $(du -sh "$GOCACHE" | cut -f1)"
-            find "$GOCACHE" -type f -atime +7 -delete 2>/dev/null || true
-            find "$GOCACHE" -type d -empty -delete 2>/dev/null || true
-            echo "Build cache after: $(du -sh "$GOCACHE" | cut -f1)"
-          else
+          if [ -z "$GOCACHE" ] || [ ! -d "$GOCACHE" ]; then
             echo "No GOCACHE directory found at '${GOCACHE:-<unset>}'"
+            exit 0
           fi
+          case "$GOCACHE" in /home/*|/opt/ci-cache/*) ;; *)
+            echo "ERROR: GOCACHE='$GOCACHE' not under /home or /opt/ci-cache, skipping"; exit 0 ;; esac
+          echo "Build cache before: $(du -sh "$GOCACHE" | cut -f1)"
+          find "$GOCACHE" -type f -atime +7 -delete 2>/dev/null || true
+          find "$GOCACHE" -type d -empty -delete 2>/dev/null || true
+          echo "Build cache after: $(du -sh "$GOCACHE" | cut -f1)"
 
       - name: Check module cache size
         run: |
-          if [ -n "$GOMODCACHE" ] && [ -d "$GOMODCACHE" ]; then
-            size_mb=$(du -sm "$GOMODCACHE" | cut -f1)
-            echo "Module cache: ${size_mb}MB"
-            if [ "$size_mb" -gt 2048 ]; then
-              echo "Exceeds 2GB threshold, clearing..."
-              chmod -R u+w "$GOMODCACHE" && rm -rf "$GOMODCACHE"
-            fi
-          else
+          if [ -z "$GOMODCACHE" ] || [ ! -d "$GOMODCACHE" ]; then
             echo "No GOMODCACHE directory found at '${GOMODCACHE:-<unset>}'"
+            exit 0
+          fi
+          case "$GOMODCACHE" in /home/*|/opt/ci-cache/*) ;; *)
+            echo "ERROR: GOMODCACHE='$GOMODCACHE' not under /home or /opt/ci-cache, skipping"; exit 0 ;; esac
+          size_mb=$(du -sm "$GOMODCACHE" | cut -f1)
+          echo "Module cache: ${size_mb}MB"
+          if [ "$size_mb" -gt 2048 ]; then
+            echo "Exceeds 2GB threshold, clearing..."
+            chmod -R u+w "$GOMODCACHE" && rm -rf "$GOMODCACHE"
           fi
 
       - name: Report tool cache size

--- a/.github/workflows/cache-cleanup.yml
+++ b/.github/workflows/cache-cleanup.yml
@@ -1,0 +1,57 @@
+name: Cache Cleanup
+
+on:
+  schedule:
+    - cron: '0 4 * * 0' # Weekly, Sunday 4am UTC
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+  actions: write
+
+jobs:
+  cleanup-host:
+    name: Trim host caches
+    runs-on: ${{ vars.RUNNER || 'ubuntu-latest' }}
+    steps:
+      - name: Trim Go build cache (files not accessed in 7 days)
+        run: |
+          if [ -n "$GOCACHE" ] && [ -d "$GOCACHE" ]; then
+            echo "Build cache before: $(du -sh "$GOCACHE" | cut -f1)"
+            find "$GOCACHE" -type f -atime +7 -delete 2>/dev/null || true
+            find "$GOCACHE" -type d -empty -delete 2>/dev/null || true
+            echo "Build cache after: $(du -sh "$GOCACHE" | cut -f1)"
+          else
+            echo "No GOCACHE directory found at '${GOCACHE:-<unset>}'"
+          fi
+
+      - name: Check module cache size
+        run: |
+          if [ -n "$GOMODCACHE" ] && [ -d "$GOMODCACHE" ]; then
+            size_mb=$(du -sm "$GOMODCACHE" | cut -f1)
+            echo "Module cache: ${size_mb}MB"
+            if [ "$size_mb" -gt 2048 ]; then
+              echo "Exceeds 2GB threshold, clearing..."
+              chmod -R u+w "$GOMODCACHE" && rm -rf "$GOMODCACHE"
+            fi
+          else
+            echo "No GOMODCACHE directory found at '${GOMODCACHE:-<unset>}'"
+          fi
+
+      - name: Report tool cache size
+        run: |
+          if [ -d "/opt/hostedtoolcache" ]; then
+            echo "Tool cache: $(du -sh /opt/hostedtoolcache | cut -f1)"
+          fi
+
+  cleanup-github-cache:
+    name: Purge stale GitHub Actions caches
+    runs-on: ubuntu-latest
+    steps:
+      - name: Delete cache entries older than 7 days
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh cache list -R "${{ github.repository }}" --limit 100 --json id,lastAccessedAt \
+            --jq '[.[] | select(.lastAccessedAt < (now - 604800 | todate)) | .id] | .[]' \
+          | xargs -I{} gh cache delete {} -R "${{ github.repository }}" 2>/dev/null || true

--- a/.github/workflows/cache-cleanup.yml
+++ b/.github/workflows/cache-cleanup.yml
@@ -20,6 +20,8 @@ jobs:
             echo "No GOCACHE directory found at '${GOCACHE:-<unset>}'"
             exit 0
           fi
+          # Canonicalize to defeat traversal tricks like /home/../../etc
+          GOCACHE="$(realpath -m "$GOCACHE")"
           case "$GOCACHE" in /home/*|/opt/ci-cache/*) ;; *)
             echo "ERROR: GOCACHE='$GOCACHE' not under /home or /opt/ci-cache, skipping"; exit 0 ;; esac
           echo "Build cache before: $(du -sh "$GOCACHE" | cut -f1)"
@@ -33,6 +35,8 @@ jobs:
             echo "No GOMODCACHE directory found at '${GOMODCACHE:-<unset>}'"
             exit 0
           fi
+          # Canonicalize to defeat traversal tricks like /home/../../etc
+          GOMODCACHE="$(realpath -m "$GOMODCACHE")"
           case "$GOMODCACHE" in /home/*|/opt/ci-cache/*) ;; *)
             echo "ERROR: GOMODCACHE='$GOMODCACHE' not under /home or /opt/ci-cache, skipping"; exit 0 ;; esac
           size_mb=$(du -sm "$GOMODCACHE" | cut -f1)

--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -51,10 +51,10 @@ jobs:
 
       - name: Setup Go
         if: ${{ contains(fromJSON('["core","jobservice","registryctl","exporter","registry","trivy-adapter"]'), matrix.component) }}
-        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        uses: ./.github/actions/setup-go-cached
         with:
           go-version-file: src/go.mod
-          cache-dependency-path: src/go.sum
+          go-sum-path: src/go.sum
 
       - name: Install Task
         if: ${{ contains(fromJSON('["core","jobservice","registryctl","exporter","registry","trivy-adapter"]'), matrix.component) }}
@@ -179,10 +179,10 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Setup Go
-        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        uses: ./.github/actions/setup-go-cached
         with:
           go-version-file: src/go.mod
-          cache: false
+          go-sum-path: src/go.sum
 
       - name: Install crane
         run: go install github.com/google/go-containerregistry/cmd/crane@v0.20.3

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -83,10 +83,10 @@ jobs:
 
       - name: Setup Go
         if: ${{ contains(fromJSON('["core","jobservice","registryctl","exporter","registry","trivy-adapter"]'), matrix.component) }}
-        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        uses: ./.github/actions/setup-go-cached
         with:
           go-version-file: src/go.mod
-          cache-dependency-path: src/go.sum
+          go-sum-path: src/go.sum
 
       - name: Install Task
         if: ${{ contains(fromJSON('["core","jobservice","registryctl","exporter","registry","trivy-adapter"]'), matrix.component) }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -76,23 +76,26 @@ jobs:
         run: |
           PREFIX="test-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
           echo "SVC_PREFIX=${PREFIX}" >> "$GITHUB_ENV"
+          # Use random host ports to avoid collisions on shared Docker daemon
           docker run -d --name "${PREFIX}-postgres" \
             -e POSTGRES_USER=postgres -e POSTGRES_PASSWORD=root123 -e POSTGRES_DB=registry \
-            -p 5432:5432 postgres:16-alpine
+            -p 0:5432 postgres:16-alpine
           docker run -d --name "${PREFIX}-redis" \
-            -p 6379:6379 redis:7-alpine
+            -p 0:6379 redis:7-alpine
           # Resolve service host: shared DinD uses its service FQDN, local Docker uses localhost
           if [ -n "$DOCKER_HOST" ] && echo "$DOCKER_HOST" | grep -qv localhost; then
             SVC_HOST=$(echo "$DOCKER_HOST" | sed 's|tcp://||;s|:.*||')
           else
             SVC_HOST=localhost
           fi
+          PG_PORT=$(docker port "${PREFIX}-postgres" 5432 | head -1 | cut -d: -f2)
+          REDIS_PORT=$(docker port "${PREFIX}-redis" 6379 | head -1 | cut -d: -f2)
           echo "SVC_HOST=${SVC_HOST}" >> "$GITHUB_ENV"
           echo "POSTGRESQL_HOST=${SVC_HOST}" >> "$GITHUB_ENV"
-          echo "POSTGRESQL_PORT=5432" >> "$GITHUB_ENV"
-          echo "JOB_SERVICE_POOL_REDIS_URL=redis://${SVC_HOST}:6379" >> "$GITHUB_ENV"
-          # Wait for postgres
-          until docker exec "${PREFIX}-postgres" pg_isready -U postgres; do sleep 1; done
+          echo "POSTGRESQL_PORT=${PG_PORT}" >> "$GITHUB_ENV"
+          echo "JOB_SERVICE_POOL_REDIS_URL=redis://${SVC_HOST}:${REDIS_PORT}" >> "$GITHUB_ENV"
+          # Wait for postgres (timeout after 30s)
+          timeout 30 bash -c "until docker exec ${PREFIX}-postgres pg_isready -U postgres; do sleep 1; done"
 
       - uses: ./.github/actions/setup-go-cached
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -94,8 +94,9 @@ jobs:
           echo "POSTGRESQL_HOST=${SVC_HOST}" >> "$GITHUB_ENV"
           echo "POSTGRESQL_PORT=${PG_PORT}" >> "$GITHUB_ENV"
           echo "JOB_SERVICE_POOL_REDIS_URL=redis://${SVC_HOST}:${REDIS_PORT}" >> "$GITHUB_ENV"
-          # Wait for postgres (timeout after 30s)
+          # Wait for services (timeout after 30s each)
           timeout 30 bash -c "until docker exec ${PREFIX}-postgres pg_isready -U postgres; do sleep 1; done"
+          timeout 10 bash -c "until docker exec ${PREFIX}-redis redis-cli ping | grep -q PONG; do sleep 1; done"
 
       - uses: ./.github/actions/setup-go-cached
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,10 +33,10 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+      - uses: ./.github/actions/setup-go-cached
         with:
           go-version-file: src/go.mod
-          cache-dependency-path: src/go.sum
+          go-sum-path: src/go.sum
 
       - uses: arduino/setup-task@b91d5d2c96a56797b48ac1e0e89220bf64044611 # v2.0.0
         with:
@@ -93,10 +93,10 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+      - uses: ./.github/actions/setup-go-cached
         with:
           go-version-file: src/go.mod
-          cache-dependency-path: src/go.sum
+          go-sum-path: src/go.sum
 
       - uses: arduino/setup-task@b91d5d2c96a56797b48ac1e0e89220bf64044611 # v2.0.0
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -44,7 +44,10 @@ jobs:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Ensure C toolchain for race detector
-        run: command -v gcc >/dev/null || sudo apt-get update && sudo apt-get install -y --no-install-recommends gcc
+        run: |
+          if ! echo '#include <stdlib.h>' | gcc -E -x c - >/dev/null 2>&1; then
+            sudo apt-get update && sudo apt-get install -y --no-install-recommends gcc libc6-dev
+          fi
 
       - name: Generate API code
         run: task build:gen-apis
@@ -102,7 +105,10 @@ jobs:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Ensure C toolchain for race detector
-        run: command -v gcc >/dev/null || sudo apt-get update && sudo apt-get install -y --no-install-recommends gcc
+        run: |
+          if ! echo '#include <stdlib.h>' | gcc -E -x c - >/dev/null 2>&1; then
+            sudo apt-get update && sudo apt-get install -y --no-install-recommends gcc libc6-dev
+          fi
 
       - name: Generate API code
         run: task build:gen-apis

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -54,7 +54,10 @@ jobs:
 
       - name: Run pure unit tests
         working-directory: src
-        run: go test -race -count=1 -timeout=15m -cover ./...
+        # -p 2 limits concurrent package compile+test to 2 to keep peak
+        # memory under the runner's limit. -race adds significant memory
+        # overhead and Harbor's full package set OOMs at higher parallelism.
+        run: go test -race -count=1 -timeout=20m -cover -p 2 ./...
 
   # --------------------------------------------------------------------------
   # DB-dependent unit tests — need PostgreSQL + Redis, run serially

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -59,31 +59,7 @@ jobs:
   test-db:
     name: Unit Tests (DB)
     runs-on: ${{ (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository || contains(fromJSON('["OWNER","MEMBER"]'), github.event.pull_request.author_association)) && vars.RUNNER || 'ubuntu-latest' }}
-    services:
-      postgres:
-        image: postgres:16-alpine
-        env:
-          POSTGRES_USER: postgres
-          POSTGRES_PASSWORD: root123
-          POSTGRES_DB: registry
-        ports:
-          - 5432/tcp
-        options: >-
-          --health-cmd pg_isready
-          --health-interval 5s
-          --health-timeout 3s
-          --health-retries 10
-      redis:
-        image: redis:7-alpine
-        ports:
-          - 6379/tcp
-        options: >-
-          --health-cmd "redis-cli ping"
-          --health-interval 5s
-          --health-timeout 3s
-          --health-retries 10
     env:
-      POSTGRESQL_HOST: localhost
       POSTGRESQL_USR: postgres
       POSTGRESQL_PWD: root123
       POSTGRESQL_DATABASE: registry
@@ -92,6 +68,28 @@ jobs:
       CGO_ENABLED: "1"
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Start test services
+        run: |
+          PREFIX="test-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+          echo "SVC_PREFIX=${PREFIX}" >> "$GITHUB_ENV"
+          docker run -d --name "${PREFIX}-postgres" \
+            -e POSTGRES_USER=postgres -e POSTGRES_PASSWORD=root123 -e POSTGRES_DB=registry \
+            -p 5432:5432 postgres:16-alpine
+          docker run -d --name "${PREFIX}-redis" \
+            -p 6379:6379 redis:7-alpine
+          # Resolve service host: shared DinD uses its service FQDN, local Docker uses localhost
+          if [ -n "$DOCKER_HOST" ] && echo "$DOCKER_HOST" | grep -qv localhost; then
+            SVC_HOST=$(echo "$DOCKER_HOST" | sed 's|tcp://||;s|:.*||')
+          else
+            SVC_HOST=localhost
+          fi
+          echo "SVC_HOST=${SVC_HOST}" >> "$GITHUB_ENV"
+          echo "POSTGRESQL_HOST=${SVC_HOST}" >> "$GITHUB_ENV"
+          echo "POSTGRESQL_PORT=5432" >> "$GITHUB_ENV"
+          echo "JOB_SERVICE_POOL_REDIS_URL=redis://${SVC_HOST}:6379" >> "$GITHUB_ENV"
+          # Wait for postgres
+          until docker exec "${PREFIX}-postgres" pg_isready -U postgres; do sleep 1; done
 
       - uses: ./.github/actions/setup-go-cached
         with:
@@ -106,14 +104,14 @@ jobs:
       - name: Ensure C toolchain for race detector
         run: command -v gcc >/dev/null || sudo apt-get update && sudo apt-get install -y --no-install-recommends gcc
 
-      - name: Export service ports
-        run: |
-          echo "POSTGRESQL_PORT=${{ job.services.postgres.ports['5432'] }}" >> "$GITHUB_ENV"
-          echo "JOB_SERVICE_POOL_REDIS_URL=redis://localhost:${{ job.services.redis.ports['6379'] }}" >> "$GITHUB_ENV"
-
       - name: Generate API code
         run: task build:gen-apis
 
       - name: Run DB unit tests
         working-directory: src
         run: go test -race -count=1 -timeout=15m -tags db -cover -p 1 -parallel 1 ./...
+
+      - name: Stop test services
+        if: always()
+        run: |
+          docker rm -f "${SVC_PREFIX}-postgres" "${SVC_PREFIX}-redis" 2>/dev/null || true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,11 +30,6 @@ jobs:
     runs-on: ${{ (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository || contains(fromJSON('["OWNER","MEMBER"]'), github.event.pull_request.author_association)) && vars.RUNNER || 'ubuntu-latest' }}
     env:
       CGO_ENABLED: "1"
-      # TestCopy in controller/artifact mocks accessoryMgr.List to always
-      # return the same accessory; without UTTEST=true the production code
-      # in controller.go:548 takes the recursive copyDeeply branch and
-      # infinite-loops, leaking ~165 MB/sec until the runner OOMs.
-      UTTEST: "true"
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
@@ -54,12 +49,8 @@ jobs:
             sudo apt-get update && sudo apt-get install -y --no-install-recommends gcc libc6-dev
           fi
 
-      - name: Generate API code
-        run: task build:gen-apis
-
       - name: Run pure unit tests
-        working-directory: src
-        run: go test -race -count=1 -timeout=15m -cover ./...
+        run: task test:unit:pure COVER_FLAGS=-cover TEST_FLAGS=-count=1
 
   # --------------------------------------------------------------------------
   # DB-dependent unit tests — need PostgreSQL + Redis, run serially
@@ -72,7 +63,6 @@ jobs:
       POSTGRESQL_PWD: root123
       POSTGRESQL_DATABASE: registry
       POSTGRES_MIGRATION_SCRIPTS_PATH: ${{ github.workspace }}/make/migrations/postgresql
-      UTTEST: "true"
       CGO_ENABLED: "1"
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -119,12 +109,8 @@ jobs:
             sudo apt-get update && sudo apt-get install -y --no-install-recommends gcc libc6-dev
           fi
 
-      - name: Generate API code
-        run: task build:gen-apis
-
       - name: Run DB unit tests
-        working-directory: src
-        run: go test -race -count=1 -timeout=15m -tags db -cover -p 1 -parallel 1 ./...
+        run: task test:unit:db COVER_FLAGS=-cover TEST_FLAGS=-count=1
 
       - name: Stop test services
         if: always()

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,6 +30,11 @@ jobs:
     runs-on: ${{ (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository || contains(fromJSON('["OWNER","MEMBER"]'), github.event.pull_request.author_association)) && vars.RUNNER || 'ubuntu-latest' }}
     env:
       CGO_ENABLED: "1"
+      # TestCopy in controller/artifact mocks accessoryMgr.List to always
+      # return the same accessory; without UTTEST=true the production code
+      # in controller.go:548 takes the recursive copyDeeply branch and
+      # infinite-loops, leaking ~165 MB/sec until the runner OOMs.
+      UTTEST: "true"
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
@@ -54,10 +59,7 @@ jobs:
 
       - name: Run pure unit tests
         working-directory: src
-        # -p 2 limits concurrent package compile+test to 2 to keep peak
-        # memory under the runner's limit. -race adds significant memory
-        # overhead and Harbor's full package set OOMs at higher parallelism.
-        run: go test -race -count=1 -timeout=20m -cover -p 2 ./...
+        run: go test -race -count=1 -timeout=15m -cover ./...
 
   # --------------------------------------------------------------------------
   # DB-dependent unit tests — need PostgreSQL + Redis, run serially

--- a/src/controller/artifact/controller_test.go
+++ b/src/controller/artifact/controller_test.go
@@ -327,6 +327,10 @@ func (c *controllerTestSuite) TestEnsureArtifact() {
 
 	// reset the mock
 	c.SetupTest()
+	c.setupRepoMgr()
+	c.setupArtMgr()
+	c.setupAccMgr()
+	c.setupAbstractor()
 
 	// the artifact doesn't exist and includes a pending attestation accessory candidate
 	c.repoMgr.On("GetByName", mock.Anything, mock.Anything).Return(&repomodel.RepoRecord{

--- a/taskfile/test.yml
+++ b/taskfile/test.yml
@@ -74,11 +74,15 @@ tasks:
   unit:
     desc: "Run Go unit tests with race detection"
     dir: src
+    env:
+      UTTEST: "true"
     cmd: go test -v -race -cover ./...
 
   unit:coverage:
     desc: "Run Go unit tests and generate HTML coverage report"
     dir: src
+    env:
+      UTTEST: "true"
     cmds:
       - go test -v -race -coverprofile=coverage.out -covermode=atomic ./...
       - go tool cover -html=coverage.out -o coverage.html
@@ -87,12 +91,16 @@ tasks:
     desc: "Run pure unit tests (no DB/Redis needed) with full parallelism"
     deps: [build:gen-apis]
     dir: src
+    env:
+      UTTEST: "true"
     cmd: go test -race -timeout=15m {{.COVER_FLAGS}} {{.TEST_FLAGS}} ./...
 
   unit:db:
     desc: "Run DB-dependent unit tests serially (needs PostgreSQL + Redis)"
     deps: [build:gen-apis]
     dir: src
+    env:
+      UTTEST: "true"
     cmd: go test -race -timeout=15m -tags db -p 1 -parallel 1 {{.COVER_FLAGS}} {{.TEST_FLAGS}} ./...
 
   unit:watch:
@@ -101,6 +109,8 @@ tasks:
       - sh: command -v watchexec
         msg: "watchexec not found. Install: brew install watchexec"
     dir: src
+    env:
+      UTTEST: "true"
     cmd: watchexec -e go -r -- go test -v ./...
 
   # ============================================================================


### PR DESCRIPTION
## Summary

Reworks the test CI pipeline end-to-end. Originally started as a Go cache fix (`actions/cache` was costing ~6 min per run of I/O overhead on ephemeral ARC runner pods), but grew to cover the full test-execution path: shared DinD integration, workflow ↔ taskfile consistency, and a latent unit-test bug.

## Problem

Our ARC runners are ephemeral K8s pods on a single node. The built-in `actions/setup-go` cache downloaded/uploaded ~1.2 GB tarballs to GitHub's remote cache storage every run — **382s for cache I/O, 23s for the actual build**. 14 cache entries consumed ~10 GB in GitHub Actions cache. Meanwhile the test-db job used a GitHub `services:` block that only works with per-pod Docker, blocking the move to a shared DinD. And `test-unit` was silently broken — it was OOM-looping on a pre-existing infinite recursion in `TestCopy` because `UTTEST=true` was only set in `test-db`.

## Changes

### Go cache
- **New composite action** `.github/actions/setup-go-cached` — disables `actions/setup-go` built-in caching and leaves the runner pod template's `GOMODCACHE`/`GOCACHE` (backed by hostPath volumes) in charge. Falls back to `actions/cache` on GitHub-hosted runners (fork PRs).
- All four workflows (`build.yml`, `test.yml`, `pr-ci.yml`, `release-please.yml`) switched to the composite action.
- New `.github/workflows/cache-cleanup.yml` — weekly trim of the on-disk Go build cache (files not modified in 7 days) + purge of stale GitHub Actions cache entries. Path guarded to only operate on `/home/*` or `/opt/ci-cache/*` after `realpath -m` canonicalization.

### Shared DinD integration (`test.yml`)
- Replaced GitHub Actions `services:` block with explicit `docker run` steps. The shared DinD service in `github-runners` only forwards ports listed in `spec.ports`, so the old `services:` block couldn't reach random Docker-published ports.
- Random host ports (`-p 0:<port>`) resolved via `docker port` to avoid collisions on shared DinD.
- Bounded readiness waits: 30s for Postgres, 10s for Redis.
- Unique container names per run (`test-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}`).
- Cleanup step with `if: always()`.
- Fixed C toolchain check (`stdlib.h` probe instead of `command -v gcc`) so `libc6-dev` gets installed when needed.

### Workflow ↔ taskfile consistency
- `test-unit`/`test-db` steps now call `task test:unit:pure` / `task test:unit:db` — thin proxies over the taskfile. The CI previously re-implemented `go test` commands, which is how `UTTEST=true` drifted out of `test-unit` when the original single Unit Tests job was split.
- `UTTEST=true` moved into the taskfile (`unit`, `unit:pure`, `unit:db`, `unit:coverage`, `unit:watch`) as a single source of truth. Running `task test:unit:pure` locally and in CI now take identical paths.
- Redundant `Generate API code` step removed from `build.yml` and `test.yml` — it's already a `deps:` of `binary:*` and `unit:*` tasks.

### Test bug found during investigation
- `controller/artifact.TestCopy` was infinite-recursing into `(*controller).copyDeeply` at 165 MB/sec (guard at `controller.go:548` keyed off `UTTEST`). Root cause for the `test-unit` OOMs.
- `TestEnsureArtifact` at `controller_test.go:329` had a latent nil-pointer panic — the lazy-mock PR (#101) made `SetupTest()` reset mocks to nil, but the fourth subtest never called the `setupXxx()` helpers afterward. Exposed once the OOM was fixed.

## Measured results

Build workflow on self-hosted runner (warm cache):

| Step | Before | After | Delta |
|---|---|---|---|
| setup-go | 382s | ~8s | **-98%** |
| Build binaries | 23s | 7s | -70% |
| **Total** | **445s** | **~45s** | **-90%** |

GitHub Actions cache storage: ~10 GB → ~0 (self-hosted runners no longer upload tarballs).

## Required companion change

ARC runner template needs `hostPath` volumes for Go toolchain + module/build caches and a headless DinD service — handled in the `k8s/apps/` repo.

## Testing
- [x] Manual testing performed — build, test-unit, test-db all pass end-to-end
- [x] Pure unit test fix verified locally: `UTTEST=true go test -race ./controller/artifact` → ok in 1.5s, 499 MB RSS (was OOM at 8+ GB)

## Type of Change
- [x] CI/CD or build changes (`ci:` / `build:`)

## Checklist
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] Commits are signed off (`git commit -s`)
- [x] No new warnings introduced

Supersedes #125