### PR TITLE
ci: Restore Security Advisory Link

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -4,3 +4,6 @@ contact_links:
   - name: GitHub Discussions
     url: https://github.com/container-registry/harbor-next/discussions
     about: Ask questions and discuss with the community
+  - name: Security Vulnerability
+    url: https://github.com/container-registry/harbor-next/security/advisories/new
+    about: Report Security Vulnerabilities privately


### PR DESCRIPTION
## Summary
- Restore the Security Vulnerability contact link in the issue template config.
- Reverts the removal from #192 because the GitHub Security Advisory link is the correct destination.

## Tests
- Not run; configuration-only change.