### PR TITLE
fix: Add Dockerfile Healthchecks

### DIFF
--- a/devenv/docker-compose.yml
+++ b/devenv/docker-compose.yml
@@ -57,11 +57,13 @@ services:
         GO_VERSION: ${GO_VERSION}
         AIR_VERSION: ${AIR_VERSION}
         DELVE_VERSION: ${DELVE_VERSION}
+        DEV_UID: ${DEV_UID:-1000}
+        DEV_GID: ${DEV_GID:-1000}
     profiles: [core]
     volumes:
       - ..:/app
       - ${HOST_GOMODCACHE:?}:/go/pkg/mod
-      - ${HOST_GOCACHE:?}:/root/.cache/go-build
+      - ${HOST_GOCACHE:?}:/home/harbor/.cache/go-build
       # Mount views directly to where beego expects them (avoids symlink leaking to host)
       - ../src/core/views:/app/views:ro
     ports:
@@ -101,6 +103,8 @@ services:
       # Trivy scanner
       TRIVY_ADAPTER_URL: http://trivy-adapter:8080
       WITH_TRIVY: "true"
+      HEALTHCHECK_PORT: "8080"
+      HEALTHCHECK_ENDPOINT: /api/v2.0/ping
       # Proxy cache and replication
       PERMITTED_REGISTRY_TYPES_FOR_PROXY_CACHE: docker-hub,harbor,azure-acr,ali-acr,aws-ecr,google-gcr,docker-registry,github-ghcr,jfrog-artifactory
       REPLICATION_ADAPTER_WHITELIST: ali-acr,aws-ecr,azure-acr,docker-hub,docker-registry,github-ghcr,google-gcr,harbor,huawei-SWR,jfrog-artifactory,tencent-tcr,volcengine-cr
@@ -121,7 +125,7 @@ services:
     volumes:
       - ..:/app
       - ${HOST_GOMODCACHE:?}:/go/pkg/mod
-      - ${HOST_GOCACHE:?}:/root/.cache/go-build
+      - ${HOST_GOCACHE:?}:/home/harbor/.cache/go-build
     # ports:
     #   - "8888:8888"  # JobService API (uncomment if needed)
     #   - "127.0.0.1:2346:2346"  # Debug port (uncomment if needed)
@@ -146,6 +150,8 @@ services:
       REGISTRY_CREDENTIAL_PASSWORD: ""
       TOKEN_SERVICE_URL: http://core:8080/service/token
       LOG_LEVEL: debug
+      HEALTHCHECK_PORT: "8888"
+      HEALTHCHECK_ENDPOINT: /api/v1/stats
     command: air -c devenv/air.jobservice.toml
     depends_on:
       - core
@@ -157,7 +163,7 @@ services:
     volumes:
       - ..:/app
       - ${HOST_GOMODCACHE:?}:/go/pkg/mod
-      - ${HOST_GOCACHE:?}:/root/.cache/go-build
+      - ${HOST_GOCACHE:?}:/home/harbor/.cache/go-build
       - harbor-registry-data:/var/lib/registry
       - ../config/registry.yml:/etc/registry/config.yml:ro
     ports:
@@ -169,6 +175,8 @@ services:
       REGISTRY_CONFIG: /etc/registry/config.yml
       CORE_SECRET: devenv-secret-do-not-use-in-production
       JOBSERVICE_SECRET: devenv-secret-do-not-use-in-production
+      HEALTHCHECK_PORT: "8080"
+      HEALTHCHECK_ENDPOINT: /api/health
     command: air -c devenv/air.registryctl.toml
     depends_on:
       - registry

--- a/dockerfile/core.dockerfile
+++ b/dockerfile/core.dockerfile
@@ -17,5 +17,6 @@ COPY icons /icons
 COPY src/core/views /views
 WORKDIR /
 EXPOSE 8080
+HEALTHCHECK --interval=10s --timeout=5s --start-period=30s --retries=5 CMD ["/lprobe", "-port", "8080", "-endpoint", "/api/v2.0/ping"]
 USER harbor
 ENTRYPOINT ["/core"]

