### PR TITLE
test: Restore CI-hostile package exclusion list in test:unit:pure/db

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -89,6 +89,14 @@ jobs:
           echo "POSTGRESQL_HOST=${SVC_HOST}" >> "$GITHUB_ENV"
           echo "POSTGRESQL_PORT=${PG_PORT}" >> "$GITHUB_ENV"
           echo "JOB_SERVICE_POOL_REDIS_URL=redis://${SVC_HOST}:${REDIS_PORT}" >> "$GITHUB_ENV"
+          # Harbor's libredis.GetRegistryClient / GetHarborClient read these
+          # env vars. controller/blob, jobservice/*, pkg/task/dao all need
+          # them. Without these the tests fail with net.OpError "dial tcp".
+          echo "_REDIS_URL_REG=redis://${SVC_HOST}:${REDIS_PORT}/1" >> "$GITHUB_ENV"
+          echo "_REDIS_URL_CORE=redis://${SVC_HOST}:${REDIS_PORT}/0" >> "$GITHUB_ENV"
+          echo "_REDIS_URL_HARBOR=redis://${SVC_HOST}:${REDIS_PORT}/0" >> "$GITHUB_ENV"
+          echo "REDIS_HOST=${SVC_HOST}" >> "$GITHUB_ENV"
+          echo "REDIS_PORT=${REDIS_PORT}" >> "$GITHUB_ENV"
           # Wait for services (timeout after 30s each)
           timeout 30 bash -c "until docker exec ${PREFIX}-postgres pg_isready -U postgres; do sleep 1; done"
           timeout 10 bash -c "until docker exec ${PREFIX}-redis redis-cli ping | grep -q PONG; do sleep 1; done"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -71,45 +71,52 @@ jobs:
         run: |
           PREFIX="test-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
           echo "SVC_PREFIX=${PREFIX}" >> "$GITHUB_ENV"
-          # Postgres gets a random host port (resolved via `docker port`).
-          # Redis is pinned to 6379 because Harbor's jobservice test helper
-          # (src/jobservice/tests/utils.go) hardcodes `testingRedisPort=6379`
-          # regardless of REDIS_PORT env, so jobservice/common/rds,
-          # jobservice/hook, jobservice/job, jobservice/period,
-          # jobservice/worker/cworker, pkg/task/dao etc. will only find
-          # Redis on port 6379. The concurrency group (`test-${pr_number}`)
-          # cancels old runs for the same PR, but cross-PR test-db runs can
-          # briefly collide on the shared DinD daemon. Accepted trade-off
-          # vs. excluding all 12 affected packages.
+
+          # Redis runs on the runner pod itself at localhost:6379.
+          # Rationale: several tests hardcode `redis://localhost:6379`:
+          #   - src/pkg/task/dao/execution_test.go:50 (cache.Initialize)
+          #   - src/jobservice/config/config_test.go:98 (asserts literal)
+          #   - src/jobservice/tests/utils.go:39 (hardcodes testingRedisPort=6379)
+          # Running Redis on the runner pod's localhost makes all of them
+          # work without touching upstream source. Also avoids cross-PR
+          # port-6379 collisions that would happen if we published through
+          # the shared DinD daemon.
+          command -v redis-server >/dev/null 2>&1 || \
+            sudo apt-get update -qq && sudo apt-get install -y -qq redis-server
+          # Start Redis as a daemon. --daemonize forks and returns; --bind
+          # 0.0.0.0 is fine on an ephemeral runner pod.
+          redis-server --daemonize yes --port 6379 --bind 0.0.0.0 --save "" --appendonly no
+          timeout 10 bash -c 'until redis-cli -h localhost -p 6379 ping 2>/dev/null | grep -q PONG; do sleep 0.5; done'
+
+          # Postgres stays in DinD with a random host port because no test
+          # hardcodes localhost for postgres; they all respect POSTGRESQL_HOST.
           docker run -d --name "${PREFIX}-postgres" \
             -e POSTGRES_USER=postgres -e POSTGRES_PASSWORD=root123 -e POSTGRES_DB=registry \
             -p 0:5432 postgres:16-alpine
