### PR TITLE
chore(devenv): Run docker check before key generation

### DIFF
--- a/taskfile/dev.yml
+++ b/taskfile/dev.yml
@@ -120,6 +120,7 @@ tasks:
 
   gen:private-key:
     desc: Generate RSA 4096 key for token signing (skipped if exists)
+    deps: [require-docker]
     status:
       - test -f {{.TOKEN_KEY_FILE}}
     cmds:


### PR DESCRIPTION
## Summary

- `gen:private-key` was a peer dependency of `dev:up` alongside `require-docker`, so Task ran them in parallel.
- When Docker was not running, openssl flooded stdout with RSA progress dots before the `Docker daemon is not running` precondition error surfaced — the actual failure ended up buried at the bottom of the output.
- Adding `require-docker` as a dependency of `gen:private-key` sequences the cheap precondition first, so it fails fast and the error is the first thing the user sees.

## Type of Change

- [x] Chore (maintenance, refactoring, etc.)

## Testing

- [x] `task dev:up` with Docker stopped now fails on the precondition without running openssl.
- [x] `task dev:up` with Docker running behaves identically (precondition passes, key generation runs as before).

## Checklist

- [x] PR title follows Conventional Commits format
- [x] Commit signed off (DCO)
- [x] No new warnings introduced