--- a/dockerfile/dev.core.dockerfile
+++ b/dockerfile/dev.core.dockerfile
@@ -6,6 +6,8 @@ FROM golang:${GO_VERSION}-alpine
 
 ARG AIR_VERSION
 ARG DELVE_VERSION
+ARG DEV_UID=1000
+ARG DEV_GID=1000
 
 # Install git (required by go modules)
 RUN apk add --no-cache git
@@ -14,7 +16,16 @@ RUN apk add --no-cache git
 RUN go install github.com/air-verse/air@${AIR_VERSION} && \
     go install github.com/go-delve/delve/cmd/dlv@${DELVE_VERSION}
 
+RUN addgroup -S -g ${DEV_GID} harbor && \
+    adduser -S -D -G harbor -u ${DEV_UID} harbor && \
+    mkdir -p /home/harbor/.cache/go-build && \
+    chown -R harbor:harbor /home/harbor
+
+ENV HOME=/home/harbor
+
 WORKDIR /app
 
 # Default command - can be overridden in docker-compose
+HEALTHCHECK --interval=10s --timeout=5s --start-period=30s --retries=5 CMD wget -q -O /dev/null "http://127.0.0.1:${HEALTHCHECK_PORT:-8080}${HEALTHCHECK_ENDPOINT:-/api/v2.0/ping}" || exit 1
+USER harbor
 CMD ["air"]

--- a/dockerfile/dev.portal.dockerfile
+++ b/dockerfile/dev.portal.dockerfile
@@ -15,4 +15,6 @@ RUN bun install --ignore-scripts
 
 WORKDIR /app
 COPY src/portal/scripts/dev-portal-start.js /app/scripts/dev-portal-start.js
+HEALTHCHECK --interval=10s --timeout=5s --retries=5 CMD wget -q -O /dev/null http://127.0.0.1:4200 || exit 1
+USER bun
 CMD ["bun", "/app/scripts/dev-portal-start.js"]

--- a/dockerfile/dev.trivy-adapter.dockerfile
+++ b/dockerfile/dev.trivy-adapter.dockerfile
@@ -36,6 +36,7 @@ WORKDIR /
 
 EXPOSE 8080
 EXPOSE 8443
+HEALTHCHECK --interval=10s --timeout=5s --retries=5 CMD ["/lprobe", "-port", "8080", "-endpoint", "/probe/ready"]
 
 USER scanner
 ENTRYPOINT ["/home/scanner/bin/scanner-trivy"]

--- a/dockerfile/exporter.dockerfile
+++ b/dockerfile/exporter.dockerfile
@@ -18,5 +18,6 @@ LABEL org.opencontainers.image.revision=${git_commit}
 COPY bin/linux-${TARGETARCH}/harbor-exporter /harbor-exporter
 WORKDIR /
 EXPOSE 8080
+HEALTHCHECK --interval=10s --timeout=5s --retries=5 CMD ["/lprobe", "-port", "8080", "-endpoint", "/metrics"]
 USER harbor
 ENTRYPOINT ["/harbor-exporter"]

--- a/dockerfile/jobservice.dockerfile
+++ b/dockerfile/jobservice.dockerfile
@@ -14,5 +14,6 @@ ARG TARGETARCH
 COPY bin/linux-${TARGETARCH}/jobservice /jobservice
 WORKDIR /
 EXPOSE 8888
+HEALTHCHECK --interval=10s --timeout=5s --retries=5 CMD ["/lprobe", "-port", "8888", "-endpoint", "/api/v1/stats"]
 USER harbor
 ENTRYPOINT ["/jobservice", "-c", "/etc/jobservice/config.yml"]

--- a/dockerfile/portal.dockerfile
+++ b/dockerfile/portal.dockerfile
@@ -18,7 +18,8 @@ RUN bun run postinstall && \
     bun run generate-build-timestamp && \
     node --max_old_space_size=2048 node_modules/@angular/cli/bin/ng build --configuration production
 COPY LICENSE ./dist/LICENSE
-RUN cd app-swagger-ui && bun install --ignore-scripts && bun run build
+WORKDIR /harbor/src/portal/app-swagger-ui
+RUN bun install --ignore-scripts && bun run build
 
 #
 # RUNTIME