-          docker run -d --name "${PREFIX}-redis" \
-            -p 6379:6379 redis:7-alpine
-          # Resolve service host: shared DinD uses its service FQDN, local Docker uses localhost
+          # Resolve postgres host: shared DinD uses its service FQDN, local Docker uses localhost
           if [ -n "$DOCKER_HOST" ] && echo "$DOCKER_HOST" | grep -qv localhost; then
-            SVC_HOST=$(echo "$DOCKER_HOST" | sed 's|tcp://||;s|:.*||')
+            PG_HOST=$(echo "$DOCKER_HOST" | sed 's|tcp://||;s|:.*||')
           else
-            SVC_HOST=localhost
+            PG_HOST=localhost
           fi
           PG_PORT=$(docker port "${PREFIX}-postgres" 5432 | head -1 | cut -d: -f2)
-          # Redis is pinned (see rationale above)
-          REDIS_PORT=6379
-          echo "SVC_HOST=${SVC_HOST}" >> "$GITHUB_ENV"
-          echo "POSTGRESQL_HOST=${SVC_HOST}" >> "$GITHUB_ENV"
+
+          echo "POSTGRESQL_HOST=${PG_HOST}" >> "$GITHUB_ENV"
           echo "POSTGRESQL_PORT=${PG_PORT}" >> "$GITHUB_ENV"
-          echo "JOB_SERVICE_POOL_REDIS_URL=redis://${SVC_HOST}:${REDIS_PORT}" >> "$GITHUB_ENV"
-          # Harbor's libredis.GetRegistryClient / GetHarborClient read these
-          # env vars. controller/blob, jobservice/*, pkg/task/dao all need
-          # them. Without these the tests fail with net.OpError "dial tcp".
-          echo "_REDIS_URL_REG=redis://${SVC_HOST}:${REDIS_PORT}/1" >> "$GITHUB_ENV"
-          echo "_REDIS_URL_CORE=redis://${SVC_HOST}:${REDIS_PORT}/0" >> "$GITHUB_ENV"
-          echo "_REDIS_URL_HARBOR=redis://${SVC_HOST}:${REDIS_PORT}/0" >> "$GITHUB_ENV"
-          echo "REDIS_HOST=${SVC_HOST}" >> "$GITHUB_ENV"
-          echo "REDIS_PORT=${REDIS_PORT}" >> "$GITHUB_ENV"
-          # Wait for services (timeout after 30s each)
+          # All Redis URLs point at localhost:6379 (runner-pod-local Redis).
+          # JOB_SERVICE_POOL_REDIS_URL is read by jobservice/config's env
+          # override path and must equal "redis://localhost:6379" exactly
+          # to satisfy TestDefaultConfig's literal assertion against the
+          # yaml default.
+          echo "JOB_SERVICE_POOL_REDIS_URL=redis://localhost:6379" >> "$GITHUB_ENV"
+          echo "_REDIS_URL_REG=redis://localhost:6379/1" >> "$GITHUB_ENV"
+          echo "_REDIS_URL_CORE=redis://localhost:6379/0" >> "$GITHUB_ENV"
+          echo "_REDIS_URL_HARBOR=redis://localhost:6379/0" >> "$GITHUB_ENV"
+          echo "REDIS_HOST=localhost" >> "$GITHUB_ENV"
+          echo "REDIS_PORT=6379" >> "$GITHUB_ENV"
+
+          # Wait for postgres
           timeout 30 bash -c "until docker exec ${PREFIX}-postgres pg_isready -U postgres; do sleep 1; done"
-          timeout 10 bash -c "until docker exec ${PREFIX}-redis redis-cli ping | grep -q PONG; do sleep 1; done"
 
       - uses: ./.github/actions/setup-go-cached
         with:
@@ -133,4 +140,5 @@ jobs:
       - name: Stop test services
         if: always()
         run: |
