### PR TITLE
perf(ci): Cache Go modules, swagger binary, and generated API code

### DIFF
--- a/.github/actions/setup-go-cached/action.yml
+++ b/.github/actions/setup-go-cached/action.yml
@@ -18,7 +18,8 @@ runs:
         go-version-file: ${{ inputs.go-version-file }}
         cache: false
 
-    # GitHub-hosted only: restore module cache from GitHub's cache storage
+    # GitHub-hosted only: restore module cache from GitHub's cache storage.
+    # Self-hosted runners use persistent host-mounted $GOMODCACHE instead.
     - name: Restore Go module cache
       if: runner.environment != 'self-hosted'
       uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
@@ -27,7 +28,8 @@ runs:
         key: go-mod-${{ runner.os }}-${{ hashFiles(inputs.go-sum-path) }}
         restore-keys: go-mod-${{ runner.os }}-
 
-    # GitHub-hosted only: restore build cache from GitHub's cache storage
+    # GitHub-hosted only: restore build cache from GitHub's cache storage.
+    # Self-hosted runners use persistent host-mounted $GOCACHE instead.
     - name: Restore Go build cache
       if: runner.environment != 'self-hosted'
       uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,6 +39,21 @@ jobs:
           go-version-file: src/go.mod
           go-sum-path: src/go.sum
 
+      - name: Cache swagger binary
+        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
+        with:
+          path: ~/go/bin/swagger
+          key: swagger-${{ runner.os }}-${{ hashFiles('versions.env') }}
+
+      - name: Cache generated API code
+        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
+        with:
+          path: |
+            src/server/v2.0/models
+            src/server/v2.0/restapi
+            .task/checksum
+          key: gen-apis-${{ hashFiles('api/v2.0/swagger.yaml', 'tools/swagger/templates/**/*') }}
+
       - uses: arduino/setup-task@b91d5d2c96a56797b48ac1e0e89220bf64044611 # v2.0.0
         with:
           version: 3.x
@@ -82,7 +97,7 @@ jobs:
 
       - name: Start test services
         run: |
-          PREFIX="test-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+          PREFIX="test-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-${{ matrix.shard_index }}"
           echo "SVC_PREFIX=${PREFIX}" >> "$GITHUB_ENV"
 
           # Redis runs on the runner pod itself at localhost:6379.
@@ -135,6 +150,21 @@ jobs:
         with:
           go-version-file: src/go.mod
           go-sum-path: src/go.sum
+
+      - name: Cache swagger binary
+        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
+        with:
+          path: ~/go/bin/swagger
+          key: swagger-${{ runner.os }}-${{ hashFiles('versions.env') }}
+
+      - name: Cache generated API code
+        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
+        with:
+          path: |
+            src/server/v2.0/models
+            src/server/v2.0/restapi
+            .task/checksum
+          key: gen-apis-${{ hashFiles('api/v2.0/swagger.yaml', 'tools/swagger/templates/**/*') }}
 
       - uses: arduino/setup-task@b91d5d2c96a56797b48ac1e0e89220bf64044611 # v2.0.0
         with:

--- a/taskfile/build.yml
+++ b/taskfile/build.yml
@@ -186,6 +186,7 @@ tasks:
   gen-apis:
     desc: "Generate Go server code from swagger.yaml"
     run: once
+    method: checksum
     deps: [require-swagger]
     sources:
       - api/v2.0/swagger.yaml


### PR DESCRIPTION
## Summary
- Cache the swagger binary (`~/go/bin/swagger`, keyed on `versions.env`) and generated API code (`src/server/v2.0/` + `.task/checksum`, keyed on `swagger.yaml` + templates) via `actions/cache` — these aren't on the host-mounted `$GOMODCACHE`/`$GOCACHE` so they were regenerated every run (~2 min overhead per job)
- Switch `gen-apis` to `method: checksum` so Task uses content hashing instead of timestamps — timestamps break after cache restore, checksums don't
- Add clarifying comments to `setup-go-cached` explaining that self-hosted runners use host-mounted caches
- Also includes the shard index fix for DinD container name collisions (#154)

## How it works (steady state, cache hit)
1. Host-mounted `$GOMODCACHE`/`$GOCACHE` handle Go module and build caching (already in place)
2. `actions/cache` restores `~/go/bin/swagger` → `require-swagger` status check passes, skip install
3. `actions/cache` restores `src/server/v2.0/` + `.task/checksum/` → `gen-apis` checksum matches, skip codegen
4. Tests start with near-zero overhead

## Type of Change
- [x] CI/CD or build changes (`ci:` / `build:`)

## Testing
- [x] CI will validate — first run populates caches, subsequent runs should skip gen-apis entirely

## Checklist
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] Commits are signed off (`git commit -s`)
- [x] No new warnings introduced