### PR TITLE
fix: Expand Global Search Input

### DIFF
--- a/src/portal/src/app/shared/components/global-search/search.component.scss
+++ b/src/portal/src/app/shared/components/global-search/search.component.scss
@@ -29,6 +29,20 @@
     position: relative !important;
 }
 
+:host {
+    display: block;
+    flex: 1 1 24rem;
+    max-width: 28rem;
+    min-width: 0;
+}
+
+.search {
+    display: flex;
+    align-items: center;
+    max-width: none;
+    width: 100%;
+}
+
 .search-spinner {
     top: 50%;
     left: 50%;
@@ -53,11 +67,17 @@
 .search::before {
     content: '';
     display: inline-block;
+    flex: 0 0 auto;
     background: #fafafa;
     opacity: .15;
     height: 40px;
     width: 1px;
     top: 10px;
+}
+
+.search label {
+    flex: 1 1 auto;
+    min-width: 0;
 }
 
 #results {
@@ -71,6 +91,7 @@
 
 .search-input {
     outline: none;
+    width: 100%;
 }
 
 .search-input::placeholder{


### PR DESCRIPTION
## Summary
- Expands the navbar global search layout so the 8gears registry placeholder fits when space is available.
- Removes the Clarity form width cap and lets the input stretch within the header flex layout.

## Testing
- bun run lint:style -- \"src/app/shared/components/global-search/search.component.scss\"
- Playwright browser measurement at 1280x720 confirmed placeholder width 231px fits within 500px input width.