### PR TITLE
fix: Honor unauthenticated project redirects

### DIFF
--- a/devenv/README.md
+++ b/devenv/README.md
@@ -78,7 +78,7 @@ dockerfile/
 
 ### Full Environment
 ```bash
-task dev:up                    # Start everything (Core, JobService, Trivy, Portal)
+task dev:up                    # Start backend containers and native Portal
 task dev:up SKIP_TRIVY=true    # Start without Trivy
 task dev:status          # Show running containers
 task dev:logs            # View all container logs

--- a/devenv/docker-compose.yml
+++ b/devenv/docker-compose.yml
@@ -5,7 +5,7 @@
 
 services:
   postgresql:
-    image: docker.io/library/postgres:${POSTGRES_VERSION:-16}-alpine
+    image: docker.io/library/postgres:18-alpine
     environment:
       POSTGRES_USER: postgres
       POSTGRES_PASSWORD: root123
@@ -19,7 +19,7 @@ services:
       retries: 15
       start_period: 5s
     volumes:
-      - harbor-postgres-data:/var/lib/postgresql/data
+      - harbor-postgres-18-data:/var/lib/postgresql
       - ../make/migrations:/migrations
 
   redis:
@@ -239,8 +239,8 @@ services:
       - core
 
 volumes:
-  harbor-postgres-data:
-    name: ${PROJECT_PREFIX:-harbor}-postgres-data
+  harbor-postgres-18-data:
+    name: ${PROJECT_PREFIX:-harbor}-postgres-18-data
   harbor-redis-data:
     name: ${PROJECT_PREFIX:-harbor}-redis-data
   harbor-registry-data:

--- a/devenv/docker-compose.yml
+++ b/devenv/docker-compose.yml
@@ -5,7 +5,7 @@
 
 services:
   postgresql:
-    image: docker.io/library/postgres:18-alpine
+    image: ${REGISTRY_ADDRESS:-docker.io}/${REGISTRY_PROJECT:-library}/postgres:18-alpine
     environment:
       POSTGRES_USER: postgres
       POSTGRES_PASSWORD: root123

--- a/devenv/docker-compose.yml
+++ b/devenv/docker-compose.yml
@@ -5,7 +5,7 @@
 
 services:
   postgresql:
-    image: docker.io/library/postgres:18-alpine
+    image: docker.io/library/postgres:${POSTGRES_VERSION:-16}-alpine
     environment:
       POSTGRES_USER: postgres
       POSTGRES_PASSWORD: root123

--- a/src/portal/README.md
+++ b/src/portal/README.md
@@ -33,8 +33,8 @@ If `postinstall` scripts were not triggered, then run manually:  `npm run postin
 - `HARBOR_USE_PROXY_AGENT=true` enables `https-proxy-agent`
 - `HARBOR_PROXY_AGENT_SERVER` overrides the corporate proxy agent URL
 
-When using `task dev:up`, the containerized dev stack sets the proxy target automatically.
-The OpenAPI / Swagger UI is built automatically in the background during portal startup.
+When using `task dev:up`, the Taskfile sets the proxy target automatically.
+The TypeScript API client is regenerated before portal startup.
 
 ### 4. Start the development server
 

--- a/src/portal/src/app/base/left-side-nav/config/auth/config-auth.component.html
+++ b/src/portal/src/app/base/left-side-nav/config/auth/config-auth.component.html
@@ -1,6 +1,8 @@
 <form #authConfigFrom="ngForm" class="clr-form clr-form-horizontal">
     <div class="clr-form-control">
-        <label for="unauthLandingPage" class="clr-control-label">
+        <label
+            for="unauthLandingPage"
+            class="clr-control-label unauth-landing-page-label">
             {{ 'CONFIG.UNAUTH_LANDING_PAGE' | translate }}
             <clr-tooltip>
                 <clr-icon

--- a/src/portal/src/app/base/left-side-nav/config/auth/config-auth.component.scss
+++ b/src/portal/src/app/base/left-side-nav/config/auth/config-auth.component.scss
@@ -13,5 +13,10 @@
 }
 
 .clr-control-label {
- width: 10.6rem !important;
+    width: 10.6rem !important;
+}
+
+.unauth-landing-page-label {
+    white-space: nowrap;
+    width: 16rem !important;
 }

--- a/src/portal/src/app/base/left-side-nav/projects/list-project/list-project.component.html
+++ b/src/portal/src/app/base/left-side-nav/projects/list-project/list-project.component.html
@@ -61,6 +61,7 @@
             <a
                 href="javascript:void(0)"
                 [routerLink]="getLink(p.project_id)"
+                [queryParams]="getQueryParams()"
                 (click)="clickLink(p.project_id)"
                 >{{ p.name }}</a
             >

--- a/src/portal/src/app/base/left-side-nav/projects/list-project/list-project.component.ts
+++ b/src/portal/src/app/base/left-side-nav/projects/list-project/list-project.component.ts
@@ -60,6 +60,7 @@ import { ConfirmationDialogService } from '../../../global-confirmation-dialog/c
 import { errorHandler } from '../../../../shared/units/shared.utils';
 import { ConfirmationMessage } from '../../../global-confirmation-dialog/confirmation-message';
 import { ExportCveComponent } from './export-cve/export-cve.component';
+import { UN_LOGGED_PARAM, YES } from '../../../../account/sign-in/sign-in.service';
 
 const MAX_PROJECTS_NUM: number = 1;
 const INTERVAL: number = 30000;