@@ -32,4 +33,6 @@ COPY config/portal/nginx.conf /etc/nginx/nginx.conf
 WORKDIR /usr/share/nginx/html
 
 EXPOSE 8080
+HEALTHCHECK --interval=10s --timeout=5s --retries=3 CMD ["/lprobe", "-port", "8080"]
+USER nginx
 ENTRYPOINT ["nginx", "-g", "daemon off;"]

--- a/dockerfile/registry.dockerfile
+++ b/dockerfile/registry.dockerfile
@@ -26,6 +26,7 @@ VOLUME /var/lib/registry
 
 EXPOSE 5000
 EXPOSE 5443
+HEALTHCHECK --interval=5s --timeout=3s --retries=5 CMD ["/lprobe", "-port", "5001", "-endpoint", "/debug/health"]
 
 USER harbor
 ENTRYPOINT ["/usr/bin/registry_DO_NOT_USE_GC", "serve", "/etc/registry/config.yml"]

--- a/dockerfile/registryctl.dockerfile
+++ b/dockerfile/registryctl.dockerfile
@@ -14,5 +14,6 @@ ARG TARGETARCH
 COPY bin/linux-${TARGETARCH}/registryctl /registryctl
 WORKDIR /
 EXPOSE 8080
+HEALTHCHECK --interval=10s --timeout=5s --retries=5 CMD ["/lprobe", "-port", "8080", "-endpoint", "/api/health"]
 USER harbor
 ENTRYPOINT ["/registryctl", "-c", "/etc/registryctl/config.yml"]

--- a/dockerfile/trivy-adapter.dockerfile
+++ b/dockerfile/trivy-adapter.dockerfile
@@ -28,6 +28,7 @@ WORKDIR /
 
 EXPOSE 8080
 EXPOSE 8443
+HEALTHCHECK --interval=10s --timeout=5s --retries=5 CMD ["/lprobe", "-port", "8080", "-endpoint", "/probe/ready"]
 
 USER scanner
 ENTRYPOINT ["/home/scanner/bin/scanner-trivy"]

--- a/taskfile/dev.yml
+++ b/taskfile/dev.yml
@@ -200,10 +200,10 @@ tasks:
         pid=""
 
         if command -v lsof >/dev/null 2>&1; then
-          pid=$(lsof -nP -t -iTCP:{{.PORT_PORTAL}} -sTCP:LISTEN 2>/dev/null | head -1)
+          pid=$(lsof -nP -t -iTCP:{{.PORT_PORTAL}} -sTCP:LISTEN 2>/dev/null | head -1 || true)
         fi
         if [ -z "$pid" ] && command -v ss >/dev/null 2>&1; then
-          pid=$(ss -tlnpH "sport = :{{.PORT_PORTAL}}" 2>/dev/null | sed -n 's/.*pid=\([0-9]*\).*/\1/p' | head -1)
+          pid=$(ss -tlnpH "sport = :{{.PORT_PORTAL}}" 2>/dev/null | sed -n 's/.*pid=\([0-9]*\).*/\1/p' | head -1 || true)
         fi
 
         if [ -z "$pid" ]; then
@@ -220,10 +220,11 @@ tasks:
         case "$args" in
           *"$expected"*)
             if [ -z "$cwd" ] || [ "$cwd" = "$PWD/src/portal" ]; then
-              kill "$pid"
+              kill "$pid" 2>/dev/null || true
             fi
             ;;
         esac
+        exit 0
 
   # ---------------------------------------------------------------------------
   # Infrastructure (Docker Compose)


### PR DESCRIPTION
## Summary
- Add component-specific Dockerfile healthchecks using the bundled lprobe binary.
- Run portal and dev images as non-root users where missing.
- Harden dev cleanup so clean workflows remain idempotent.

## Validation
- task clean && task build
- task clean && task test:quick
- task clean && PUSH=false PLATFORMS=linux/amd64 task images
- task clean && trivy fs --scanners misconfig --skip-dirs tests --skip-dirs .opencode --skip-dirs .git --skip-dirs src/portal --skip-dirs src/pkg/chart/testdata .