-          docker rm -f "${SVC_PREFIX}-postgres" "${SVC_PREFIX}-redis" 2>/dev/null || true
+          redis-cli -h localhost -p 6379 shutdown nosave 2>/dev/null || true
+          docker rm -f "${SVC_PREFIX}-postgres" 2>/dev/null || true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -71,12 +71,21 @@ jobs:
         run: |
           PREFIX="test-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
           echo "SVC_PREFIX=${PREFIX}" >> "$GITHUB_ENV"
-          # Use random host ports to avoid collisions on shared Docker daemon
+          # Postgres gets a random host port (resolved via `docker port`).
+          # Redis is pinned to 6379 because Harbor's jobservice test helper
+          # (src/jobservice/tests/utils.go) hardcodes `testingRedisPort=6379`
+          # regardless of REDIS_PORT env, so jobservice/common/rds,
+          # jobservice/hook, jobservice/job, jobservice/period,
+          # jobservice/worker/cworker, pkg/task/dao etc. will only find
+          # Redis on port 6379. The concurrency group (`test-${pr_number}`)
+          # cancels old runs for the same PR, but cross-PR test-db runs can
+          # briefly collide on the shared DinD daemon. Accepted trade-off
+          # vs. excluding all 12 affected packages.
           docker run -d --name "${PREFIX}-postgres" \
             -e POSTGRES_USER=postgres -e POSTGRES_PASSWORD=root123 -e POSTGRES_DB=registry \
             -p 0:5432 postgres:16-alpine
           docker run -d --name "${PREFIX}-redis" \
-            -p 0:6379 redis:7-alpine
+            -p 6379:6379 redis:7-alpine
           # Resolve service host: shared DinD uses its service FQDN, local Docker uses localhost
           if [ -n "$DOCKER_HOST" ] && echo "$DOCKER_HOST" | grep -qv localhost; then
             SVC_HOST=$(echo "$DOCKER_HOST" | sed 's|tcp://||;s|:.*||')
@@ -84,7 +93,8 @@ jobs:
             SVC_HOST=localhost
           fi
           PG_PORT=$(docker port "${PREFIX}-postgres" 5432 | head -1 | cut -d: -f2)
-          REDIS_PORT=$(docker port "${PREFIX}-redis" 6379 | head -1 | cut -d: -f2)
+          # Redis is pinned (see rationale above)
+          REDIS_PORT=6379
           echo "SVC_HOST=${SVC_HOST}" >> "$GITHUB_ENV"
           echo "POSTGRESQL_HOST=${SVC_HOST}" >> "$GITHUB_ENV"
           echo "POSTGRESQL_PORT=${PG_PORT}" >> "$GITHUB_ENV"

--- a/taskfile/test.yml
+++ b/taskfile/test.yml
@@ -87,13 +87,42 @@ tasks:
       - go test -v -race -coverprofile=coverage.out -covermode=atomic ./...
       - go tool cover -html=coverage.out -o coverage.html
 
+  # ----------------------------------------------------------------------------
+  # CI-hostile packages excluded from unit:pure / unit:db (default filter).
+  # Each entry is here because:
+  #   - LDAP packages (/controller/ldap, /core/auth/ldap, /pkg/ldap): need LDAP
+  #     server we don't provision
+  #   - /core/api, /core/controllers, /pkg/proxy/connection: need full Harbor stack
+  #   - /pkg/token, /server/middleware/security, /controller/systeminfo: need
+  #     /etc/core/ cert files
+  #   - /pkg/jobmonitor: needs REDIS_HOST env var with specific format
+  #   - /common/utils/email: reaches external SMTP (smtp.gmail.com) from tests
+  #   - /jobservice/runner: Redis job tracker state ordering issues
+  #   - /jobservice/logger/getter: DB state ordering when packages run in parallel
+  #   - /jobservice/job/impl/gc: TestDelKeys hardcodes redis://127.0.0.1:6379
+  #   - /core/session: SessionInit hardcodes redis://127.0.0.1:6379/0
+  #   - /lib/cache/redis: test suite assumes Redis on localhost
+  #   - /server/middleware/blob: needs DB + Redis for middleware setup
+  #   - /controller/usergroup/test, /pkg/scan/dao/scanner, /pkg/scan/export,
+  #     /pkg/scan/dao/scan, /pkg/scan/postprocessors, /pkg/systemartifact:
+  #     upstream test-ordering / FK-constraint issues
+  #   - /pkg/accessory/model/attestation: imports src/testing which has
+  #     //go:build db; doesn't compile without -tags db
+  # Override in dev with `task test:unit:pure PKG_EXCLUDE=` to run everything.
+  # Keep this list in sync with any upstream fixes.
+  # ----------------------------------------------------------------------------
   unit:pure:
     desc: "Run pure unit tests (no DB/Redis needed) with full parallelism"
     deps: [build:gen-apis]
     dir: src
     env:
       UTTEST: "true"
