### PR TITLE
fix: Restore Postgres 18 Volume Mount

### DIFF
--- a/devenv/docker-compose.yml
+++ b/devenv/docker-compose.yml
@@ -19,7 +19,7 @@ services:
       retries: 15
       start_period: 5s
     volumes:
-      - harbor-postgres-18-data:/var/lib/postgresql/data
+      - harbor-postgres-18-data:/var/lib/postgresql
       - ../make/migrations:/migrations
 
   redis:


### PR DESCRIPTION
## Summary
- Restore the dev Postgres named volume mount to `/var/lib/postgresql`, which is required by the official Postgres 18 image.
- Keep the portable frontend stop changes from the prior review fix.

## Related Issues
- Follow-up to #196

## Type of Change
- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` / `fix!:`)
- [ ] Documentation (`docs:`)
- [ ] Refactoring (`refactor:`)
- [ ] CI/CD or build changes (`ci:` / `build:`)
- [ ] Dependencies update (`chore:`)
- [ ] Tests (`test:`)

## Release Notes


## Testing
- [ ] Unit tests added/updated
- [x] Manual testing performed

Validated locally:
- `task --list-all >/dev/null`
- `git diff --check`

## Checklist
- [x] PR title follows Conventional Commits format
- [x] Commits are signed off (`git commit -s`)
- [x] No new warnings introduced