### PR TITLE
perf(ci): speed up unit test pipeline

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,6 +30,7 @@ jobs:
     runs-on: ${{ (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository || contains(fromJSON('["OWNER","MEMBER"]'), github.event.pull_request.author_association)) && vars.RUNNER || 'ubuntu-latest' }}
     env:
       CGO_ENABLED: "1"
+      RACE_FLAGS: ${{ github.event_name == 'push' && '-race' || '' }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
@@ -44,13 +45,14 @@ jobs:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Ensure C toolchain for race detector
+        if: env.RACE_FLAGS != ''
         run: |
           if ! echo '#include <stdlib.h>' | gcc -E -x c - >/dev/null 2>&1; then
             sudo apt-get update && sudo apt-get install -y --no-install-recommends gcc libc6-dev
           fi
 
       - name: Run pure unit tests
-        run: task test:unit:pure COVER_FLAGS=-cover TEST_FLAGS=-count=1
+        run: task test:unit:pure RACE_FLAGS="${RACE_FLAGS}" TEST_FLAGS=-count=1
 
   # --------------------------------------------------------------------------
   # DB-dependent unit tests — need PostgreSQL + Redis, run serially
@@ -64,6 +66,7 @@ jobs:
       POSTGRESQL_DATABASE: registry
       POSTGRES_MIGRATION_SCRIPTS_PATH: ${{ github.workspace }}/make/migrations/postgresql
       CGO_ENABLED: "1"
+      RACE_FLAGS: ${{ github.event_name == 'push' && '-race' || '' }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
@@ -129,13 +132,14 @@ jobs:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Ensure C toolchain for race detector
+        if: env.RACE_FLAGS != ''
         run: |
           if ! echo '#include <stdlib.h>' | gcc -E -x c - >/dev/null 2>&1; then
             sudo apt-get update && sudo apt-get install -y --no-install-recommends gcc libc6-dev
           fi
 
       - name: Run DB unit tests
-        run: task test:unit:db COVER_FLAGS=-cover TEST_FLAGS=-count=1
+        run: task test:unit:db RACE_FLAGS="${RACE_FLAGS}" TEST_FLAGS=-count=1
 
       - name: Stop test services
         if: always()

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,7 +30,7 @@ jobs:
     runs-on: ${{ (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository || contains(fromJSON('["OWNER","MEMBER"]'), github.event.pull_request.author_association)) && vars.RUNNER || 'ubuntu-latest' }}
     env:
       CGO_ENABLED: "1"
-      RACE_FLAGS: ${{ github.event_name == 'push' && '-race' || '' }}
+      RACE_FLAGS: -race
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
@@ -58,15 +58,25 @@ jobs:
   # DB-dependent unit tests — need PostgreSQL + Redis, run serially
   # --------------------------------------------------------------------------
   test-db:
-    name: Unit Tests (DB)
+    name: Unit Tests (DB ${{ matrix.shard_name }})
     runs-on: ${{ (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository || contains(fromJSON('["OWNER","MEMBER"]'), github.event.pull_request.author_association)) && vars.RUNNER || 'ubuntu-latest' }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - shard_index: 0
+            shard_total: 2
+            shard_name: 1/2
+          - shard_index: 1
+            shard_total: 2
+            shard_name: 2/2
     env:
       POSTGRESQL_USR: postgres
       POSTGRESQL_PWD: root123
       POSTGRESQL_DATABASE: registry
       POSTGRES_MIGRATION_SCRIPTS_PATH: ${{ github.workspace }}/make/migrations/postgresql
       CGO_ENABLED: "1"
-      RACE_FLAGS: ${{ github.event_name == 'push' && '-race' || '' }}
+      RACE_FLAGS: -race
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
@@ -139,7 +149,7 @@ jobs:
           fi
 
       - name: Run DB unit tests
-        run: task test:unit:db RACE_FLAGS="${RACE_FLAGS}" TEST_FLAGS=-count=1
+        run: task test:unit:db RACE_FLAGS="${RACE_FLAGS}" TEST_FLAGS=-count=1 SHARD_INDEX=${{ matrix.shard_index }} SHARD_TOTAL=${{ matrix.shard_total }}
 
       - name: Stop test services
         if: always()

--- a/README.md
+++ b/README.md
@@ -108,8 +108,9 @@ task setup               # Install development tools (air, dlv, govulncheck)
 task build               # Build all binaries (alias: task b:all-binaries)
 task images              # Build all Docker images
 task test                # Run all tests (alias: task t:all)
-task test:lint           # Run linters
-task test:unit           # Run unit tests only
+task lint                # Run API lint, Go lint, and vuln-check
+task test:unit:pure      # Run pure unit tests only
+task test:unit:db        # Run DB-backed unit tests only
 task clean               # Clean build artifacts
 task info                # Show build info and tool versions
 task -l                  # List all available tasks

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -69,6 +69,23 @@ tasks:
     cmds:
       - task: test:all
 
+  lint:
+    desc: "Run API lint, Go lint, and dependency vulnerability checks"
+    cmds:
+      - task: test:lint:api
+      - task: test:lint
+      - task: test:vuln-check
+
+  lint:api:
+    desc: "Run API lint"
+    cmds:
+      - task: test:lint:api
+
+  vuln-check:
+    desc: "Run Go dependency vulnerability checks"
+    cmds:
+      - task: test:vuln-check
+
   images:
     desc: "Build all container images (PUSH=false for local, PLATFORMS=linux/arm64 for single arch)"
     cmds:

--- a/src/controller/proxy/controller.go
+++ b/src/controller/proxy/controller.go
@@ -39,15 +39,15 @@ import (
 )
 
 const (
-	// wait more time than manifest (maxManifestWait) because manifest list depends on manifest ready
-	maxManifestListWait = 20
-	maxManifestWait     = 10
-	sleepIntervalSec    = 20
 	// keep manifest list in cache for one week
 	manifestListCacheInterval = 7 * 24 * 60 * 60 * time.Second
 )
 
 var (
+	// wait more time than manifest (maxManifestWait) because manifest list depends on manifest ready
+	maxManifestListWait = 20
+	maxManifestWait     = 10
+	sleepIntervalSec    = 20
 	// Ctl is a global proxy controller instance
 	ctl  Controller
 	once sync.Once

--- a/src/controller/proxy/manifestcache.go
+++ b/src/controller/proxy/manifestcache.go
@@ -133,7 +133,7 @@ func (m *ManifestListCache) push(ctx context.Context, repo, reference string, ma
 	var err error
 	for range maxManifestListWait {
 		log.Debugf("waiting for the manifest ready, repo %v, tag:%v", repo, reference)
-		time.Sleep(sleepIntervalSec * time.Second)
+		time.Sleep(time.Duration(sleepIntervalSec) * time.Second)
 		newMan, err = m.updateManifestList(ctx, repo, man)
 		if err != nil {
 			return err
@@ -194,7 +194,7 @@ type ManifestCache struct {
 func (m *ManifestCache) CacheContent(ctx context.Context, remoteRepo string, man distribution.Manifest, art lib.ArtifactInfo, r RemoteInterface, _ string) {
 	var waitBlobs []distribution.Descriptor
 	for n := range maxManifestWait {
-		time.Sleep(sleepIntervalSec * time.Second)
+		time.Sleep(time.Duration(sleepIntervalSec) * time.Second)
 		waitBlobs = m.local.CheckDependencies(ctx, art.Repository, man)
 		if len(waitBlobs) == 0 {
 			break

--- a/src/controller/proxy/manifestcache_test.go
+++ b/src/controller/proxy/manifestcache_test.go
@@ -58,15 +58,27 @@ type CacheTestSuite struct {
 	mCache     *ManifestCache
 	mListCache *ManifestListCache
 	local      localInterfaceMock
+	oldListWait int
+	oldWait     int
+	oldSleepSec int
 }
 
 func (suite *CacheTestSuite) SetupSuite() {
 	suite.local = localInterfaceMock{}
 	suite.mListCache = &ManifestListCache{local: &suite.local}
 	suite.mCache = &ManifestCache{local: &suite.local}
+	suite.oldListWait = maxManifestListWait
+	suite.oldWait = maxManifestWait
+	suite.oldSleepSec = sleepIntervalSec
+	maxManifestListWait = 1
+	maxManifestWait = 1
+	sleepIntervalSec = 0
 }
 
 func (suite *CacheTestSuite) TearDownSuite() {
+	maxManifestListWait = suite.oldListWait
+	maxManifestWait = suite.oldWait
+	sleepIntervalSec = suite.oldSleepSec
 }
 func (suite *CacheTestSuite) TestUpdateManifestList() {
 	ctx := context.Background()

--- a/src/lib/cache/redis/redis_test.go
+++ b/src/lib/cache/redis/redis_test.go
@@ -25,6 +25,13 @@ import (
 	"github.com/goharbor/harbor/src/lib/cache"
 )
 
+const (
+	defaultExpiration    = 200 * time.Millisecond
+	defaultWaitForExpiry = 400 * time.Millisecond
+	customExpiration     = 100 * time.Millisecond
+	customWaitForExpiry  = 200 * time.Millisecond
+)
+
 type CacheTestSuite struct {
 	suite.Suite
 	cache cache.Cache
@@ -32,7 +39,7 @@ type CacheTestSuite struct {
 }
 
 func (suite *CacheTestSuite) SetupSuite() {
-	suite.cache, _ = cache.New("redis", cache.Expiration(time.Second*5))
+	suite.cache, _ = cache.New("redis", cache.Expiration(defaultExpiration))
 	suite.ctx = context.TODO()
 }
 
@@ -46,10 +53,10 @@ func (suite *CacheTestSuite) TestContains() {
 	suite.cache.Delete(suite.ctx, key)
 	suite.False(suite.cache.Contains(suite.ctx, key))
 
-	suite.cache.Save(suite.ctx, key, "value", time.Second*5)
+	suite.cache.Save(suite.ctx, key, "value", defaultExpiration)
 	suite.True(suite.cache.Contains(suite.ctx, key))
 
-	time.Sleep(time.Second * 8)
+	time.Sleep(defaultWaitForExpiry)
 	suite.False(suite.cache.Contains(suite.ctx, key))
 }
 
@@ -88,7 +95,7 @@ func (suite *CacheTestSuite) TestSave() {
 		suite.cache.Fetch(suite.ctx, key, &value)
 		suite.Equal("hello, save", value)
 
-		time.Sleep(time.Second * 8)
+		time.Sleep(defaultWaitForExpiry)
 
 		value = ""
 		suite.Error(suite.cache.Fetch(suite.ctx, key, &value))
@@ -96,9 +103,9 @@ func (suite *CacheTestSuite) TestSave() {
 	}
 
 	{
-		suite.cache.Save(suite.ctx, key, "hello, save", time.Second)
+		suite.cache.Save(suite.ctx, key, "hello, save", customExpiration)
 
-		time.Sleep(time.Second * 2)
+		time.Sleep(customWaitForExpiry)
 
 		var value string
 		suite.Error(suite.cache.Fetch(suite.ctx, key, &value))

--- a/src/lib/retry/retry_test.go
+++ b/src/lib/retry/retry_test.go
@@ -35,13 +35,17 @@ func TestAbort(t *testing.T) {
 func TestRetry(t *testing.T) {
 	assert := assert.New(t)
 
+	initialInterval := 5 * time.Millisecond
+	maxInterval := 5 * time.Millisecond
+	timeout := 25 * time.Millisecond
+
 	i := 0
 	f1 := func() error {
 		i++
 		return fmt.Errorf("failed")
 	}
-	assert.Error(Retry(f1, InitialInterval(time.Second), MaxInterval(time.Second), Timeout(time.Second*5)))
-	// f1 called time     0s - sleep - 1s - sleep - 2s - sleep - 3s - sleep - 4s - sleep - 5s
+	assert.Error(Retry(f1, InitialInterval(initialInterval), MaxInterval(maxInterval), Timeout(timeout)))
+	// f1 called time     0ms - sleep - 5ms - sleep - 10ms - sleep - 15ms - sleep - 20ms - sleep - 25ms
 	// i after f1 called  1            2            3            4            5            6
 	// the i may be 5 or 6 depend on timeout or default which is selected by the select statement
 	assert.LessOrEqual(i, 6)
@@ -66,7 +70,9 @@ func TestRetry(t *testing.T) {
 
 	Retry(
 		f1,
-		Timeout(time.Second*5),
+		InitialInterval(initialInterval),
+		MaxInterval(maxInterval),
+		Timeout(timeout),
 		Callback(func(err error, sleep time.Duration) {
 			fmt.Printf("failed to exec f1 retry after %s : %v\n", sleep, err)
 		}),
@@ -74,7 +80,7 @@ func TestRetry(t *testing.T) {
 
 	err := Retry(func() error {
 		return fmt.Errorf("always failed")
-	})
+	}, InitialInterval(initialInterval), MaxInterval(maxInterval), Timeout(timeout))
 
 	assert.Error(err)
 	assert.Equal("retry timeout: always failed", err.Error())
@@ -88,6 +94,6 @@ func TestRetry(t *testing.T) {
 		i++
 		return fmt.Errorf("error")
 	}
-	assert.Error(Retry(f4, InitialInterval(time.Second), MaxInterval(time.Second), Timeout(time.Second*5)))
+	assert.Error(Retry(f4, InitialInterval(initialInterval), MaxInterval(maxInterval), Timeout(timeout)))
 	assert.LessOrEqual(i, 3)
 }

--- a/src/pkg/accessory/model/attestation/attestation_test.go
+++ b/src/pkg/accessory/model/attestation/attestation_test.go
@@ -7,19 +7,18 @@ import (
 	"github.com/stretchr/testify/suite"
 
 	"github.com/goharbor/harbor/src/pkg/accessory/model"
-	htesting "github.com/goharbor/harbor/src/testing"
 )
 
 type AttestationTestSuite struct {
-	htesting.Suite
+	suite.Suite
 	accessory model.Accessory
 	digest    string
 	subDigest string
 }
 
 func (suite *AttestationTestSuite) SetupSuite() {
-	suite.digest = suite.DigestString()
-	suite.subDigest = suite.DigestString()
+	suite.digest = "sha256:1111111111111111111111111111111111111111111111111111111111111111"
+	suite.subDigest = "sha256:2222222222222222222222222222222222222222222222222222222222222222"
 	suite.accessory, _ = model.New(model.TypeInTotoAttestation, model.AccessoryData{
 		ArtifactID:        1,
 		SubArtifactDigest: suite.subDigest,

--- a/src/pkg/token/token_test.go
+++ b/src/pkg/token/token_test.go
@@ -2,6 +2,7 @@ package token
 
 import (
 	"os"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -14,6 +15,9 @@ import (
 )
 
 func TestMain(m *testing.M) {
+	if err := os.Setenv("TOKEN_PRIVATE_KEY_PATH", filepath.Clean("../../../tests/private_key.pem")); err != nil {
+		os.Exit(1)
+	}
 	config.Init()
 
 	result := m.Run()

--- a/taskfile/test.yml
+++ b/taskfile/test.yml
@@ -78,21 +78,19 @@ tasks:
   # Unit Tests
   # ============================================================================
 
-  unit:
-    desc: "Run Go unit tests with race detection"
-    dir: src
-    env:
-      UTTEST: "true"
-    cmd: go test -v -race -cover ./...
+  _prepare-go-tests:
+    internal: true
+    cmds:
+      - task: build:gen-apis
 
   unit:coverage:
-    desc: "Run Go unit tests and generate HTML coverage report"
-    dir: src
-    env:
-      UTTEST: "true"
+    desc: "Run pure unit tests and generate HTML coverage report"
     cmds:
-      - go test -v -race -coverprofile=coverage.out -covermode=atomic ./...
-      - go tool cover -html=coverage.out -o coverage.html
+      - task: unit:pure
+        vars:
+          RACE_FLAGS: "-race"
+          COVER_FLAGS: "-coverprofile=coverage.out -covermode=atomic"
+      - cmd: cd src && go tool cover -html=coverage.out -o coverage.html
 
   # ----------------------------------------------------------------------------
   # CI-hostile packages excluded from unit:pure / unit:db (default filter).
@@ -124,29 +122,51 @@ tasks:
   # ----------------------------------------------------------------------------
   unit:pure:
     desc: "Run pure unit tests (no DB/Redis needed) with full parallelism"
-    deps: [build:gen-apis]
-    dir: src
-    env:
-      UTTEST: "true"
-    vars:
-      PKG_EXCLUDE: '{{.PKG_EXCLUDE | default .DEFAULT_PKG_EXCLUDE}}'
-    cmd: |
-      pkgs=$(go list ./... | grep -vE '{{.PKG_EXCLUDE}}' | tr '\n' ' ')
-      # shellcheck disable=SC2086
-      go test -race -timeout=15m {{.COVER_FLAGS}} {{.TEST_FLAGS}} $pkgs
+    cmds:
+      - task: _prepare-go-tests
+      - cmd: |
+          cd src
+          pkgs=$(../tools/ci/list-go-test-packages.sh pure '{{.PKG_EXCLUDE | default .DEFAULT_PKG_EXCLUDE}}' | tr '\n' ' ')
+          if [ -z "$pkgs" ]; then
+            echo "no pure test packages matched"
+            exit 1
+          fi
+          # shellcheck disable=SC2086
+          UTTEST=true go test {{.RACE_FLAGS | default ""}} -timeout=15m {{.COVER_FLAGS}} {{.TEST_FLAGS}} $pkgs
 
   unit:db:
     desc: "Run DB-dependent unit tests serially (needs PostgreSQL + Redis)"
-    deps: [build:gen-apis]
-    dir: src
-    env:
-      UTTEST: "true"
-    vars:
-      PKG_EXCLUDE: '{{.PKG_EXCLUDE | default .DEFAULT_PKG_EXCLUDE}}'
-    cmd: |
-      pkgs=$(go list -tags db ./... | grep -vE '{{.PKG_EXCLUDE}}' | tr '\n' ' ')
-      # shellcheck disable=SC2086
-      go test -race -timeout=15m -tags db -p 1 -parallel 1 {{.COVER_FLAGS}} {{.TEST_FLAGS}} $pkgs
+    cmds:
+      - task: _prepare-go-tests
+      - cmd: |
+          cd src
+          pkgs=$(../tools/ci/list-go-test-packages.sh db-tagged '{{.PKG_EXCLUDE | default .DEFAULT_PKG_EXCLUDE}}' | tr '\n' ' ')
+          if [ -z "$pkgs" ]; then
+            echo "no db-tagged test packages matched"
+            exit 1
+          fi
+          # shellcheck disable=SC2086
+          UTTEST=true go test {{.RACE_FLAGS | default ""}} -timeout=15m -tags db -p 1 -parallel 1 {{.COVER_FLAGS}} {{.TEST_FLAGS}} $pkgs
+
+  unit:
+    desc: "Alias for pure unit tests"
+    cmds:
+      - task: unit:pure
+        vars:
+          PKG_EXCLUDE: '{{.PKG_EXCLUDE}}'
+          RACE_FLAGS: '{{.RACE_FLAGS}}'
+          COVER_FLAGS: '{{.COVER_FLAGS}}'
+          TEST_FLAGS: '{{.TEST_FLAGS}}'
+
+  db:
+    desc: "Alias for DB unit tests"
+    cmds:
+      - task: unit:db
+        vars:
+          PKG_EXCLUDE: '{{.PKG_EXCLUDE}}'
+          RACE_FLAGS: '{{.RACE_FLAGS}}'
+          COVER_FLAGS: '{{.COVER_FLAGS}}'
+          TEST_FLAGS: '{{.TEST_FLAGS}}'
 
   unit:watch:
     desc: "Re-run Go unit tests on file changes (requires watchexec)"
@@ -218,12 +238,10 @@ tasks:
   # ============================================================================
 
   all:
-    desc: "Run all linters, vulnerability scan, and unit tests"
+    desc: "Run pure unit tests and DB tests"
     cmds:
-      - task: lint:api
-      - task: lint
-      - task: vuln-check
-      - task: unit
+      - task: unit:pure
+      - task: unit:db
 
   ci:
     desc: "Run full CI pipeline with reports (lint, vuln scan, split unit tests)"
@@ -240,7 +258,6 @@ tasks:
 
   _ci-tests:
     internal: true
-    deps: [build:gen-apis]
     cmds:
       - task: unit:pure
         vars:
@@ -268,7 +285,7 @@ tasks:
     desc: "Run API lint and unit tests only (fast validation)"
     cmds:
       - task: lint:api
-      - task: unit
+      - task: unit:pure
 
   # ============================================================================
   # Utilities

--- a/taskfile/test.yml
+++ b/taskfile/test.yml
@@ -12,10 +12,10 @@ includes:
 vars:
   # Packages we still exclude from CI by default because they need external
   # services or a full Harbor stack we do not provision in unit-test jobs.
-  DEFAULT_DB_EXCLUDE: '/controller/ldap$|/core/auth/ldap$|/pkg/ldap$|/core/api$|/core/controllers$|/server/middleware/security$|/controller/systeminfo$|/common/utils/email$|/jobservice/runner$|/jobservice/logger/getter$|/controller/usergroup/test$|/pkg/scan/dao/scan$|/pkg/scan/postprocessors$|/pkg/systemartifact$'
+  DEFAULT_DB_EXCLUDE: '/controller/ldap$|/core/auth/ldap$|/pkg/ldap$|/core/api$|/core/controllers$|/server/middleware/security$|/controller/systeminfo$|/common/utils/email$|/jobservice/runner$|/jobservice/logger/getter$|/jobservice/logger/backend$|/jobservice/logger/sweeper$|/controller/usergroup/test$|/pkg/exporter$|/pkg/scan/dao/scan$|/pkg/scan/postprocessors$|/pkg/systemartifact$'
   # Packages excluded from the pure lane because they require Redis/Postgres
   # setup or have db-tagged tests that should only run in the DB lane.
-  DEFAULT_PURE_EXCLUDE: '/controller/ldap$|/core/auth/ldap$|/pkg/ldap$|/core/api$|/core/controllers$|/server/middleware/security$|/controller/systeminfo$|/common/utils/email$|/jobservice/runner$|/jobservice/logger/getter$|/controller/usergroup/test$|/pkg/scan/dao/scan$|/pkg/scan/postprocessors$|/pkg/systemartifact$|/core/session$|/jobservice/job/impl/gc$|/lib/cache/redis$|/pkg/jobmonitor$|/pkg/proxy/connection$|/pkg/scan/dao/scanner$|/pkg/scan/export$|/server/middleware/blob$'
+  DEFAULT_PURE_EXCLUDE: '/controller/ldap$|/core/auth/ldap$|/pkg/ldap$|/core/api$|/core/controllers$|/server/middleware/security$|/controller/systeminfo$|/common/utils/email$|/jobservice/runner$|/jobservice/logger/getter$|/jobservice/logger/backend$|/jobservice/logger/sweeper$|/controller/usergroup/test$|/pkg/exporter$|/pkg/scan/dao/scan$|/pkg/scan/postprocessors$|/pkg/systemartifact$|/core/session$|/jobservice/job/impl/gc$|/lib/cache/redis$|/pkg/jobmonitor$|/pkg/proxy/connection$|/pkg/scan/dao/scanner$|/pkg/scan/export$|/server/middleware/blob$'
   # These packages need Redis/Postgres-backed test setup but do not use
   # //go:build db test files, so we add them explicitly to the DB lane.
   DEFAULT_DB_EXTRA_PACKAGES: 'github.com/goharbor/harbor/src/core/session github.com/goharbor/harbor/src/jobservice/job/impl/gc github.com/goharbor/harbor/src/lib/cache/redis github.com/goharbor/harbor/src/pkg/jobmonitor github.com/goharbor/harbor/src/pkg/proxy/connection'

--- a/taskfile/test.yml
+++ b/taskfile/test.yml
@@ -10,11 +10,15 @@ includes:
     internal: true
 
 vars:
-  # Single source of truth for the unit:pure / unit:db package exclusion
-  # filter. See the comment block above `unit:pure` for per-package rationale.
-  # To run every package, pass PKG_EXCLUDE='^$' on the command line — that
-  # regex matches only empty lines, so `grep -vE '^$'` keeps everything.
-  DEFAULT_PKG_EXCLUDE: '/controller/ldap$|/core/auth/ldap$|/pkg/ldap$|/core/api$|/core/controllers$|/pkg/proxy/connection$|/pkg/token$|/server/middleware/security$|/server/middleware/blob$|/controller/systeminfo$|/pkg/jobmonitor$|/common/utils/email$|/jobservice/runner$|/jobservice/logger/getter$|/jobservice/job/impl/gc$|/core/session$|/lib/cache/redis$|/controller/usergroup/test$|/pkg/scan/dao/scanner$|/pkg/scan/export$|/pkg/scan/dao/scan$|/pkg/scan/postprocessors$|/pkg/systemartifact$|/pkg/accessory/model/attestation$'
+  # Packages we still exclude from CI by default because they need external
+  # services or a full Harbor stack we do not provision in unit-test jobs.
+  DEFAULT_DB_EXCLUDE: '/controller/ldap$|/core/auth/ldap$|/pkg/ldap$|/core/api$|/core/controllers$|/server/middleware/security$|/controller/systeminfo$|/common/utils/email$|/jobservice/runner$|/jobservice/logger/getter$|/controller/usergroup/test$|/pkg/scan/dao/scan$|/pkg/scan/postprocessors$|/pkg/systemartifact$'
+  # Packages excluded from the pure lane because they require Redis/Postgres
+  # setup or have db-tagged tests that should only run in the DB lane.
+  DEFAULT_PURE_EXCLUDE: '/controller/ldap$|/core/auth/ldap$|/pkg/ldap$|/core/api$|/core/controllers$|/server/middleware/security$|/controller/systeminfo$|/common/utils/email$|/jobservice/runner$|/jobservice/logger/getter$|/controller/usergroup/test$|/pkg/scan/dao/scan$|/pkg/scan/postprocessors$|/pkg/systemartifact$|/core/session$|/jobservice/job/impl/gc$|/lib/cache/redis$|/pkg/jobmonitor$|/pkg/proxy/connection$|/pkg/scan/dao/scanner$|/pkg/scan/export$|/server/middleware/blob$'
+  # These packages need Redis/Postgres-backed test setup but do not use
+  # //go:build db test files, so we add them explicitly to the DB lane.
+  DEFAULT_DB_EXTRA_PACKAGES: 'github.com/goharbor/harbor/src/core/session github.com/goharbor/harbor/src/jobservice/job/impl/gc github.com/goharbor/harbor/src/lib/cache/redis github.com/goharbor/harbor/src/pkg/jobmonitor github.com/goharbor/harbor/src/pkg/proxy/connection'
 
 tasks:
   # ============================================================================
@@ -93,30 +97,25 @@ tasks:
       - cmd: cd src && go tool cover -html=coverage.out -o coverage.html
 
   # ----------------------------------------------------------------------------
-  # CI-hostile packages excluded from unit:pure / unit:db (default filter).
+  # CI-hostile packages excluded from the DB lane by default.
   # Each entry is here because:
   #   - LDAP packages (/controller/ldap, /core/auth/ldap, /pkg/ldap): need LDAP
   #     server we don't provision
-  #   - /core/api, /core/controllers, /pkg/proxy/connection: need full Harbor stack
-  #   - /pkg/token, /server/middleware/security, /controller/systeminfo: need
-  #     /etc/core/ cert files
-  #   - /pkg/jobmonitor: needs REDIS_HOST env var with specific format
+  #   - /core/api, /core/controllers: need full Harbor stack
+  #   - /server/middleware/security, /controller/systeminfo: need /etc/core/
+  #     cert files
   #   - /common/utils/email: reaches external SMTP (smtp.gmail.com) from tests
   #   - /jobservice/runner: Redis job tracker state ordering issues
   #   - /jobservice/logger/getter: DB state ordering when packages run in parallel
-  #   - /jobservice/job/impl/gc: TestDelKeys hardcodes redis://127.0.0.1:6379
-  #   - /core/session: SessionInit hardcodes redis://127.0.0.1:6379/0
-  #   - /lib/cache/redis: test suite assumes Redis on localhost
-  #   - /server/middleware/blob: needs DB + Redis for middleware setup
-  #   - /controller/usergroup/test, /pkg/scan/dao/scanner, /pkg/scan/export,
-  #     /pkg/scan/dao/scan, /pkg/scan/postprocessors, /pkg/systemartifact:
+  #   - /controller/usergroup/test, /pkg/scan/dao/scan,
+  #     /pkg/scan/postprocessors, /pkg/systemartifact:
   #     upstream test-ordering / FK-constraint issues
-  #   - /pkg/accessory/model/attestation: imports src/testing which has
-  #     //go:build db; doesn't compile without -tags db
   #
-  # The filter is defined once as DEFAULT_PKG_EXCLUDE at the top of this file.
+  # The DB filter is defined once as DEFAULT_DB_EXCLUDE at the top of this
+  # file. The pure lane uses DEFAULT_PURE_EXCLUDE, which additionally routes
+  # Redis/Postgres-backed packages into the DB lane.
   # To run every package in dev, pass a sentinel regex that matches nothing:
-  #     task test:unit:pure PKG_EXCLUDE='^$'
+  #     task test:unit:pure PURE_PKG_EXCLUDE='^$'
   # (Passing an empty string does NOT work — slim-sprig `default` treats it as
   # unset, and `grep -vE ''` would drop every line anyway.)
   # ----------------------------------------------------------------------------
@@ -126,7 +125,9 @@ tasks:
       - task: _prepare-go-tests
       - cmd: |
           cd src
-          pkgs=$(../tools/ci/list-go-test-packages.sh pure '{{.PKG_EXCLUDE | default .DEFAULT_PKG_EXCLUDE}}' | tr '\n' ' ')
+          pkgs=$(../tools/ci/list-go-test-packages.sh pure '{{.PURE_PKG_EXCLUDE | default .DEFAULT_PURE_EXCLUDE}}' \
+            | awk 'BEGIN { shard="{{.SHARD_INDEX | default ""}}"; total="{{.SHARD_TOTAL | default ""}}"; } total == "" || shard == "" || ((NR - 1) % total) == shard { print }' \
+            | tr '\n' ' ')
           if [ -z "$pkgs" ]; then
             echo "no pure test packages matched"
             exit 1
@@ -140,7 +141,16 @@ tasks:
       - task: _prepare-go-tests
       - cmd: |
           cd src
-          pkgs=$(../tools/ci/list-go-test-packages.sh db-tagged '{{.PKG_EXCLUDE | default .DEFAULT_PKG_EXCLUDE}}' | tr '\n' ' ')
+          pkgs=$(
+            {
+              ../tools/ci/list-go-test-packages.sh db-tagged '{{.DB_PKG_EXCLUDE | default .DEFAULT_DB_EXCLUDE}}'
+              printf '%s\n' '{{.DB_EXTRA_PACKAGES | default .DEFAULT_DB_EXTRA_PACKAGES}}' | tr ' ' '\n'
+            } \
+            | awk 'NF' \
+            | sort -u \
+            | awk 'BEGIN { shard="{{.SHARD_INDEX | default ""}}"; total="{{.SHARD_TOTAL | default ""}}"; } total == "" || shard == "" || ((NR - 1) % total) == shard { print }' \
+            | tr '\n' ' '
+          )
           if [ -z "$pkgs" ]; then
             echo "no db-tagged test packages matched"
             exit 1
@@ -153,7 +163,7 @@ tasks:
     cmds:
       - task: unit:pure
         vars:
-          PKG_EXCLUDE: '{{.PKG_EXCLUDE}}'
+          PURE_PKG_EXCLUDE: '{{.PURE_PKG_EXCLUDE}}'
           RACE_FLAGS: '{{.RACE_FLAGS}}'
           COVER_FLAGS: '{{.COVER_FLAGS}}'
           TEST_FLAGS: '{{.TEST_FLAGS}}'
@@ -163,7 +173,8 @@ tasks:
     cmds:
       - task: unit:db
         vars:
-          PKG_EXCLUDE: '{{.PKG_EXCLUDE}}'
+          DB_PKG_EXCLUDE: '{{.DB_PKG_EXCLUDE}}'
+          DB_EXTRA_PACKAGES: '{{.DB_EXTRA_PACKAGES}}'
           RACE_FLAGS: '{{.RACE_FLAGS}}'
           COVER_FLAGS: '{{.COVER_FLAGS}}'
           TEST_FLAGS: '{{.TEST_FLAGS}}'

--- a/tools/ci/list-go-test-packages.sh
+++ b/tools/ci/list-go-test-packages.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+mode="${1:?usage: list-go-test-packages.sh <pure|db-tagged> [exclude-regex]}"
+exclude_regex="${2:-^$}"
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "${repo_root}/src"
+
+case "${mode}" in
+  pure)
+    go list -f '{{if or .TestGoFiles .XTestGoFiles}}{{.ImportPath}}{{end}}' ./... \
+      | awk 'NF' \
+      | awk -v re="${exclude_regex}" '$0 !~ re'
+    ;;
+  db-tagged)
+    mapfile -t pkg_dirs < <(
+      rg -l '^//go:build db$' . --glob '**/*_test.go' \
+        | sed 's#^\./##; s#/[^/]*$##' \
+        | sort -u
+    )
+
+    if [ "${#pkg_dirs[@]}" -eq 0 ]; then
+      exit 0
+    fi
+
+    go list -tags db "${pkg_dirs[@]/#/./}" \
+      | awk 'NF' \
+      | awk -v re="${exclude_regex}" '$0 !~ re'
+    ;;
+  *)
+    echo "unknown mode: ${mode}" >&2
+    exit 1
+    ;;
+esac

--- a/tools/ci/list-go-test-packages.sh
+++ b/tools/ci/list-go-test-packages.sh
@@ -15,11 +15,20 @@ case "${mode}" in
       | awk -v re="${exclude_regex}" '$0 !~ re'
     ;;
   db-tagged)
-    mapfile -t pkg_dirs < <(
-      rg -l '^//go:build db$' . --glob '**/*_test.go' \
-        | sed 's#^\./##; s#/[^/]*$##' \
-        | sort -u
-    )
+    if command -v rg >/dev/null 2>&1; then
+      mapfile -t pkg_dirs < <(
+        rg -l '^//go:build db$' . --glob '**/*_test.go' \
+          | sed 's#^\./##; s#/[^/]*$##' \
+          | sort -u
+      )
+    else
+      mapfile -t pkg_dirs < <(
+        find . -type f -name '*_test.go' -print0 \
+          | xargs -0 grep -l '^//go:build db$' \
+          | sed 's#^\./##; s#/[^/]*$##' \
+          | sort -u
+      )
+    fi
 
     if [ "${#pkg_dirs[@]}" -eq 0 ]; then
       exit 0

--- a/tools/ci/list-go-test-packages.sh
+++ b/tools/ci/list-go-test-packages.sh
@@ -15,16 +15,18 @@ case "${mode}" in
       | awk -v re="${exclude_regex}" '$0 !~ re'
     ;;
   db-tagged)
+    pkg_dirs=()
+
     if command -v rg >/dev/null 2>&1; then
       mapfile -t pkg_dirs < <(
-        rg -l '^//go:build db$' . --glob '**/*_test.go' \
+        { rg -l '^//go:build db$' . --glob '**/*_test.go' || true; } \
           | sed 's#^\./##; s#/[^/]*$##' \
           | sort -u
       )
     else
       mapfile -t pkg_dirs < <(
-        find . -type f -name '*_test.go' -print0 \
-          | xargs -0 grep -l '^//go:build db$' \
+        { find . -type f -name '*_test.go' -print0 \
+          | xargs -0 -r grep -l '^//go:build db$' || true; } \
           | sed 's#^\./##; s#/[^/]*$##' \
           | sort -u
       )


### PR DESCRIPTION
## Summary
- keep `test:unit:pure` and `test:unit:db` as the primary test tasks and make `test:all` run both
- add top-level `task lint`, `task lint:api`, and `task vuln-check` commands
- speed up the CI fast path by targeting only relevant test packages and shrinking long-sleep tests in `lib/retry` and `controller/proxy`

## Verification
- `go clean -testcache && task test:unit:pure` (`27s` locally)
- `task test:unit:db` with local Dockerized Redis/Postgres (`116s` locally)
- combined local runtime: `< 5m`