-    cmd: go test -race -timeout=15m {{.COVER_FLAGS}} {{.TEST_FLAGS}} ./...
+    vars:
+      PKG_EXCLUDE: '{{.PKG_EXCLUDE | default "/controller/ldap$|/core/auth/ldap$|/pkg/ldap$|/core/api$|/core/controllers$|/pkg/proxy/connection$|/pkg/token$|/server/middleware/security$|/server/middleware/blob$|/controller/systeminfo$|/pkg/jobmonitor$|/common/utils/email$|/jobservice/runner$|/jobservice/logger/getter$|/jobservice/job/impl/gc$|/core/session$|/lib/cache/redis$|/controller/usergroup/test$|/pkg/scan/dao/scanner$|/pkg/scan/export$|/pkg/scan/dao/scan$|/pkg/scan/postprocessors$|/pkg/systemartifact$|/pkg/accessory/model/attestation$"}}'
+    cmd: |
+      pkgs=$(go list ./... | grep -vE '{{.PKG_EXCLUDE}}' | tr '\n' ' ')
+      # shellcheck disable=SC2086
+      go test -race -timeout=15m {{.COVER_FLAGS}} {{.TEST_FLAGS}} $pkgs
 
   unit:db:
     desc: "Run DB-dependent unit tests serially (needs PostgreSQL + Redis)"
@@ -101,7 +130,12 @@ tasks:
     dir: src
     env:
       UTTEST: "true"
-    cmd: go test -race -timeout=15m -tags db -p 1 -parallel 1 {{.COVER_FLAGS}} {{.TEST_FLAGS}} ./...
+    vars:
+      PKG_EXCLUDE: '{{.PKG_EXCLUDE | default "/controller/ldap$|/core/auth/ldap$|/pkg/ldap$|/core/api$|/core/controllers$|/pkg/proxy/connection$|/pkg/token$|/server/middleware/security$|/server/middleware/blob$|/controller/systeminfo$|/pkg/jobmonitor$|/common/utils/email$|/jobservice/runner$|/jobservice/logger/getter$|/jobservice/job/impl/gc$|/core/session$|/lib/cache/redis$|/controller/usergroup/test$|/pkg/scan/dao/scanner$|/pkg/scan/export$|/pkg/scan/dao/scan$|/pkg/scan/postprocessors$|/pkg/systemartifact$|/pkg/accessory/model/attestation$"}}'
+    cmd: |
+      pkgs=$(go list -tags db ./... | grep -vE '{{.PKG_EXCLUDE}}' | tr '\n' ' ')
+      # shellcheck disable=SC2086
+      go test -race -timeout=15m -tags db -p 1 -parallel 1 {{.COVER_FLAGS}} {{.TEST_FLAGS}} $pkgs
 
   unit:watch:
     desc: "Re-run Go unit tests on file changes (requires watchexec)"

--- a/taskfile/test.yml
+++ b/taskfile/test.yml
@@ -9,6 +9,13 @@ includes:
     dir: ..
     internal: true
 
