### PR TITLE
chore(devenv): Share single dev image and use host Go caches

### DIFF
--- a/devenv/docker-compose.yml
+++ b/devenv/docker-compose.yml
@@ -49,6 +49,7 @@ services:
 
   # Core API - starts with: docker compose --profile core up
   core:
+    image: harbor-dev-go
     build:
       context: ..
       dockerfile: dockerfile/dev.core.dockerfile
@@ -59,8 +60,8 @@ services:
     profiles: [core]
     volumes:
       - ..:/app
-      - go-mod-cache:/go/pkg/mod
-      - go-build-cache:/root/.cache/go-build
+      - ${HOST_GOMODCACHE:?}:/go/pkg/mod
+      - ${HOST_GOCACHE:?}:/root/.cache/go-build
       # Mount views directly to where beego expects them (avoids symlink leaking to host)
       - ../src/core/views:/app/views:ro
     ports:
@@ -115,18 +116,12 @@ services:
 
   # JobService - starts with: docker compose --profile jobservice up
   jobservice:
-    build:
-      context: ..
-      dockerfile: dockerfile/dev.core.dockerfile
-      args:
-        GO_VERSION: ${GO_VERSION}
-        AIR_VERSION: ${AIR_VERSION}
-        DELVE_VERSION: ${DELVE_VERSION}
+    image: harbor-dev-go
     profiles: [jobservice]
     volumes:
       - ..:/app
-      - go-mod-cache:/go/pkg/mod
-      - go-build-cache:/root/.cache/go-build
+      - ${HOST_GOMODCACHE:?}:/go/pkg/mod
+      - ${HOST_GOCACHE:?}:/root/.cache/go-build
     # ports:
     #   - "8888:8888"  # JobService API (uncomment if needed)
     #   - "127.0.0.1:2346:2346"  # Debug port (uncomment if needed)
@@ -157,18 +152,12 @@ services:
 
   # RegistryCtl - starts with: docker compose --profile registryctl up
   registryctl:
-    build:
-      context: ..
-      dockerfile: dockerfile/dev.core.dockerfile
-      args:
-        GO_VERSION: ${GO_VERSION}
-        AIR_VERSION: ${AIR_VERSION}
-        DELVE_VERSION: ${DELVE_VERSION}
+    image: harbor-dev-go
     profiles: [registryctl]
     volumes:
       - ..:/app
-      - go-mod-cache:/go/pkg/mod
-      - go-build-cache:/root/.cache/go-build
+      - ${HOST_GOMODCACHE:?}:/go/pkg/mod
+      - ${HOST_GOCACHE:?}:/root/.cache/go-build
       - harbor-registry-data:/var/lib/registry
       - ../config/registry.yml:/etc/registry/config.yml:ro
     ports:
@@ -220,6 +209,7 @@ services:
 
   # Portal (Angular UI) - starts with: docker compose --profile portal up
   portal:
+    image: harbor-dev-portal
     build:
       context: ..
       dockerfile: dockerfile/dev.portal.dockerfile
@@ -239,7 +229,7 @@ services:
       - ../src/portal/app-swagger-ui/index.html:/swagger-ui/index.html:ro
       - ../src/portal/app-swagger-ui/favicon.ico:/swagger-ui/favicon.ico:ro
       - ../src/portal/app-swagger-ui/webpack.config.js:/swagger-ui/webpack.config.js:ro
-      - portal-angular-cache:/app/.angular
+      - ../src/portal/.angular:/app/.angular
       - portal-openapi-ui:/app/src/openapi-ui
     ports:
       - "${PORT_PORTAL:-4200}:4200"
@@ -255,11 +245,5 @@ volumes:
     name: ${PROJECT_PREFIX:-harbor}-redis-data
   harbor-registry-data:
     name: ${PROJECT_PREFIX:-harbor}-registry-data
