### PR TITLE
ci: Remove Duplicate Security Advisory Link

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -4,6 +4,3 @@ contact_links:
   - name: GitHub Discussions
     url: https://github.com/container-registry/harbor-next/discussions
     about: Ask questions and discuss with the community
-  - name: Security Vulnerability
-    url: https://github.com/container-registry/harbor-next/security/advisories/new
-    about: Report Security Vulnerabilities privately


### PR DESCRIPTION
## Summary
- Remove the duplicate Security Vulnerability issue contact link now that GitHub Security Advisories are used directly.
- Keep GitHub Discussions as the only issue template contact link.

## Tests
- Not run; configuration-only change.