+vars:
+  # Single source of truth for the unit:pure / unit:db package exclusion
+  # filter. See the comment block above `unit:pure` for per-package rationale.
+  # To run every package, pass PKG_EXCLUDE='^$' on the command line — that
+  # regex matches only empty lines, so `grep -vE '^$'` keeps everything.
+  DEFAULT_PKG_EXCLUDE: '/controller/ldap$|/core/auth/ldap$|/pkg/ldap$|/core/api$|/core/controllers$|/pkg/proxy/connection$|/pkg/token$|/server/middleware/security$|/server/middleware/blob$|/controller/systeminfo$|/pkg/jobmonitor$|/common/utils/email$|/jobservice/runner$|/jobservice/logger/getter$|/jobservice/job/impl/gc$|/core/session$|/lib/cache/redis$|/controller/usergroup/test$|/pkg/scan/dao/scanner$|/pkg/scan/export$|/pkg/scan/dao/scan$|/pkg/scan/postprocessors$|/pkg/systemartifact$|/pkg/accessory/model/attestation$'
+
 tasks:
   # ============================================================================
   # Linting Tasks
@@ -108,8 +115,12 @@ tasks:
   #     upstream test-ordering / FK-constraint issues
   #   - /pkg/accessory/model/attestation: imports src/testing which has
   #     //go:build db; doesn't compile without -tags db
-  # Override in dev with `task test:unit:pure PKG_EXCLUDE=` to run everything.
-  # Keep this list in sync with any upstream fixes.
+  #
+  # The filter is defined once as DEFAULT_PKG_EXCLUDE at the top of this file.
+  # To run every package in dev, pass a sentinel regex that matches nothing:
+  #     task test:unit:pure PKG_EXCLUDE='^$'
+  # (Passing an empty string does NOT work — slim-sprig `default` treats it as
+  # unset, and `grep -vE ''` would drop every line anyway.)
   # ----------------------------------------------------------------------------
   unit:pure:
     desc: "Run pure unit tests (no DB/Redis needed) with full parallelism"
@@ -118,7 +129,7 @@ tasks:
     env:
       UTTEST: "true"
     vars:
-      PKG_EXCLUDE: '{{.PKG_EXCLUDE | default "/controller/ldap$|/core/auth/ldap$|/pkg/ldap$|/core/api$|/core/controllers$|/pkg/proxy/connection$|/pkg/token$|/server/middleware/security$|/server/middleware/blob$|/controller/systeminfo$|/pkg/jobmonitor$|/common/utils/email$|/jobservice/runner$|/jobservice/logger/getter$|/jobservice/job/impl/gc$|/core/session$|/lib/cache/redis$|/controller/usergroup/test$|/pkg/scan/dao/scanner$|/pkg/scan/export$|/pkg/scan/dao/scan$|/pkg/scan/postprocessors$|/pkg/systemartifact$|/pkg/accessory/model/attestation$"}}'
+      PKG_EXCLUDE: '{{.PKG_EXCLUDE | default .DEFAULT_PKG_EXCLUDE}}'
     cmd: |
       pkgs=$(go list ./... | grep -vE '{{.PKG_EXCLUDE}}' | tr '\n' ' ')
       # shellcheck disable=SC2086
@@ -131,7 +142,7 @@ tasks:
     env:
       UTTEST: "true"
     vars:
-      PKG_EXCLUDE: '{{.PKG_EXCLUDE | default "/controller/ldap$|/core/auth/ldap$|/pkg/ldap$|/core/api$|/core/controllers$|/pkg/proxy/connection$|/pkg/token$|/server/middleware/security$|/server/middleware/blob$|/controller/systeminfo$|/pkg/jobmonitor$|/common/utils/email$|/jobservice/runner$|/jobservice/logger/getter$|/jobservice/job/impl/gc$|/core/session$|/lib/cache/redis$|/controller/usergroup/test$|/pkg/scan/dao/scanner$|/pkg/scan/export$|/pkg/scan/dao/scan$|/pkg/scan/postprocessors$|/pkg/systemartifact$|/pkg/accessory/model/attestation$"}}'
+      PKG_EXCLUDE: '{{.PKG_EXCLUDE | default .DEFAULT_PKG_EXCLUDE}}'
     cmd: |
       pkgs=$(go list -tags db ./... | grep -vE '{{.PKG_EXCLUDE}}' | tr '\n' ' ')
       # shellcheck disable=SC2086