@@ -167,6 +168,13 @@ export class ListProjectComponent implements OnDestroy {
     }
     getLink(proId: number) {
         return `/harbor/projects/${proId}/repositories`;
+    }
+
+    getQueryParams() {
+        if (this.session.getCurrentUser()) {
+            return null;
+        }
+        return { [UN_LOGGED_PARAM]: YES };
     }
 
     clrLoad(state: ClrDatagridStateInterface) {

--- a/src/portal/src/app/base/project/project-detail/project-detail.component.html
+++ b/src/portal/src/app/base/project/project-detail/project-detail.component.html
@@ -138,6 +138,7 @@
                     id="{{ 'project-' + tab.linkName }}"
                     clrTabLink
                     routerLink="{{ tab.linkName }}"
+                    [queryParams]="getQueryParams()"
                     routerLinkActive="active"
                     type="button">
                     <a class="nav-link">{{ tab.showTabName | translate }}</a>

--- a/src/portal/src/app/base/project/project-detail/project-detail.component.html
+++ b/src/portal/src/app/base/project/project-detail/project-detail.component.html
@@ -1,17 +1,17 @@
 <ng-container *ngIf="hasSignedIn || isPublicAndNotLogged">
-    <span class="back-icon"><</span>
+    <span class="back-icon">&lt;</span>
     <a (click)="backToProject()" class="backStyle">{{
         'PROJECT_DETAIL.PROJECTS' | translate
     }}</a>
 </ng-container>
 <ng-container *ngIf="hasSignedIn && isWebhookTaskListPage()">
-    <span class="back-icon"><</span>
+    <span class="back-icon">&lt;</span>
     <a (click)="backToWebhook()" class="backStyle">{{
         'PROJECT_DETAIL.WEBHOOKS' | translate
     }}</a>
 </ng-container>
 <ng-container *ngIf="hasSignedIn && isP2pPreheatTaskListPage()">
-    <span class="back-icon"><</span>
+    <span class="back-icon">&lt;</span>
     <a (click)="backToP2pPreheat()" class="backStyle">{{
         'P2P_PROVIDER.P2P_PROVIDER' | translate
     }}</a>

--- a/src/portal/src/app/base/project/project-detail/project-detail.component.html
+++ b/src/portal/src/app/base/project/project-detail/project-detail.component.html
@@ -1,7 +1,9 @@
-<span class="back-icon"><</span>
-<a *ngIf="hasSignedIn" (click)="backToProject()" class="backStyle">{{
-    'PROJECT_DETAIL.PROJECTS' | translate
-}}</a>
+<ng-container *ngIf="hasSignedIn || isPublicAndNotLogged">
+    <span class="back-icon"><</span>
+    <a (click)="backToProject()" class="backStyle">{{
+        'PROJECT_DETAIL.PROJECTS' | translate
+    }}</a>
+</ng-container>
 <ng-container *ngIf="hasSignedIn && isWebhookTaskListPage()">
     <span class="back-icon"><</span>
     <a (click)="backToWebhook()" class="backStyle">{{

--- a/src/portal/src/app/base/project/project-detail/project-detail.component.ts
+++ b/src/portal/src/app/base/project/project-detail/project-detail.component.ts
@@ -391,6 +391,12 @@ export class ProjectDetailComponent
         if (window.sessionStorage) {
             window.sessionStorage.setItem('fromDetails', 'true');
         }
+        if (this.isPublicAndNotLogged) {
+            this.router.navigate(['/harbor', 'projects'], {
+                queryParams: { [UN_LOGGED_PARAM]: YES },
+            });
+            return;
+        }
         this.router.navigate(['/harbor', 'projects']);
     }
     isDefaultTab(tab, index) {

--- a/src/portal/src/app/base/project/project-detail/project-detail.component.ts
+++ b/src/portal/src/app/base/project/project-detail/project-detail.component.ts
@@ -49,6 +49,7 @@ import {
     HarborEvent,
 } from '../../../services/event-service/event.service';
 import { RouteConfigId } from '../../../route-reuse-strategy/harbor-route-reuse-strategy';
+import { UN_LOGGED_PARAM, YES } from '../../../account/sign-in/sign-in.service';
 
 @Component({
     selector: 'project-detail',
@@ -220,6 +221,12 @@ export class ProjectDetailComponent
         }
     }
     getPermissionsList(projectId: number): void {
+        if (this.isPublicAndNotLogged) {
+            this.hasProjectReadPermission = true;
+            this.hasRepositoryListPermission = true;
+            return;
+        }
+
         let permissionsList: Array<Observable<boolean>> = [];
         permissionsList.push(
             this.userPermissionService.getPermission(
@@ -364,6 +371,20 @@ export class ProjectDetailComponent
 
     public get isSessionValid(): boolean {
         return this.sessionService.getCurrentUser() != null;
+    }
+
+    public get isPublicAndNotLogged(): boolean {
+        return (
+            !this.isSessionValid &&
+            this.route.snapshot.queryParams[UN_LOGGED_PARAM] === YES
+        );
+    }
+
+    getQueryParams() {
+        if (!this.isPublicAndNotLogged) {
+            return null;
+        }
+        return { [UN_LOGGED_PARAM]: YES };
     }
 
     backToProject(): void {

--- a/src/portal/src/app/base/project/repository/artifact/artifact-list-page/artifact-list-page.component.html
+++ b/src/portal/src/app/base/project/repository/artifact/artifact-list-page/artifact-list-page.component.html
@@ -1,8 +1,8 @@
 <div>
     <div class="breadcrumb">
-        <span class="back-icon"><</span>
+        <span class="back-icon">&lt;</span>
         <a (click)="goProBack()">{{ 'SIDE_NAV.PROJECTS' | translate }}</a>
-        <span class="back-icon"><</span>
+        <span class="back-icon">&lt;</span>
         <a (click)="watchGoBackEvt(projectId)">{{ projectName }}</a>
         <span *ngIf="depth"
             >&lt;<a (click)="backInitRepo()">{{ repoName }}</a></span

--- a/src/portal/src/app/base/project/repository/artifact/artifact-list-page/artifact-list/artifact-list-tab/artifact-list-tab.component.html
+++ b/src/portal/src/app/base/project/repository/artifact/artifact-list-page/artifact-list/artifact-list-tab/artifact-list-tab.component.html
@@ -326,10 +326,10 @@
                     <div *ngIf="artifact.tags" class="truncated width-p-100">
                         <clr-tooltip class="width-p-100">
                             <div clrTooltipTrigger class="center">
-                                <div class="center width-p-100">
+                                <div class="tag-cell-content">
                                     <span
                                         #tagsSpan
-                                        class="truncated width-p-75">
+                                        class="truncated tag-cell-text">
                                         {{ tagsString(artifact?.tags) }}
                                     </span>
 
@@ -342,6 +342,7 @@
                                     >
                                     <app-pull-command
                                         *ngIf="artifact?.tags?.length > 0"
+                                        class="tag-copy-command"
                                         [isTagMode]="true"
                                         [artifact]="artifact"
                                         [registryUrl]="registryUrl"

--- a/src/portal/src/app/base/project/repository/artifact/artifact-list-page/artifact-list/artifact-list-tab/artifact-list-tab.component.scss
+++ b/src/portal/src/app/base/project/repository/artifact/artifact-list-page/artifact-list/artifact-list-tab/artifact-list-tab.component.scss
@@ -203,6 +203,24 @@
   width: 75%;
 }
 
+.tag-cell-content {
+  display: flex;
+  align-items: center;
+  width: 100%;
+  min-width: 0;
+}
+
+.tag-cell-text {
+  flex: 1 1 auto;
+  width: auto;
+  min-width: 0;
+}
+
+.tag-copy-command {
+  flex: 0 0 auto;
+  margin-left: 4px;
+}
+
 .action-bar {
   display: flex;
   align-items: center;

--- a/src/portal/src/app/base/project/repository/artifact/artifact-list-page/artifact-list/artifact-list-tab/pull-command/pull-command.component.spec.ts
+++ b/src/portal/src/app/base/project/repository/artifact/artifact-list-page/artifact-list/artifact-list-tab/pull-command/pull-command.component.spec.ts
@@ -160,6 +160,24 @@ describe('PullCommandComponent', () => {
         expect(cmd).not.toContain('v1.0.0');
     });
 
+    it('should generate tag mode pull command when artifact tag list is loaded separately', () => {
+        component.isTagMode = true;
+        component.registryUrl = 'myregistry.io';
+        component.projectName = 'library';
+        component.repoName = 'registry';
+        component.selectedTag = 'latest';
+        component.artifact = {
+            type: ArtifactType.IMAGE,
+            digest: 'sha256@digest',
+            tags: undefined,
+        };
+        fixture.detectChanges();
+
+        const cmd = component.getPullCommandForRuntimeByTag(component.artifact);
+        expect(cmd).toContain('latest');
+        expect(cmd).toContain('myregistry.io/library/registry');
+    });
+
     it('should return true for hasPullCommandForTag with IMAGE type', () => {
         component.artifact = {
             type: ArtifactType.IMAGE,

--- a/src/portal/src/app/base/project/repository/artifact/artifact-list-page/artifact-list/artifact-list-tab/pull-command/pull-command.component.ts
+++ b/src/portal/src/app/base/project/repository/artifact/artifact-list-page/artifact-list/artifact-list-tab/pull-command/pull-command.component.ts
@@ -141,8 +141,7 @@ export class PullCommandComponent {
     }
 
     getPullCommandForRuntimeByTag(artifact: Artifact): string {
-        // early return if artifact has no tags
-        if (!this.isArtifactTagValid(artifact)) {
+        if (!this.isSelectedTagValid()) {
             return '';
         }
         return getPullCommandByTag(
@@ -156,8 +155,7 @@ export class PullCommandComponent {
     }
 
     getPullCommandForCNABByTag(artifact: Artifact): string {
-        // early return if artifact has no tags
-        if (!this.isArtifactTagValid(artifact)) {
+        if (!this.isSelectedTagValid()) {
             return '';
         }
         return getPullCommandByTag(
@@ -171,8 +169,7 @@ export class PullCommandComponent {
     }
 
     getPullCommandForChartByTag(artifact: Artifact): string {
-        // early return if artifact has no tags
-        if (!this.isArtifactTagValid(artifact)) {
+        if (!this.isSelectedTagValid()) {
             return '';
         }
         return getPullCommandByTag(
@@ -193,6 +190,10 @@ export class PullCommandComponent {
             artifact.tags.length > 0 &&
             typeof artifact.tags[0]?.name === 'string'
         );
+    }
+
+    private isSelectedTagValid(): boolean {
+        return typeof this.selectedTag === 'string' && this.selectedTag !== '';
     }
 
     onCpSuccess(copied: string): void {

--- a/src/portal/src/app/base/project/repository/artifact/artifact-summary.component.html
+++ b/src/portal/src/app/base/project/repository/artifact/artifact-summary.component.html
@@ -3,9 +3,9 @@
     <a class="pl-0" (click)="goBackPro()">{{
         'SIDE_NAV.PROJECTS' | translate
     }}</a>
-    <span class="back-icon"><</span>
+    <span class="back-icon">&lt;</span>
     <a (click)="goBackRep()">{{ projectName }}</a>
-    <span class="back-icon"><</span>
+    <span class="back-icon">&lt;</span>
     <a (click)="goBack()">{{ repositoryName }}</a>
 
     <span

--- a/src/portal/src/app/base/project/repository/repository-gridview.component.html
+++ b/src/portal/src/app/base/project/repository/repository-gridview.component.html
@@ -101,7 +101,10 @@
                 }}</clr-dg-placeholder>
                 <clr-dg-row *ngFor="let r of repositories" [clrDgItem]="r">
                     <clr-dg-cell>
-                        <a href="javascript:void(0)" [routerLink]="getLink(r)">
+                        <a
+                            href="javascript:void(0)"
+                            [routerLink]="getLink(r)"
+                            [queryParams]="getQueryParams()">
                             <span *ngIf="withAdmiral" class="list-img"
                                 ><img [src]="getImgLink(r)" /></span
                             >{{ r.name }}</a
@@ -151,7 +154,10 @@
         [withAdmiral]="withAdmiral"
         (loadNextPageEvent)="loadNextPage()">
         <ng-template let-item="item">
-            <a class="card clickable" [routerLink]="getLink(item)">
+            <a
+                class="card clickable"
+                [routerLink]="getLink(item)"
+                [queryParams]="getQueryParams()">
                 <div class="card-header">
                     <div
                         [ngClass]="{

--- a/src/portal/src/app/base/project/repository/repository-gridview.component.ts
+++ b/src/portal/src/app/base/project/repository/repository-gridview.component.ts
@@ -84,6 +84,7 @@ import {
     EventService,
     HarborEvent,
 } from '../../../services/event-service/event.service';
+import { UN_LOGGED_PARAM, YES } from '../../../account/sign-in/sign-in.service';
 
 @Component({
     selector: 'hbr-repository-gridview',
@@ -173,6 +174,13 @@ export class RepositoryGridviewComponent
             'repositories',
             repoEvt.name.substr(this.projectName.length + 1),
         ];
+    }
+
+    getQueryParams() {
+        if (this.session.getCurrentUser()) {
+            return null;
+        }
+        return { [UN_LOGGED_PARAM]: YES };
     }
 
     ngOnChanges(changes: SimpleChanges): void {
@@ -572,6 +580,15 @@ export class RepositoryGridviewComponent
     }
 
     getHelmChartVersionPermission(projectId: number): void {
+        if (
+            !this.hasSignedIn &&
+            this.route.snapshot.queryParams[UN_LOGGED_PARAM] === YES
+        ) {
+            this.hasCreateRepositoryPermission = false;
+            this.hasDeleteRepositoryPermission = false;
+            return;
+        }
+
         let hasCreateRepositoryPermission =
             this.userPermissionService.getPermission(
                 this.projectId,

--- a/src/portal/src/app/shared/components/list-project-ro/list-project-ro.component.html
+++ b/src/portal/src/app/shared/components/list-project-ro/list-project-ro.component.html
@@ -8,6 +8,7 @@
             ><a
                 href="javascript:void(0)"
                 [routerLink]="getLink(p.project_id)"
+                [queryParams]="getQueryParams()"
                 >{{ p.name }}</a
             ></clr-dg-cell
         >

--- a/src/portal/src/app/shared/components/list-project-ro/list-project-ro.component.ts
+++ b/src/portal/src/app/shared/components/list-project-ro/list-project-ro.component.ts
@@ -13,6 +13,8 @@
 // limitations under the License.
 import { ChangeDetectionStrategy, Component, Input } from '@angular/core';
 import { Project } from '../../../../../ng-swagger-gen/models/project';
+import { UN_LOGGED_PARAM, YES } from '../../../account/sign-in/sign-in.service';
+import { SessionService } from '../../services/session.service';
 
 @Component({
     selector: 'list-project-ro',
@@ -22,9 +24,16 @@ import { Project } from '../../../../../ng-swagger-gen/models/project';
 export class ListProjectROComponent {
     @Input() projects: Project[];
 
-    constructor() {}
+    constructor(private sessionService: SessionService) {}
 
     getLink(proId: number) {
         return `/harbor/projects/${proId}/repositories`;
+    }
+
+    getQueryParams() {
+        if (this.sessionService.getCurrentUser()) {
+            return null;
+        }
+        return { [UN_LOGGED_PARAM]: YES };
     }
 }

--- a/src/portal/src/app/shared/router-guard/auth-user-activate.service.spec.ts
+++ b/src/portal/src/app/shared/router-guard/auth-user-activate.service.spec.ts
@@ -65,6 +65,7 @@ describe('AuthCheckGuard', () => {
         guard = TestBed.inject(AuthCheckGuard);
         router = TestBed.inject(Router);
         spyOn(router, 'navigate');
+        spyOn(router, 'navigateByUrl');
     });
 
     it('should be created', () => {
@@ -124,7 +125,7 @@ describe('AuthCheckGuard', () => {
             });
         });
 
-        it('should fall back to sign-in when already on /harbor/projects to prevent redirect loop', (done) => {
+        it('should allow public projects route when already on /harbor/projects', (done) => {
             appConfigService.getConfig.and.returnValue(createAppConfig({
                 unauthenticated_landing_page: LANDING_PAGE.PUBLIC_PROJECTS,
             }));
@@ -135,12 +136,40 @@ describe('AuthCheckGuard', () => {
             const result = guard.canActivate(route, state);
             (result as Observable<boolean>).subscribe(canActivate => {
                 expect(canActivate).toBeFalse();
-                expect(router.navigate).toHaveBeenCalledWith(
-                    [CommonRoutes.EMBEDDED_SIGN_IN],
-                    jasmine.objectContaining({
-                        queryParams: { redirect_url: CommonRoutes.HARBOR_DEFAULT },
-                    })
+                const urlTree = (router.navigateByUrl as jasmine.Spy).calls
+                    .mostRecent()
+                    .args[0];
+                expect(router.serializeUrl(urlTree)).toBe(
+                    `${CommonRoutes.HARBOR_DEFAULT}?${UN_LOGGED_PARAM}=${YES}`
                 );
+                expect(router.navigate).not.toHaveBeenCalled();
+                done();
+            });
+        });
+
+        it('should preserve public project repository route for unauthenticated access', (done) => {
+            appConfigService.getConfig.and.returnValue(createAppConfig({
+                unauthenticated_landing_page: LANDING_PAGE.PUBLIC_PROJECTS,
+            }));
+
+            const route = createRouteSnapshot();
+            const state = createStateSnapshot(
+                '/harbor/projects/123/repositories/library%2Fnginx/artifacts-tab'
+            );
+
+            const result = guard.canActivate(route, state);
+            (result as Observable<boolean>).subscribe(canActivate => {
+                expect(canActivate).toBeFalse();
+                const urlTree = (router.navigateByUrl as jasmine.Spy).calls
+                    .mostRecent()
+                    .args[0];
+                const expectedUrl =
+                    '/harbor/projects/123/repositories/library%2Fnginx/artifacts-tab' +
+                    '?publicAndNotLogged=yes';
+                expect(router.serializeUrl(urlTree)).toBe(
+                    expectedUrl
+                );
+                expect(router.navigate).not.toHaveBeenCalled();
                 done();
             });
         });

--- a/src/portal/src/app/shared/router-guard/auth-user-activate.service.ts
+++ b/src/portal/src/app/shared/router-guard/auth-user-activate.service.ts
@@ -81,11 +81,23 @@ export class AuthCheckGuard {
                             if (
                                 config &&
                                 config.unauthenticated_landing_page ===
-                                    LANDING_PAGE.PUBLIC_PROJECTS &&
-                                !state.url.startsWith(
-                                    CommonRoutes.HARBOR_DEFAULT
-                                )
+                                    LANDING_PAGE.PUBLIC_PROJECTS
                             ) {
+                                if (
+                                    state.url.startsWith(
+                                        CommonRoutes.HARBOR_DEFAULT
+                                    )
+                                ) {
+                                    const urlTree = this.router.parseUrl(
+                                        state.url
+                                    );
+                                    urlTree.queryParams = {
+                                        ...urlTree.queryParams,
+                                        [UN_LOGGED_PARAM]: YES,
+                                    };
+                                    this.router.navigateByUrl(urlTree);
+                                    return observer.next(false);
+                                }
                                 this.router.navigate(
                                     [CommonRoutes.HARBOR_DEFAULT],
                                     {

--- a/src/portal/src/app/shared/router-guard/member-guard-activate.service.spec.ts
+++ b/src/portal/src/app/shared/router-guard/member-guard-activate.service.spec.ts
@@ -16,23 +16,91 @@ import { RouterTestingModule } from '@angular/router/testing';
 import { SessionService } from '../services/session.service';
 import { MemberGuard } from './member-guard-activate.service';
 import { ProjectService } from '../services';
+import { Router } from '@angular/router';
+import { Observable, of, throwError } from 'rxjs';
+import { CommonRoutes } from '../entities/shared.const';
+import { UN_LOGGED_PARAM, YES } from '../../account/sign-in/sign-in.service';
 
 describe('MemberGuard', () => {
-    const fakeSessionService = null;
-    const fakeProjectService = null;
+    let sessionService: jasmine.SpyObj<SessionService>;
+    let projectService: jasmine.SpyObj<ProjectService>;
+    let router: Router;
 
     beforeEach(() => {
+        sessionService = jasmine.createSpyObj('SessionService', [
+            'clear',
+            'getCurrentUser',
+            'retrieveUser',
+            'setProjectMembers',
+        ]);
+        projectService = jasmine.createSpyObj('ProjectService', [
+            'getProjectFromCache',
+        ]);
         TestBed.configureTestingModule({
             imports: [RouterTestingModule],
             providers: [
                 MemberGuard,
-                { provide: SessionService, useValue: fakeSessionService },
-                { provide: ProjectService, useValue: fakeProjectService },
+                { provide: SessionService, useValue: sessionService },
+                { provide: ProjectService, useValue: projectService },
             ],
         });
+        router = TestBed.inject(Router);
+        spyOn(router, 'navigate');
     });
 
     it('should ...', inject([MemberGuard], (guard: MemberGuard) => {
         expect(guard).toBeTruthy();
     }));
+
+    it('should open public project route without retrieving user session', inject(
+        [MemberGuard],
+        (guard: MemberGuard) => {
+            sessionService.getCurrentUser.and.returnValue(null);
+            projectService.getProjectFromCache.and.returnValue(
+                of({ project_id: 1, name: 'library' } as any)
+            );
+
+            const result = guard.canActivate(
+                {
+                    params: { id: 1 },
+                    queryParams: { [UN_LOGGED_PARAM]: YES },
+                } as any,
+                {
+                    url: `/harbor/projects/1/repositories?${UN_LOGGED_PARAM}=${YES}`,
+                } as any
+            ) as Observable<boolean>;
+
+            result.subscribe(canActivate => {
+                expect(canActivate).toBeTrue();
+                expect(sessionService.retrieveUser).not.toHaveBeenCalled();
+                expect(projectService.getProjectFromCache).toHaveBeenCalledWith(
+                    1
+                );
+                expect(router.navigate).not.toHaveBeenCalled();
+            });
+        }
+    ));
+
+    it('should redirect anonymous non-public route to projects when session retrieval fails', inject(
+        [MemberGuard],
+        (guard: MemberGuard) => {
+            sessionService.getCurrentUser.and.returnValue(null);
+            sessionService.retrieveUser.and.returnValue(
+                throwError(() => ({ status: 401 }))
+            );
+
+            const result = guard.canActivate(
+                { params: { id: 1 }, queryParams: {} } as any,
+                { url: '/harbor/projects/1/repositories' } as any
+            ) as Observable<boolean>;
+
+            result.subscribe(canActivate => {
+                expect(canActivate).toBeFalse();
+                expect(projectService.getProjectFromCache).not.toHaveBeenCalled();
+                expect(router.navigate).toHaveBeenCalledWith([
+                    CommonRoutes.HARBOR_DEFAULT,
+                ]);
+            });
+        }
+    ));
 });

--- a/src/portal/src/app/shared/router-guard/member-guard-activate.service.spec.ts
+++ b/src/portal/src/app/shared/router-guard/member-guard-activate.service.spec.ts
@@ -52,10 +52,11 @@ describe('MemberGuard', () => {
         expect(guard).toBeTruthy();
     }));
 
-    it('should open public project route without retrieving user session', inject(
+    it('should retrieve user session before opening public project route', inject(
         [MemberGuard],
         (guard: MemberGuard) => {
             sessionService.getCurrentUser.and.returnValue(null);
+            sessionService.retrieveUser.and.returnValue(of({} as any));
             projectService.getProjectFromCache.and.returnValue(
                 of({ project_id: 1, name: 'library' } as any)
             );
@@ -72,7 +73,39 @@ describe('MemberGuard', () => {
 
             result.subscribe(canActivate => {
                 expect(canActivate).toBeTrue();
-                expect(sessionService.retrieveUser).not.toHaveBeenCalled();
+                expect(sessionService.retrieveUser).toHaveBeenCalled();
+                expect(projectService.getProjectFromCache).toHaveBeenCalledWith(
+                    1
+                );
+                expect(router.navigate).not.toHaveBeenCalled();
+            });
+        }
+    ));
+
+    it('should fall back to public project route when user retrieval fails with public marker', inject(
+        [MemberGuard],
+        (guard: MemberGuard) => {
+            sessionService.getCurrentUser.and.returnValue(null);
+            sessionService.retrieveUser.and.returnValue(
+                throwError(() => ({ status: 401 }))
+            );
+            projectService.getProjectFromCache.and.returnValue(
+                of({ project_id: 1, name: 'library' } as any)
+            );
+
+            const result = guard.canActivate(
+                {
+                    params: { id: 1 },
+                    queryParams: { [UN_LOGGED_PARAM]: YES },
+                } as any,
+                {
+                    url: `/harbor/projects/1/repositories?${UN_LOGGED_PARAM}=${YES}`,
+                } as any
+            ) as Observable<boolean>;
+
+            result.subscribe(canActivate => {
+                expect(canActivate).toBeTrue();
+                expect(sessionService.retrieveUser).toHaveBeenCalled();
                 expect(projectService.getProjectFromCache).toHaveBeenCalledWith(
                     1
                 );

--- a/src/portal/src/app/shared/router-guard/member-guard-activate.service.ts
+++ b/src/portal/src/app/shared/router-guard/member-guard-activate.service.ts
@@ -19,7 +19,7 @@ import {
 } from '@angular/router';
 import { SessionService } from '../services/session.service';
 import { Observable, of } from 'rxjs';
-import { map, catchError } from 'rxjs/operators';
+import { map, catchError, switchMap } from 'rxjs/operators';
 import { ProjectService } from '../services';
 import { CommonRoutes } from '../entities/shared.const';
 import { HttpStatusCode } from '@angular/common/http';
@@ -48,17 +48,20 @@ export class MemberGuard {
             return this.hasProjectPerm(state.url, projectId, route);
         }
 
-        if (route.queryParams[UN_LOGGED_PARAM] === YES) {
-            return this.hasProjectPerm(state.url, projectId, route);
-        }
-
         return this.sessionService.retrieveUser().pipe(
-            () => {
-                return this.hasProjectPerm(state.url, projectId, route);
-            },
-            catchError(err => {
+            map(() => true),
+            catchError(() => {
+                if (route.queryParams[UN_LOGGED_PARAM] === YES) {
+                    return of(true);
+                }
                 this.router.navigate([CommonRoutes.HARBOR_DEFAULT]);
                 return of(false);
+            }),
+            switchMap(canCheckProject => {
+                if (!canCheckProject) {
+                    return of(false);
+                }
+                return this.hasProjectPerm(state.url, projectId, route);
             })
         );
     }
@@ -82,9 +85,12 @@ export class MemberGuard {
             }),
             catchError(err => {
                 // User session timed out, then redirect to sign-in page
+                const isAnonymousPublicRoute =
+                    route.queryParams[UN_LOGGED_PARAM] === YES &&
+                    this.sessionService.getCurrentUser() === null;
                 if (
                     err.status === HttpStatusCode.Unauthorized &&
-                    route.queryParams[UN_LOGGED_PARAM] !== YES
+                    !isAnonymousPublicRoute
                 ) {
                     this.sessionService.clear(); // because of SignInGuard, must clear user session before navigating to sign-in page
                     this.router.navigate([CommonRoutes.EMBEDDED_SIGN_IN], {

--- a/src/portal/src/app/shared/router-guard/member-guard-activate.service.ts
+++ b/src/portal/src/app/shared/router-guard/member-guard-activate.service.ts
@@ -48,6 +48,10 @@ export class MemberGuard {
             return this.hasProjectPerm(state.url, projectId, route);
         }
 
+        if (route.queryParams[UN_LOGGED_PARAM] === YES) {
+            return this.hasProjectPerm(state.url, projectId, route);
+        }
+
         return this.sessionService.retrieveUser().pipe(
             () => {
                 return this.hasProjectPerm(state.url, projectId, route);

--- a/src/portal/src/app/shared/router-guard/member-permission-guard-activate.service.spec.ts
+++ b/src/portal/src/app/shared/router-guard/member-permission-guard-activate.service.spec.ts
@@ -11,37 +11,130 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-import { TestBed, inject } from '@angular/core/testing';
+import { TestBed } from '@angular/core/testing';
+import { Router } from '@angular/router';
 import { RouterTestingModule } from '@angular/router/testing';
-import { MemberPermissionGuard } from './member-permission-guard-activate.service';
-import { of } from 'rxjs';
+import { Observable, of, throwError } from 'rxjs';
+import { UN_LOGGED_PARAM, YES } from '../../account/sign-in/sign-in.service';
+import { CommonRoutes } from '../entities/shared.const';
+import { UserPermissionService, USERSTATICPERMISSION } from '../services';
 import { ErrorHandler } from '../units/error-handler';
-import { UserPermissionService } from '../services';
+import { MemberPermissionGuard } from './member-permission-guard-activate.service';
 
 describe('MemberPermissionGuardActivateServiceGuard', () => {
-    const fakeUserPermissionService = {
-        getPermission() {
-            return of(true);
-        },
+    let guard: MemberPermissionGuard;
+    let router: Router;
+    let errorHandler: jasmine.SpyObj<ErrorHandler>;
+    let userPermissionService: jasmine.SpyObj<UserPermissionService>;
+
+    const repositoryListPermission = {
+        resource: USERSTATICPERMISSION.REPOSITORY.KEY,
+        action: USERSTATICPERMISSION.REPOSITORY.VALUE.LIST,
     };
+    const memberListPermission = {
+        resource: USERSTATICPERMISSION.MEMBER.KEY,
+        action: USERSTATICPERMISSION.MEMBER.VALUE.LIST,
+    };
+
     beforeEach(() => {
+        errorHandler = jasmine.createSpyObj('ErrorHandler', ['error']);
+        userPermissionService = jasmine.createSpyObj('UserPermissionService', [
+            'getPermission',
+        ]);
         TestBed.configureTestingModule({
             imports: [RouterTestingModule],
             providers: [
-                ErrorHandler,
                 MemberPermissionGuard,
                 {
+                    provide: ErrorHandler,
+                    useValue: errorHandler,
+                },
+                {
                     provide: UserPermissionService,
-                    useValue: fakeUserPermissionService,
+                    useValue: userPermissionService,
                 },
             ],
         });
+        guard = TestBed.inject(MemberPermissionGuard);
+        router = TestBed.inject(Router);
+        spyOn(router, 'navigate');
     });
 
-    it('should ...', inject(
-        [MemberPermissionGuard],
-        (guard: MemberPermissionGuard) => {
-            expect(guard).toBeTruthy();
-        }
-    ));
+    it('should be created', () => {
+        expect(guard).toBeTruthy();
+    });
+
+    it('should check backend permissions for normal project routes', done => {
+        userPermissionService.getPermission.and.returnValue(of(true));
+
+        const result = guard.canActivate(
+            createRoute(repositoryListPermission),
+            {} as any
+        ) as Observable<boolean>;
+
+        result.subscribe(canActivate => {
+            expect(canActivate).toBeTrue();
+            expect(userPermissionService.getPermission).toHaveBeenCalledWith(
+                1,
+                USERSTATICPERMISSION.REPOSITORY.KEY,
+                USERSTATICPERMISSION.REPOSITORY.VALUE.LIST
+            );
+            expect(router.navigate).not.toHaveBeenCalled();
+            done();
+        });
+    });
+
+    it('should allow public anonymous repository list permission without backend permission check', () => {
+        const result = guard.canActivate(
+            createRoute(repositoryListPermission, { [UN_LOGGED_PARAM]: YES }),
+            {} as any
+        );
+
+        expect(result).toBeTrue();
+        expect(userPermissionService.getPermission).not.toHaveBeenCalled();
+        expect(router.navigate).not.toHaveBeenCalled();
+    });
+
+    it('should block public anonymous non-read permissions', () => {
+        const result = guard.canActivate(
+            createRoute(memberListPermission, { [UN_LOGGED_PARAM]: YES }),
+            {} as any
+        );
+
+        expect(result).toBeFalse();
+        expect(userPermissionService.getPermission).not.toHaveBeenCalled();
+        expect(router.navigate).toHaveBeenCalledWith(
+            [CommonRoutes.HARBOR_DEFAULT],
+            { queryParams: { [UN_LOGGED_PARAM]: YES } }
+        );
+    });
+
+    it('should redirect when backend permission check fails', done => {
+        const error = { status: 401 };
+        userPermissionService.getPermission.and.returnValue(
+            throwError(() => error)
+        );
+
+        const result = guard.canActivate(
+            createRoute(repositoryListPermission),
+            {} as any
+        ) as Observable<boolean>;
+
+        result.subscribe(canActivate => {
+            expect(canActivate).toBeFalse();
+            expect(router.navigate).toHaveBeenCalledWith([
+                CommonRoutes.HARBOR_DEFAULT,
+            ]);
+            expect(errorHandler.error).toHaveBeenCalledWith(error);
+            done();
+        });
+    });
+
+    function createRoute(permission, queryParams = {}) {
+        return {
+            parent: { params: { id: 1 } },
+            data: { permissionParam: permission },
+            queryParams,
+        } as any;
+    }
 });

--- a/src/portal/src/app/shared/router-guard/member-permission-guard-activate.service.spec.ts
+++ b/src/portal/src/app/shared/router-guard/member-permission-guard-activate.service.spec.ts
@@ -18,6 +18,7 @@ import { Observable, of, throwError } from 'rxjs';
 import { UN_LOGGED_PARAM, YES } from '../../account/sign-in/sign-in.service';
 import { CommonRoutes } from '../entities/shared.const';
 import { UserPermissionService, USERSTATICPERMISSION } from '../services';
+import { SessionService } from '../services/session.service';
 import { ErrorHandler } from '../units/error-handler';
 import { MemberPermissionGuard } from './member-permission-guard-activate.service';
 
@@ -26,6 +27,7 @@ describe('MemberPermissionGuardActivateServiceGuard', () => {
     let router: Router;
     let errorHandler: jasmine.SpyObj<ErrorHandler>;
     let userPermissionService: jasmine.SpyObj<UserPermissionService>;
+    let sessionService: jasmine.SpyObj<SessionService>;
 
     const repositoryListPermission = {
         resource: USERSTATICPERMISSION.REPOSITORY.KEY,
@@ -41,6 +43,10 @@ describe('MemberPermissionGuardActivateServiceGuard', () => {
         userPermissionService = jasmine.createSpyObj('UserPermissionService', [
             'getPermission',
         ]);
+        sessionService = jasmine.createSpyObj('SessionService', [
+            'getCurrentUser',
+        ]);
+        sessionService.getCurrentUser.and.returnValue(null);
         TestBed.configureTestingModule({
             imports: [RouterTestingModule],
             providers: [
@@ -52,6 +58,10 @@ describe('MemberPermissionGuardActivateServiceGuard', () => {
                 {
                     provide: UserPermissionService,
                     useValue: userPermissionService,
+                },
+                {
+                    provide: SessionService,
+                    useValue: sessionService,
                 },
             ],
         });
@@ -107,6 +117,27 @@ describe('MemberPermissionGuardActivateServiceGuard', () => {
             [CommonRoutes.HARBOR_DEFAULT],
             { queryParams: { [UN_LOGGED_PARAM]: YES } }
         );
+    });
+
+    it('should check backend permissions for signed-in routes even with public marker', done => {
+        sessionService.getCurrentUser.and.returnValue({} as any);
+        userPermissionService.getPermission.and.returnValue(of(true));
+
+        const result = guard.canActivate(
+            createRoute(memberListPermission, { [UN_LOGGED_PARAM]: YES }),
+            {} as any
+        ) as Observable<boolean>;
+
+        result.subscribe(canActivate => {
+            expect(canActivate).toBeTrue();
+            expect(userPermissionService.getPermission).toHaveBeenCalledWith(
+                1,
+                USERSTATICPERMISSION.MEMBER.KEY,
+                USERSTATICPERMISSION.MEMBER.VALUE.LIST
+            );
+            expect(router.navigate).not.toHaveBeenCalled();
+            done();
+        });
     });
 
     it('should redirect when backend permission check fails', done => {

--- a/src/portal/src/app/shared/router-guard/member-permission-guard-activate.service.ts
+++ b/src/portal/src/app/shared/router-guard/member-permission-guard-activate.service.ts
@@ -19,8 +19,13 @@ import {
 } from '@angular/router';
 import { Observable } from 'rxjs';
 import { ErrorHandler } from '../units/error-handler';
-import { UserPermissionService, UserPrivilegeServeItem } from '../services';
+import {
+    UserPermissionService,
+    UserPrivilegeServeItem,
+    USERSTATICPERMISSION,
+} from '../services';
 import { CommonRoutes } from '../entities/shared.const';
+import { UN_LOGGED_PARAM, YES } from '../../account/sign-in/sign-in.service';
 
 @Injectable({
     providedIn: 'root',
@@ -38,6 +43,15 @@ export class MemberPermissionGuard {
     ): Observable<boolean> | boolean {
         const projectId = route.parent.params['id'];
         const permission = route.data.permissionParam as UserPrivilegeServeItem;
+        if (route.queryParams[UN_LOGGED_PARAM] === YES) {
+            if (this.isPublicProjectPermission(permission)) {
+                return true;
+            }
+            this.router.navigate([CommonRoutes.HARBOR_DEFAULT], {
+                queryParams: { [UN_LOGGED_PARAM]: YES },
+            });
+            return false;
+        }
         return this.checkPermission(projectId, permission);
     }
 
@@ -72,5 +86,18 @@ export class MemberPermissionGuard {
                     },
                 });
         });
+    }
+
+    private isPublicProjectPermission(
+        permission: UserPrivilegeServeItem
+    ): boolean {
+        return (
+            (permission.resource === USERSTATICPERMISSION.PROJECT.KEY &&
+                permission.action ===
+                    USERSTATICPERMISSION.PROJECT.VALUE.READ) ||
+            (permission.resource === USERSTATICPERMISSION.REPOSITORY.KEY &&
+                permission.action ===
+                    USERSTATICPERMISSION.REPOSITORY.VALUE.LIST)
+        );
     }
 }

--- a/src/portal/src/app/shared/router-guard/member-permission-guard-activate.service.ts
+++ b/src/portal/src/app/shared/router-guard/member-permission-guard-activate.service.ts
@@ -26,6 +26,7 @@ import {
 } from '../services';
 import { CommonRoutes } from '../entities/shared.const';
 import { UN_LOGGED_PARAM, YES } from '../../account/sign-in/sign-in.service';
+import { SessionService } from '../services/session.service';
 
 @Injectable({
     providedIn: 'root',
@@ -34,7 +35,8 @@ export class MemberPermissionGuard {
     constructor(
         private router: Router,
         private errorHandler: ErrorHandler,
-        private userPermission: UserPermissionService
+        private userPermission: UserPermissionService,
+        private sessionService: SessionService
     ) {}
 
     canActivate(
@@ -43,7 +45,10 @@ export class MemberPermissionGuard {
     ): Observable<boolean> | boolean {
         const projectId = route.parent.params['id'];
         const permission = route.data.permissionParam as UserPrivilegeServeItem;
-        if (route.queryParams[UN_LOGGED_PARAM] === YES) {
+        if (
+            route.queryParams[UN_LOGGED_PARAM] === YES &&
+            this.sessionService.getCurrentUser() === null
+        ) {
             if (this.isPublicProjectPermission(permission)) {
                 return true;
             }

--- a/taskfile/dev.yml
+++ b/taskfile/dev.yml
@@ -35,6 +35,7 @@ vars:
   # Docker Compose profile strings (reused across multiple tasks)
   ALL_PROFILES: "--profile portal --profile core --profile jobservice --profile registryctl --profile trivy"
   APP_PROFILES: "--profile portal --profile core --profile jobservice --profile registryctl"
+  BACKEND_PROFILES: "--profile core --profile jobservice --profile registryctl"
 
 env:
   COMPOSE_PROJECT_NAME:   '{{.PROJECT_PREFIX}}'
@@ -147,7 +148,7 @@ tasks:
       echo ""
 
   # ---------------------------------------------------------------------------
-  # Full Development Environment (Containerized)
+  # Full Development Environment (backend containers + native Portal)
   # ---------------------------------------------------------------------------
   _codegen:
     internal: true
@@ -170,21 +171,35 @@ tasks:
       - task: :build:gen-apis:frontend
 
   up:
-    desc: "Start all services with hot reload in foreground (SKIP_TRIVY=true to exclude Trivy)"
+    desc: "Start backend containers and native Portal with hot reload (SKIP_TRIVY=true to exclude Trivy)"
     deps: [require-docker, require-ports, gen:private-key]
     vars:
       TRIVY_PROFILE: '{{if ne .SKIP_TRIVY "true"}}--profile trivy{{end}}'
     cmds:
-      - defer: { task: dev:down, vars: { SKIP_TRIVY: "{{.SKIP_TRIVY}}" } }
+      - defer: { task: down, vars: { SKIP_TRIVY: "{{.SKIP_TRIVY}}" } }
       - task: _codegen
       - task: info
-      - '{{.COMPOSE_CMD}} {{.APP_PROFILES}} {{.TRIVY_PROFILE}} up --build'
+      - '{{.COMPOSE_CMD}} {{.BACKEND_PROFILES}} {{.TRIVY_PROFILE}} up -d --build'
+      - task: _wait-core
+      - task: _frontend-serve
 
   down:
     desc: Stop and remove all dev environment containers
     vars:
       TRIVY_PROFILE: '{{if ne .SKIP_TRIVY "true"}}--profile trivy{{end}}'
-    cmd: '{{.COMPOSE_CMD}} {{.APP_PROFILES}} {{.TRIVY_PROFILE}} down'
+    cmds:
+      - task: _frontend-stop
+      - '{{.COMPOSE_CMD}} {{.BACKEND_PROFILES}} {{.TRIVY_PROFILE}} down'
+
+  _frontend-stop:
+    internal: true
+    silent: true
+    cmds:
+      - |
+        pid=$(ss -tlnpH "sport = :{{.PORT_PORTAL}}" 2>/dev/null | sed -n 's/.*pid=\([0-9]*\).*/\1/p' | head -1)
+        if [ -n "$pid" ] && ps -p "$pid" -o args= | grep -q "ng serve"; then
+          kill "$pid"
+        fi
 
   # ---------------------------------------------------------------------------
   # Infrastructure (Docker Compose)
@@ -244,6 +259,24 @@ tasks:
     desc: Restart Core, JobService, and RegistryCtl containers
     cmd: '{{.COMPOSE_CMD}} restart core jobservice registryctl'
 
+  _wait-core:
+    internal: true
+    silent: true
+    cmds:
+      - |
+        echo "Waiting for Core at http://localhost:{{.PORT_CORE}}..."
+        timeout=120
+        elapsed=0
+        until curl -fsS "http://localhost:{{.PORT_CORE}}/api/v2.0/ping" >/dev/null 2>&1; do
+          if [ "$elapsed" -ge "$timeout" ]; then
+            echo "Core did not become ready within ${timeout}s"
+            exit 1
+          fi
+          sleep 2
+          elapsed=$((elapsed + 2))
+        done
+        echo "Core ready"
+
   # ---------------------------------------------------------------------------
   # Frontend (Native - alternative to containerized portal)
   # ---------------------------------------------------------------------------
@@ -263,11 +296,17 @@ tasks:
   frontend:native:
     desc: Serve Portal with ng serve on host (alternative to containerized portal)
     silent: true
-    dir: src/portal
     deps: [frontend:install]
     cmds:
       - task: :build:gen-apis:frontend
-      - exec ./node_modules/.bin/ng serve --host 0.0.0.0 --hmr
+      - task: _frontend-serve
+
+  _frontend-serve:
+    internal: true
+    dir: src/portal
+    env:
+      HARBOR_PROXY_TARGET: 'http://localhost:{{.PORT_CORE}}'
+    cmd: exec node --max_old_space_size=2048 ./node_modules/@angular/cli/bin/ng serve --host 0.0.0.0 --port {{.PORT_PORTAL}} --hmr
 
   frontend:build:
     desc: Build Portal for production

--- a/taskfile/dev.yml
+++ b/taskfile/dev.yml
@@ -197,9 +197,14 @@ tasks:
     cmds:
       - |
         pid=$(ss -tlnpH "sport = :{{.PORT_PORTAL}}" 2>/dev/null | sed -n 's/.*pid=\([0-9]*\).*/\1/p' | head -1)
-        if [ -n "$pid" ] && ps -p "$pid" -o args= | grep -q "ng serve"; then
-          kill "$pid"
-        fi
+        args=$(ps -p "$pid" -o args= 2>/dev/null || true)
+        cwd=$(readlink "/proc/$pid/cwd" 2>/dev/null || true)
+        expected="./node_modules/@angular/cli/bin/ng serve --host 0.0.0.0 --port {{.PORT_PORTAL}} --hmr"
+        case "$args" in
+          *"$expected"*)
+            [ "$cwd" = "$PWD/src/portal" ] && kill "$pid"
+            ;;
+        esac
 
   # ---------------------------------------------------------------------------
   # Infrastructure (Docker Compose)
@@ -404,7 +409,7 @@ tasks:
     desc: Remove all containers, volumes, node_modules, and temp files
     cmds:
       - '{{.COMPOSE_CMD}} {{.ALL_PROFILES}} down -v'
-      - pkill -f "ng serve" || true
+      - task: _frontend-stop
       - rm -rf tmp/
       - rm -rf src/portal/node_modules
       - rm -f build-errors.log


### PR DESCRIPTION
## Summary
- Respect the public projects unauthenticated landing page setting for `/harbor/projects...` routes instead of redirecting to login.
- Preserve `publicAndNotLogged=yes` across public project, repository, and breadcrumb navigation.
- Keep anonymous public project/repository views read-only without calling signed-in permission APIs.
- Fix artifact tag copy actions so tag-table copy buttons use the selected tag row.
- Fix local `task dev:up` so Core is ready before the native portal starts and the portal proxy targets the running backend.

Closes https://github.com/container-registry/harbor-next/issues/180

## Testing
- `node ./node_modules/typescript/bin/tsc -p tsconfig.spec.json --noEmit`
- `node ./node_modules/@angular/cli/bin/ng build --aot`
- `task dev:up SKIP_TRIVY=true`
- `curl http://localhost:4200/api/v2.0/ping` returns `200`
- `curl http://localhost:4200/api/v2.0/systeminfo` returns `200`