### PR TITLE
docs(example/aws-eks-irsa): Update for v2.15.0 release + fix middlware typo

### DIFF
--- a/deploy/chart/example/aws-eks-irsa/README.md
+++ b/deploy/chart/example/aws-eks-irsa/README.md
@@ -56,7 +56,7 @@ All scripts accept these overrides:
 | `DB_CLUSTER_ID` | `harbor-next-aurora` | Aurora cluster identifier |
 | `DB_MASTER_PASSWORD` | (random) | Aurora master password |
 | `CHART_VERSION` | `3.0.0` | Helm chart version |
-| `CHART_REF` | `oci://8gears.container-registry.com/harbor-next/chart/harbor` | Chart OCI reference |
+| `CHART_REF` | `oci://8gears.container-registry.com/8gcr/charts/harbor-next` | Chart OCI reference |
 | `KUBECONFIG_PATH` | `~/.kube/<CLUSTER_NAME>.yaml` | Kubeconfig file path |
 
 ## Quick Start
@@ -146,7 +146,7 @@ ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT ALL ON SEQUENCES TO harbor_iam_u
 ### 7. Deploy Harbor
 
 ```bash
-helm install harbor-next oci://8gears.container-registry.com/harbor-next/chart/harbor \
+helm install harbor-next oci://8gears.container-registry.com/8gcr/charts/harbor-next \
   --version 3.0.0 -n harbor --create-namespace \
   -f values-aws-irsa.yaml \
   --set database.host=<AURORA_ENDPOINT> \

--- a/deploy/chart/example/aws-eks-irsa/README.md
+++ b/deploy/chart/example/aws-eks-irsa/README.md
@@ -34,28 +34,13 @@ Deploy Harbor Next on AWS EKS using IAM Roles for Service Accounts (IRSA) for ze
 
 ## Prerequisites
 
-- AWS CLI v2, configured for account `163500494166` (or your target account)
+- AWS CLI v2, configured for your target AWS account
 - `eksctl` >= 0.170
 - `helm` >= 3.14
 - `kubectl`
 - `docker` (for push/pull verification)
-- Harbor Next images with RDS IAM Auth support (from `aws-iam-auth` branch)
-
-### IAM Auth Commits
-
-The RDS IAM Auth code is on the `aws-iam-auth` branch. Cherry-pick these commits onto your build branch before building images:
-
-```bash
-git cherry-pick 702be52951  # feat: add support for AWS IAM auth
-git cherry-pick 31f5ead5f1  # fix: add the metadata entries for the new config keys
-git cherry-pick fce902463f  # fix: JobService database authentication with IAM
-```
-
-Then build images:
-
-```bash
-task images PLATFORMS=linux/amd64
-```
+- Harbor Next `v2.15.0` or later — RDS IAM Auth is built in.
+  Public images: `8gears.container-registry.com/8gcr/harbor-{core,jobservice,registry,portal}:v2.15.0`
 
 ## Environment Variables
 
@@ -71,7 +56,7 @@ All scripts accept these overrides:
 | `DB_CLUSTER_ID` | `harbor-next-aurora` | Aurora cluster identifier |
 | `DB_MASTER_PASSWORD` | (random) | Aurora master password |
 | `CHART_VERSION` | `3.0.0` | Helm chart version |
-| `CHART_REF` | `oci://8gears.container-registry.com/8gcr/charts/harbor-next` | Chart OCI reference |
+| `CHART_REF` | `oci://8gears.container-registry.com/harbor-next/chart/harbor` | Chart OCI reference |
 | `KUBECONFIG_PATH` | `~/.kube/<CLUSTER_NAME>.yaml` | Kubeconfig file path |
 
 ## Quick Start