-  go-mod-cache:
-    name: ${PROJECT_PREFIX:-harbor}-go-mod-cache
-  go-build-cache:
-    name: ${PROJECT_PREFIX:-harbor}-go-build-cache
-  portal-angular-cache:
-    name: ${PROJECT_PREFIX:-harbor}-portal-angular-cache
   portal-openapi-ui:
     name: ${PROJECT_PREFIX:-harbor}-portal-openapi-ui

--- a/dockerfile/dev.core.dockerfile
+++ b/dockerfile/dev.core.dockerfile
@@ -7,16 +7,12 @@ FROM golang:${GO_VERSION}-alpine
 ARG AIR_VERSION
 ARG DELVE_VERSION
 
-# Install git (required for go mod download) and other tools
+# Install git (required by go modules)
 RUN apk add --no-cache git
 
 # Install development tools
 RUN go install github.com/air-verse/air@${AIR_VERSION} && \
     go install github.com/go-delve/delve/cmd/dlv@${DELVE_VERSION}
-
-# Pre-download Go modules (seeds go-mod-cache volume on first create)
-COPY src/go.mod src/go.sum /tmp/harbor-deps/
-RUN cd /tmp/harbor-deps && go mod download && rm -rf /tmp/harbor-deps
 
 WORKDIR /app
 

--- a/taskfile/dev.yml
+++ b/taskfile/dev.yml
@@ -39,6 +39,10 @@ vars:
 env:
   COMPOSE_PROJECT_NAME:   '{{.PROJECT_PREFIX}}'
   PROJECT_PREFIX:         '{{.PROJECT_PREFIX}}'
+  HOST_GOMODCACHE:
+    sh: go env GOMODCACHE
+  HOST_GOCACHE:
+    sh: go env GOCACHE
   PORT_CORE:              '{{.PORT_CORE}}'
   PORT_PORTAL:            '{{.PORT_PORTAL}}'
   PORT_POSTGRES:          '{{.PORT_POSTGRES}}'
@@ -120,6 +124,14 @@ tasks:
     deps:
       - :build:gen-apis
       - _frontend-codegen
+      - _warm-caches
+
+  _warm-caches:
+    internal: true
+    cmds:
+      - mkdir -p src/portal/.angular
+      - cmd: cd src && go mod download
+        silent: true
 
   _frontend-codegen:
     internal: true
@@ -133,8 +145,8 @@ tasks:
     vars:
       TRIVY_PROFILE: '{{if ne .SKIP_TRIVY "true"}}--profile trivy{{end}}'
     cmds:
-      - task: _codegen
       - defer: { task: dev:down, vars: { SKIP_TRIVY: "{{.SKIP_TRIVY}}" } }
+      - task: _codegen
       - task: info
       - '{{.COMPOSE_CMD}} {{.APP_PROFILES}} {{.TRIVY_PROFILE}} up --build'
 


### PR DESCRIPTION
## Summary
- **Share a single dev image** across core, jobservice, and registryctl instead of building three identical copies from the same Dockerfile
- **Mount host Go caches** (`GOMODCACHE`, `GOCACHE`) directly into containers, eliminating Docker-volume cold starts and reusing the developer's existing module/build cache
- **Remove `go mod download` from Dockerfile** — modules are already present via the host cache mount
- **Warm host caches in parallel** with codegen (`go mod download` + Angular cache dir) before `docker compose up`

## Related Issues
<!-- N/A -->

## Type of Change
- [ ] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` / `fix!:`)
- [ ] Documentation (`docs:`)
- [x] Refactoring (`refactor:`)
- [ ] CI/CD or build changes (`ci:` / `build:`)
- [ ] Dependencies update (`chore:`)
- [ ] Tests (`test:`)

## Release Notes
<!-- Dev-only change, no user-facing impact -->

## Testing
- [ ] Unit tests added/updated
- [x] Manual testing performed

## Checklist
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] Commits are signed off (`git commit -s`)
- [x] No new warnings introduced