### PR TITLE
chore: Update Issue Template Links

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -8,7 +8,7 @@ body:
       value: |
         Thanks for taking the time to fill out this bug report!
 
-        **Before submitting**, please search [existing issues](https://github.com/bupd/harbor-next-test-release/issues) to avoid duplicates.
+        **Before submitting**, please search [existing issues](https://github.com/container-registry/harbor-next/issues) to avoid duplicates.
 
   - type: textarea
     id: description

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -8,7 +8,7 @@ body:
       value: |
         Thanks for suggesting a feature!
 
-        **Before submitting**, please search [existing issues](https://github.com/bupd/harbor-next-test-release/issues) to check if it has already been requested.
+        **Before submitting**, please search [existing issues](https://github.com/container-registry/harbor-next/issues) to check if it has already been requested.
 
   - type: textarea
     id: problem


### PR DESCRIPTION
## Summary
- Update bug report and feature request issue-template links to point at `container-registry/harbor-next` issues.
- Remove stale `bupd/harbor-next-test-release` issue references.

## Verification
- Confirmed no `bupd` references remain in `.github/ISSUE_TEMPLATE`.
- Not run: test suite, link-only YAML template change.