### PR TITLE
fix: Re-add missing in-toto attestation accessory model import

### DIFF
--- a/src/core/main.go
+++ b/src/core/main.go
@@ -59,6 +59,7 @@ import (
 	"github.com/goharbor/harbor/src/lib/retry"
 	tracelib "github.com/goharbor/harbor/src/lib/trace"
 	"github.com/goharbor/harbor/src/migration"
+	_ "github.com/goharbor/harbor/src/pkg/accessory/model/attestation"
 	_ "github.com/goharbor/harbor/src/pkg/accessory/model/base"
 	_ "github.com/goharbor/harbor/src/pkg/accessory/model/cosign"
 	_ "github.com/goharbor/harbor/src/pkg/accessory/model/notation"


### PR DESCRIPTION
## Summary
- Re-add the side-effect import `_ "github.com/goharbor/harbor/src/pkg/accessory/model/attestation"` to `src/core/main.go`
- PR #118 accidentally removed this import, which means the `init()` in the attestation package never runs and `model.Register(model.TypeInTotoAttestation, New)` is never called
- Without this registration, Harbor fails to handle OCI artifacts carrying `application/vnd.in-toto+json` payloads (SLSA provenance, in-toto layouts)

## Related Issues
Fixes #144

## Type of Change
- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` / `fix!:`)
- [ ] Documentation (`docs:`)
- [ ] Refactoring (`refactor:`)
- [ ] CI/CD or build changes (`ci:` / `build:`)
- [ ] Dependencies update (`chore:`)
- [ ] Tests (`test:`)

## Release Notes
Restore in-toto attestation support that was accidentally removed during the pgx/v5 upgrade.

## Testing
- [x] Unit tests added/updated
- [x] Manual testing performed

## Checklist
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] Commits are signed off (`git commit -s`)
- [x] No new warnings introduced