### PR TITLE
fix(ci): Add shard index to DB test container name prefix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -82,7 +82,7 @@ jobs:
 
       - name: Start test services
         run: |
-          PREFIX="test-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+          PREFIX="test-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-${{ matrix.shard_index }}"
           echo "SVC_PREFIX=${PREFIX}" >> "$GITHUB_ENV"
 
           # Redis runs on the runner pod itself at localhost:6379.


### PR DESCRIPTION
## Summary
- Matrix shards share a DinD daemon and both tried to create a Postgres container with the same name (`test-<runid>-<attempt>-postgres`), causing a Docker name conflict (exit 125) on one shard and a timeout (exit 124) on the other
- Appends `${{ matrix.shard_index }}` to the container name prefix so each shard gets a unique name

## Related Issues
<!-- Fixes the DB test failures introduced by #147 -->

## Type of Change
- [x] CI/CD or build changes (`ci:` / `build:`)

## Release Notes
<!-- N/A — CI-only change -->

## Testing
- [x] CI will validate by running the sharded DB tests without container name collisions

## Checklist
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] Commits are signed off (`git commit -s`)
- [x] No new warnings introduced