### PR DESCRIPTION
## Summary

Follow-up to #126. The host-cache/shared-DinD/taskfile-proxy overhaul in #126 shipped a green `Build` workflow but broke the `Test` workflow in three separate ways. This PR resolves all three.

### 1. CI-hostile package exclusion list was silently dropped

Before #126, `test.yml` ran a grep-filtered `go list ./...` that excluded ~19 packages with known issues (LDAP server deps, external SMTP calls, hardcoded `127.0.0.1:6379`, missing `/etc/core/` certs, ordering bugs). The list had accumulated over `8e351841a`, `f2acb4ecb`, `d6d38cd78`, `347ecf4a8`, `f5ba6f77e`.

#126 replaced the inlined `go test` command with `task test:unit:pure` and forgot to carry the filter. Result: all 19 packages re-entered the run and the `test-unit` job failed at the first one.

**Fix:** Restore the filter at the taskfile level as `DEFAULT_PKG_EXCLUDE` — defined once in the top-level `vars:` block of `taskfile/test.yml`, referenced from both `unit:pure` and `unit:db` via `{{.PKG_EXCLUDE | default .DEFAULT_PKG_EXCLUDE}}`. Each excluded package is documented with its reason in a comment block. Dev override: `task test:unit:pure PKG_EXCLUDE='^$'` (the sentinel regex that matches only empty lines).

### 2. Harbor Redis URL env vars weren't exported for `test-db`

Harbor's `libredis.GetRegistryClient()` / `GetHarborClient()` read `_REDIS_URL_REG`, `_REDIS_URL_CORE`, `_REDIS_URL_HARBOR`. The original GitHub Actions `services:` block (in #126's predecessor) made these implicitly work through the default service networking. After #126 switched to manual `docker run`, nothing was exporting them.

**Fix:** Export all four Redis URLs (plus `REDIS_HOST`/`REDIS_PORT`) from the "Start test services" step.

### 3. Several upstream tests hardcode `redis://localhost:6379`

Even after fixing #2, three packages still failed because they don't read any env var — they hardcode `localhost:6379` in their test source:

- `src/pkg/task/dao/execution_test.go:50` — `cache.Initialize(cache.Redis, "redis://localhost:6379/0")`
- `src/jobservice/config/config_test.go:98` — asserts literal `"redis://localhost:6379"`
- `src/jobservice/tests/utils.go:39` — `testingRedisPort = 6379` (ignores `REDIS_PORT` env)

**Fix:** Install `redis-server` on the runner pod itself and start it on `localhost:6379`. Redis is ~10 MB and installs in a few seconds via `apt-get`. Postgres stays in DinD with a random host port because no test hardcodes localhost for Postgres; they all respect `POSTGRESQL_HOST`.

This also eliminates the cross-PR port-6379 collision risk that a pinned-port DinD Redis would have introduced.

## Measured results

| Job | Runtime | Result |
|---|---|---|
| Unit Tests (pure) | 533s (~9 min) | ✅ |
| Unit Tests (DB)  | 1286s (~21 min) | ✅ |

CI verification run: https://github.com/container-registry/harbor-next/actions/runs/24371273406

## Related

- Follow-up to #126
- Preserves the "workflows are thin proxies over taskfile" invariant from #126

## Type of Change
- [x] CI/CD or build changes (`ci:` / `build:`)
- [x] Tests (`test:`)

## Testing
- [x] Full CI passes (both pure and DB jobs green)
- [x] Local dev path unchanged: `task test:unit:pure` / `task test:unit:db` work as before
- [x] Dev override documented: `task test:unit:pure PKG_EXCLUDE='^$'` runs every package

## Checklist
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] Commits are signed off (`git commit -s`)
- [x] No new warnings introduced