@@ -161,7 +146,7 @@ ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT ALL ON SEQUENCES TO harbor_iam_u
 ### 7. Deploy Harbor
 
 ```bash
-helm install harbor-next oci://8gears.container-registry.com/8gcr/charts/harbor-next \
+helm install harbor-next oci://8gears.container-registry.com/harbor-next/chart/harbor \
   --version 3.0.0 -n harbor --create-namespace \
   -f values-aws-irsa.yaml \
   --set database.host=<AURORA_ENDPOINT> \
@@ -220,7 +205,7 @@ kubectl exec -n harbor <registry-pod> -- env | grep AWS  # should show AWS_WEB_I
 
 ### "password authentication failed" for harbor_iam_user
 
-The IAM auth code (`HARBOR_DATABASE_IAM_AUTH=true`) is required. Ensure images are built from the `aws-iam-auth` branch or have the cherry-picked commits.
+IAM auth is activated by `POSTGRESQL_USE_IAM_AUTH=true` + `POSTGRESQL_AWS_REGION=<region>`, set via `core.config` / `jobservice.config` in `values-aws-irsa.yaml`. Confirm they reach the pod with `kubectl exec <core-pod> -n harbor -- env | grep POSTGRESQL_USE_IAM_AUTH`. Use public images tagged `v2.15.0` or later — earlier images do not include the IAM code.
 
 ### automountServiceAccountToken
 

--- a/deploy/chart/example/aws-eks-irsa/setup.sh
+++ b/deploy/chart/example/aws-eks-irsa/setup.sh
@@ -30,7 +30,7 @@ IAM_POLICY_NAME="${IAM_POLICY_NAME:-harbor-next-irsa}"
 IAM_ROLE_NAME="${IAM_ROLE_NAME:-harbor-next-irsa}"
 
 CHART_VERSION="${CHART_VERSION:-3.0.0}"
-CHART_REF="${CHART_REF:-oci://8gears.container-registry.com/harbor-next/chart/harbor}"
+CHART_REF="${CHART_REF:-oci://8gears.container-registry.com/8gcr/charts/harbor-next}"
 
 KUBECONFIG_PATH="${KUBECONFIG_PATH:-${HOME}/.kube/${CLUSTER_NAME}.yaml}"
 export KUBECONFIG="${KUBECONFIG_PATH}"

--- a/deploy/chart/example/aws-eks-irsa/setup.sh
+++ b/deploy/chart/example/aws-eks-irsa/setup.sh
@@ -30,7 +30,7 @@ IAM_POLICY_NAME="${IAM_POLICY_NAME:-harbor-next-irsa}"
 IAM_ROLE_NAME="${IAM_ROLE_NAME:-harbor-next-irsa}"
 
 CHART_VERSION="${CHART_VERSION:-3.0.0}"
-CHART_REF="${CHART_REF:-oci://8gears.container-registry.com/8gcr/charts/harbor-next}"
+CHART_REF="${CHART_REF:-oci://8gears.container-registry.com/harbor-next/chart/harbor}"
 
 KUBECONFIG_PATH="${KUBECONFIG_PATH:-${HOME}/.kube/${CLUSTER_NAME}.yaml}"
 export KUBECONFIG="${KUBECONFIG_PATH}"

--- a/deploy/chart/example/aws-eks-irsa/values-aws-irsa.yaml
+++ b/deploy/chart/example/aws-eks-irsa/values-aws-irsa.yaml
@@ -18,6 +18,8 @@
 
 # Access via kubectl port-forward svc/harbor-next-core 8443:443 -n harbor
 externalURL: "https://localhost:8443"
+# Demo password. For production, use `existingSecretAdminPassword` with a
+# Secret from AWS Secrets Manager, external-secrets, or SOPS.
 harborAdminPassword: "Harbor12345"
 
 # --- Exposure: ClusterIP only (port-forward access) ---

--- a/deploy/chart/example/aws-eks-irsa/values-aws-irsa.yaml
+++ b/deploy/chart/example/aws-eks-irsa/values-aws-irsa.yaml
@@ -7,7 +7,7 @@
 #   - IRSA role with S3 + rds-db:connect permissions
 #
 # Usage:
-#   helm install harbor-next oci://8gears.container-registry.com/harbor-next/chart/harbor \
+#   helm install harbor-next oci://8gears.container-registry.com/8gcr/charts/harbor-next \
 #     --version 3.0.0 -n harbor --create-namespace \
 #     -f values-aws-irsa.yaml \
 #     --set database.host=<AURORA_ENDPOINT> \

--- a/deploy/chart/example/aws-eks-irsa/values-aws-irsa.yaml
+++ b/deploy/chart/example/aws-eks-irsa/values-aws-irsa.yaml
@@ -7,7 +7,7 @@
 #   - IRSA role with S3 + rds-db:connect permissions
 #
 # Usage:
-#   helm install harbor-next oci://8gears.container-registry.com/8gcr/charts/harbor-next \
+#   helm install harbor-next oci://8gears.container-registry.com/harbor-next/chart/harbor \
 #     --version 3.0.0 -n harbor --create-namespace \
 #     -f values-aws-irsa.yaml \
 #     --set database.host=<AURORA_ENDPOINT> \

--- a/deploy/chart/templates/_helpers-tls.tpl
+++ b/deploy/chart/templates/_helpers-tls.tpl
@@ -11,7 +11,7 @@ Check if internal TLS is enabled
   {{- printf "http" -}}
 {{- end }}
 
-{{- define "harbor.middlware.enabled" -}}
+{{- define "harbor.middleware.enabled" -}}
 {{- false }}
 {{- end }}
 

--- a/deploy/chart/templates/registry.configmap.yaml
+++ b/deploy/chart/templates/registry.configmap.yaml
@@ -165,7 +165,7 @@ data:
       schema1:
         enabled: true
 
-    {{- if (include "harbor.middlware.enabled" .) }}
+    {{- if (include "harbor.middleware.enabled" .) }}
     {{- $middleware := .Values.registry.middleware }}
     {{- $middlewareType := $middleware.type }}
     {{- if eq $middlewareType "cloudFront" }}


### PR DESCRIPTION
## Summary

The `aws-eks-irsa` chart example was written while RDS IAM Auth still lived on a feature branch and needed cherry-picks + a local image build. That code is now merged and released as **`v2.15.0`** on `8gears.container-registry.com/8gcr/harbor-*`, so the prerequisites are obsolete. This PR brings the example in line with what a user actually runs today.

No schema or script-logic changes — the `values-aws-irsa.yaml`, `setup.sh`, `teardown.sh`, `verify.sh`, `iam-policy.json`, and `cluster.yaml` are already correct.

### Changes

**`README.md`**
- Remove the "IAM Auth Commits" section — cherry-picks `702be52951`, `31f5ead5f1`, `fce902463f` are no longer needed; code is merged into main and shipped in `v2.15.0`.
- Remove the `task images PLATFORMS=linux/amd64` local build step.
- Prerequisites now point to public `8gears.container-registry.com/8gcr/harbor-{core,jobservice,registry,portal}:v2.15.0` images.
- Drop hardcoded AWS account ID `163500494166`.
- Troubleshooting: replace the wrong env var name `HARBOR_DATABASE_IAM_AUTH` with the correct `POSTGRESQL_USE_IAM_AUTH` + `POSTGRESQL_AWS_REGION`, plus a `kubectl exec env` sanity check.

**Chart templates — pre-existing typo flagged by CI**
- Rename Helm template helper `harbor.middlware.enabled` → `harbor.middleware.enabled` in [_helpers-tls.tpl](deploy/chart/templates/_helpers-tls.tpl) and its single call site in [registry.configmap.yaml](deploy/chart/templates/registry.configmap.yaml). Surfaced by the `typos` CI on this PR.

## Type of Change
- [x] Documentation (`docs:`)

## Release Notes
Internal docs fix + 1-line Helm template helper rename (no behaviour change).

## Testing
- [x] Manual testing performed — full deploy + push validated on AWS
- [ ] Unit tests — N/A (docs-only change)
