### PR TITLE
fix: Address Devenv Review Feedback

### DIFF
--- a/devenv/docker-compose.yml
+++ b/devenv/docker-compose.yml
@@ -19,7 +19,7 @@ services:
       retries: 15
       start_period: 5s
     volumes:
-      - harbor-postgres-18-data:/var/lib/postgresql
+      - harbor-postgres-18-data:/var/lib/postgresql/data
       - ../make/migrations:/migrations
 
   redis:

--- a/taskfile/dev.yml
+++ b/taskfile/dev.yml
@@ -200,7 +200,7 @@ tasks:
         pid=""
 
         if command -v lsof >/dev/null 2>&1; then
-          pid=$(lsof -nP -tiTCP:{{.PORT_PORTAL}} -sTCP:LISTEN 2>/dev/null | head -1)
+          pid=$(lsof -nP -t -iTCP:{{.PORT_PORTAL}} -sTCP:LISTEN 2>/dev/null | head -1)
         fi
         if [ -z "$pid" ] && command -v ss >/dev/null 2>&1; then
           pid=$(ss -tlnpH "sport = :{{.PORT_PORTAL}}" 2>/dev/null | sed -n 's/.*pid=\([0-9]*\).*/\1/p' | head -1)

--- a/taskfile/dev.yml
+++ b/taskfile/dev.yml
@@ -196,13 +196,32 @@ tasks:
     silent: true
     cmds:
       - |
-        pid=$(ss -tlnpH "sport = :{{.PORT_PORTAL}}" 2>/dev/null | sed -n 's/.*pid=\([0-9]*\).*/\1/p' | head -1)
-        args=$(ps -p "$pid" -o args= 2>/dev/null || true)
-        cwd=$(readlink "/proc/$pid/cwd" 2>/dev/null || true)
         expected="./node_modules/@angular/cli/bin/ng serve --host 0.0.0.0 --port {{.PORT_PORTAL}} --hmr"
+        pid=""
+
+        if command -v lsof >/dev/null 2>&1; then
+          pid=$(lsof -nP -tiTCP:{{.PORT_PORTAL}} -sTCP:LISTEN 2>/dev/null | head -1)
+        fi
+        if [ -z "$pid" ] && command -v ss >/dev/null 2>&1; then
+          pid=$(ss -tlnpH "sport = :{{.PORT_PORTAL}}" 2>/dev/null | sed -n 's/.*pid=\([0-9]*\).*/\1/p' | head -1)
+        fi
+
+        if [ -z "$pid" ]; then
+          exit 0
+        fi
+
+        args=$(ps -p "$pid" -o command= 2>/dev/null || ps -p "$pid" -o args= 2>/dev/null || true)
+        cwd=""
+        if [ -e "/proc/$pid/cwd" ]; then
+          cwd=$(readlink "/proc/$pid/cwd" 2>/dev/null || true)
+        elif command -v lsof >/dev/null 2>&1; then
+          cwd=$(lsof -a -p "$pid" -d cwd -Fn 2>/dev/null | sed -n 's/^n//p' | head -1)
+        fi
         case "$args" in
           *"$expected"*)
-            [ "$cwd" = "$PWD/src/portal" ] && kill "$pid"
+            if [ -z "$cwd" ] || [ "$cwd" = "$PWD/src/portal" ]; then
+              kill "$pid"
+            fi
             ;;
         esac
 


### PR DESCRIPTION
## Summary
- Persist the dev PostgreSQL named volume at the image PGDATA path.
- Make native Portal shutdown work on macOS by using lsof before Linux-specific ss/procfs fallbacks.

## Related Issues

## Type of Change
- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` / `fix!:`)
- [ ] Documentation (`docs:`)
- [ ] Refactoring (`refactor:`)
- [ ] CI/CD or build changes (`ci:` / `build:`)
- [ ] Dependencies update (`chore:`)
- [ ] Tests (`test:`)

## Release Notes

## Testing
- [ ] Unit tests added/updated
- [x] Manual testing performed

## Checklist
- [x] PR title follows Conventional Commits format
- [x] Commits are signed off (`git commit -s`)
- [x] No new warnings introduced

Manual testing: `git diff --check`; `task --list-all`.