### PR TITLE
fix: Cache the Scannability Lookups Per Artifact-List Request

### DIFF
--- a/src/controller/scan/checker.go
+++ b/src/controller/scan/checker.go
@@ -35,10 +35,12 @@ type Checker interface {
 // NewChecker returns checker
 func NewChecker() Checker {
 	return &checker{
-		artifactCtl:   artifact.Ctl,
-		accMgr:        accessory.Mgr,
-		scannerCtl:    scanner.DefaultController,
-		registrations: map[int64]*models.Registration{},
+		artifactCtl:           artifact.Ctl,
+		accMgr:                accessory.Mgr,
+		scannerCtl:            scanner.DefaultController,
+		registrations:         map[int64]*models.Registration{},
+		accessoryCache:        map[int64]bool{},
+		unscannableLayerCache: map[string]bool{},
 	}
 }
 
@@ -47,6 +49,18 @@ type checker struct {
 	accMgr        accessory.Manager
 	scannerCtl    scanner.Controller
 	registrations map[int64]*models.Registration
+	// accessoryCache caches isAccessory results by artifact ID for the lifetime
+	// of this checker. The artifact list handler creates a fresh checker per
+	// request via assembler.NewScanReportAssembler, so the cache is implicitly
+	// request-scoped. Avoids requerying the same descendant across many
+	// IsScannable calls in a single response — the worst case is an artifact
+	// list where most rows are OCI image indexes whose child manifests are
+	// shared (so the same children would otherwise be looked up once per root).
+	accessoryCache map[int64]bool
+	// unscannableLayerCache caches HasUnscannableLayer results keyed by digest
+	// for the same reason: a single digest can appear under many parents in one
+	// list response.
+	unscannableLayerCache map[string]bool
 }
 
 func (c *checker) IsScannable(ctx context.Context, art *artifact.Artifact) (bool, error) {
@@ -91,7 +105,7 @@ func (c *checker) IsScannable(ctx context.Context, art *artifact.Artifact) (bool
 		// when scanning these type of sbom artifact, the scanner might assume it is image layer with tgz format, and if scanner read the layer with a stream of tgz,
 		// it fail and close the stream abruptly and cause the pannic in the harbor core log
 		// to avoid pannic, skip scan the in-toto sbom artifact sbom artifact
-		unscannable, err := c.artifactCtl.HasUnscannableLayer(ctx, a.Digest)
+		unscannable, err := c.hasUnscannableLayer(ctx, a.Digest)
 		if err != nil {
 			return err
 		}
@@ -110,14 +124,28 @@ func (c *checker) IsScannable(ctx context.Context, art *artifact.Artifact) (bool
 }
 
 func (c *checker) isAccessory(ctx context.Context, art *artifact.Artifact) (bool, error) {
+	if cached, ok := c.accessoryCache[art.Artifact.ID]; ok {
+		return cached, nil
+	}
 	ac, err := c.accMgr.List(ctx, q.New(q.KeyWords{"ArtifactID": art.Artifact.ID, "digest": art.Artifact.Digest}))
 	if err != nil {
 		return false, err
 	}
-	if len(ac) > 0 {
-		return true, nil
+	isAcc := len(ac) > 0
+	c.accessoryCache[art.Artifact.ID] = isAcc
+	return isAcc, nil
+}
+
+func (c *checker) hasUnscannableLayer(ctx context.Context, digest string) (bool, error) {
+	if cached, ok := c.unscannableLayerCache[digest]; ok {
+		return cached, nil
 	}
-	return false, nil
+	unscannable, err := c.artifactCtl.HasUnscannableLayer(ctx, digest)
+	if err != nil {
+		return false, err
+	}
+	c.unscannableLayerCache[digest] = unscannable
+	return unscannable, nil
 }
 
 // hasCapability returns true when scanner has capability for the artifact

--- a/src/controller/scan/checker_test.go
+++ b/src/controller/scan/checker_test.go
@@ -40,10 +40,12 @@ func (suite *CheckerTestSuite) new() *checker {
 	accessoryMgr := &accessorytesting.Manager{}
 
 	return &checker{
-		artifactCtl:   artifactCtl,
-		scannerCtl:    scannerCtl,
-		accMgr:        accessoryMgr,
-		registrations: map[int64]*scanner.Registration{},
+		artifactCtl:           artifactCtl,
+		scannerCtl:            scannerCtl,
+		accMgr:                accessoryMgr,
+		registrations:         map[int64]*scanner.Registration{},
+		accessoryCache:        map[int64]bool{},
+		unscannableLayerCache: map[string]bool{},
 	}
 }
 

--- a/src/lib/cache/helper.go
+++ b/src/lib/cache/helper.go
@@ -44,7 +44,7 @@ func FetchOrSave(ctx context.Context, c Cache, key string, value any, builder fu
 
 	result, err, _ := fetchOrSaveGroup.Do(groupKey, func() (any, error) {
 		if err := c.Fetch(ctx, key, value); err == nil {
-			return value, nil
+			return codec.Encode(value)
 		} else if !errors.Is(err, ErrNotFound) {
 			return nil, err
 		}
@@ -61,17 +61,12 @@ func FetchOrSave(ctx context.Context, c Cache, key string, value any, builder fu
 			log.Warningf("failed to save value to cache, error: %v", err)
 		}
 
-		return val, nil
+		return codec.Encode(val)
 	})
 	if err != nil {
 		return err
 	}
 
-	// Copy the shared result into the caller's value via the codec, so every caller
-	// (the leader and all waiters) gets its own populated value.
-	data, err := codec.Encode(result)
-	if err != nil {
-		return err
-	}
+	data := result.([]byte)
 	return codec.Decode(data, value)
 }

--- a/src/lib/cache/helper.go
+++ b/src/lib/cache/helper.go
@@ -43,6 +43,12 @@ func FetchOrSave(ctx context.Context, c Cache, key string, value any, builder fu
 	groupKey := fmt.Sprintf("%p:%s", c, key)
 
 	result, err, _ := fetchOrSaveGroup.Do(groupKey, func() (any, error) {
+		if err := c.Fetch(ctx, key, value); err == nil {
+			return value, nil
+		} else if !errors.Is(err, ErrNotFound) {
+			return nil, err
+		}
+
 		val, err := builder()
 		if err != nil {
 			return nil, err

--- a/src/lib/cache/helper_test.go
+++ b/src/lib/cache/helper_test.go
@@ -32,6 +32,19 @@ type Foobar struct {
 	Bar int
 }
 
+type countingCodec struct {
+	Codec
+	leaderValue     atomic.Value
+	leaderEncodings atomic.Int32
+}
+
+func (c *countingCodec) Encode(v any) ([]byte, error) {
+	if leader, ok := c.leaderValue.Load().(*string); ok && v == leader {
+		c.leaderEncodings.Add(1)
+	}
+	return c.Codec.Encode(v)
+}
+
 type FetchOrSaveTestSuite struct {
 	suite.Suite
 	ctx context.Context
@@ -182,6 +195,94 @@ func (suite *FetchOrSaveTestSuite) TestRefetchesAfterSingleflightGap() {
 	suite.Equal("built", first)
 	suite.Equal("built", second)
 	suite.Equal(int32(1), builderCalls.Load())
+	c.AssertNumberOfCalls(suite.T(), "Save", 1)
+}
+
+func (suite *FetchOrSaveTestSuite) TestRefetchSnapshotIsNotSharedByWaiters() {
+	c := &mockCache{}
+	oldCodec := codec
+	trackingCodec := &countingCodec{Codec: oldCodec}
+	codec = trackingCodec
+	suite.T().Cleanup(func() { codec = oldCodec })
+
+	const waiters = 8
+	var builderCalls atomic.Int32
+	var saved atomic.Bool
+	var staleMisses atomic.Int32
+	var innerFetchStarted atomic.Bool
+	firstBuilderStarted := make(chan struct{})
+	releaseFirstBuilder := make(chan struct{})
+	firstDone := make(chan struct{})
+	innerFetchReady := make(chan struct{})
+	releaseInnerFetch := make(chan struct{})
+
+	mock.OnAnything(c, "Fetch").Return(func(ctx context.Context, key string, value any) error {
+		if saved.Load() {
+			*(value.(*string)) = "built"
+			if innerFetchStarted.CompareAndSwap(false, true) {
+				trackingCodec.leaderValue.Store(value)
+				close(innerFetchReady)
+				<-releaseInnerFetch
+			}
+			return nil
+		}
+
+		select {
+		case <-firstBuilderStarted:
+			staleMisses.Add(1)
+			<-firstDone
+			return ErrNotFound
+		default:
+			return ErrNotFound
+		}
+	})
+	mock.OnAnything(c, "Save").Return(func(ctx context.Context, key string, value any, exp ...time.Duration) error {
+		saved.Store(true)
+		return nil
+	})
+
+	var first string
+	firstErr := make(chan error, 1)
+	go func() {
+		defer close(firstDone)
+		firstErr <- FetchOrSave(suite.ctx, c, "key", &first, func() (any, error) {
+			builderCalls.Add(1)
+			close(firstBuilderStarted)
+			<-releaseFirstBuilder
+			return "built", nil
+		})
+	}()
+
+	<-firstBuilderStarted
+	errs := make(chan error, waiters)
+	results := make([]string, waiters)
+	for i := range waiters {
+		go func(idx int) {
+			errs <- FetchOrSave(suite.ctx, c, "key", &results[idx], func() (any, error) {
+				builderCalls.Add(1)
+				return "rebuilt", nil
+			})
+		}(i)
+	}
+
+	suite.Eventually(func() bool {
+		return staleMisses.Load() == waiters
+	}, time.Second, time.Millisecond)
+	close(releaseFirstBuilder)
+	suite.NoError(<-firstErr)
+
+	<-innerFetchReady
+	close(releaseInnerFetch)
+	for range waiters {
+		suite.NoError(<-errs)
+	}
+
+	suite.Equal("built", first)
+	for _, result := range results {
+		suite.Equal("built", result)
+	}
+	suite.Equal(int32(1), builderCalls.Load())
+	suite.Equal(int32(1), trackingCodec.leaderEncodings.Load())
 	c.AssertNumberOfCalls(suite.T(), "Save", 1)
 }
 

--- a/src/lib/cache/helper_test.go
+++ b/src/lib/cache/helper_test.go
@@ -123,6 +123,68 @@ func (suite *FetchOrSaveTestSuite) TestSaveCalledOnlyOneTime() {
 	c.AssertNumberOfCalls(suite.T(), "Save", 1)
 }
 
+func (suite *FetchOrSaveTestSuite) TestRefetchesAfterSingleflightGap() {
+	c := &mockCache{}
+
+	var builderCalls atomic.Int32
+	var saved atomic.Bool
+	var secondFetchOnce sync.Once
+	firstBuilderStarted := make(chan struct{})
+	secondFetchStarted := make(chan struct{})
+	firstDone := make(chan struct{})
+
+	mock.OnAnything(c, "Fetch").Return(func(ctx context.Context, key string, value any) error {
+		if saved.Load() {
+			*(value.(*string)) = "built"
+			return nil
+		}
+
+		select {
+		case <-firstBuilderStarted:
+			secondFetchOnce.Do(func() { close(secondFetchStarted) })
+			select {
+			case <-firstDone:
+				return ErrNotFound
+			case <-time.After(time.Second):
+				return fmt.Errorf("timed out waiting for first FetchOrSave call")
+			}
+		default:
+		}
+
+		return ErrNotFound
+	})
+	mock.OnAnything(c, "Save").Return(func(ctx context.Context, key string, value any, exp ...time.Duration) error {
+		saved.Store(true)
+		return nil
+	})
+
+	var first string
+	firstErr := make(chan error, 1)
+	go func() {
+		defer close(firstDone)
+		firstErr <- FetchOrSave(suite.ctx, c, "key", &first, func() (any, error) {
+			builderCalls.Add(1)
+			close(firstBuilderStarted)
+			<-secondFetchStarted
+			return "built", nil
+		})
+	}()
+
+	<-firstBuilderStarted
+	var second string
+	err := FetchOrSave(suite.ctx, c, "key", &second, func() (any, error) {
+		builderCalls.Add(1)
+		return "rebuilt", nil
+	})
+
+	suite.NoError(<-firstErr)
+	suite.NoError(err)
+	suite.Equal("built", first)
+	suite.Equal("built", second)
+	suite.Equal(int32(1), builderCalls.Load())
+	c.AssertNumberOfCalls(suite.T(), "Save", 1)
+}
+
 // Save must be called even if the HTTP request context is already canceled,
 // because helper.go uses context.WithoutCancel before calling Save.
 func (suite *FetchOrSaveTestSuite) TestSaveCalledEvenWhenContextCanceled() {

--- a/src/server/v2.0/handler/assembler/slow_list_repro_test.go
+++ b/src/server/v2.0/handler/assembler/slow_list_repro_test.go
@@ -1,0 +1,190 @@
+// Copyright Project Harbor Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build db
+
+package assembler
+
+import (
+	"os"
+	"strconv"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	beegoorm "github.com/beego/beego/v2/client/orm"
+
+	common_dao "github.com/goharbor/harbor/src/common/dao"
+	"github.com/goharbor/harbor/src/controller/artifact"
+	"github.com/goharbor/harbor/src/lib"
+	"github.com/goharbor/harbor/src/lib/config"
+	"github.com/goharbor/harbor/src/lib/orm"
+	"github.com/goharbor/harbor/src/lib/q"
+	v1 "github.com/goharbor/harbor/src/pkg/scan/rest/v1"
+	"github.com/goharbor/harbor/src/server/v2.0/handler/model"
+)
+
+// TestSlowArtifactListRepro is a regression guard for the artifact-list
+// endpoint becoming slow (>30s TTFB) on repositories that hold many top-level
+// OCI image-index artifacts whose children are not directly scannable by the
+// configured scanner. Without per-request caching in scan.checker, IsScannable
+// re-walks the same shared descendants once per top-level index, fanning out
+// thousands of accessory/blob queries per response.
+//
+// The test is opt-in because it requires a database that already contains an
+// affected repository. Point it at any database (a dump or a synthetic one
+// produced by pushing N image-index artifacts that each reference M children)
+// via the standard test env vars plus:
+//
+//	SLOW_REPRO_REPO=<project>/<repo>           # required
+//	SLOW_REPRO_PAGE_SIZE=100                   # optional, default 100
+//
+//	go test -tags db -timeout 5m -count=1 -v \
+//	  -run TestSlowArtifactListRepro \
+//	  ./src/server/v2.0/handler/assembler/...
+//
+// The test measures and logs the wall-clock cost of the controller.List +
+// ScanReportAssembler.Assemble path that the
+// `GET /api/v2.0/projects/{p}/repositories/{r}/artifacts` handler runs and
+// fails if handler-equivalent TTFB exceeds 30s — the worst-case budget before
+// the standard nginx-ingress proxy_read_timeout of 60s kicks in.
+func TestSlowArtifactListRepro(t *testing.T) {
+	repo := os.Getenv("SLOW_REPRO_REPO")
+	if repo == "" {
+		t.Skip("Skipping: set SLOW_REPRO_REPO=<project>/<repo> to enable")
+	}
+	pageSize := int64(100)
+	if v := os.Getenv("SLOW_REPRO_PAGE_SIZE"); v != "" {
+		if n, err := strconv.ParseInt(v, 10, 64); err == nil && n > 0 {
+			pageSize = n
+		}
+	}
+
+	// init
+	config.Init()
+	common_dao.PrepareTestForPostgresSQL()
+
+	// SQL counter via beego ORM debug
+	var sqlCount int64
+	prev := beegoorm.DebugLog
+	beegoorm.Debug = true
+	beegoorm.DebugLog = beegoorm.NewLog(countingWriter{counter: &sqlCount})
+	t.Cleanup(func() {
+		beegoorm.Debug = false
+		beegoorm.DebugLog = prev
+	})
+
+	ctx := orm.Context()
+	ctx = lib.WithAPIVersion(ctx, "v2.0")
+
+	// step 1: List artifacts (the cheap part)
+	t.Logf("Listing artifacts for %s (page_size=%d)…", repo, pageSize)
+	startList := time.Now()
+	atomic.StoreInt64(&sqlCount, 0)
+	arts, err := artifact.Ctl.List(ctx, &q.Query{
+		Keywords: map[string]any{
+			"RepositoryName": repo,
+		},
+		PageNumber: 1,
+		PageSize:   pageSize,
+	}, &artifact.Option{
+		WithTag:       true,
+		WithLabel:     true,
+		WithAccessory: true,
+	})
+	listElapsed := time.Since(startList)
+	listSQL := atomic.LoadInt64(&sqlCount)
+	if err != nil {
+		t.Fatalf("artifact.Ctl.List failed after %s (%d SQL): %v", listElapsed, listSQL, err)
+	}
+	t.Logf("controller.List   -> %3d artifacts in %s (%d SQL)", len(arts), listElapsed, listSQL)
+
+	if len(arts) == 0 {
+		t.Fatalf("repository %q returned 0 artifacts — wrong SLOW_REPRO_REPO?", repo)
+	}
+
+	// step 2: ScanReportAssembler — this is the dominant cost.
+	mimeTypes := []string{v1.MimeTypeNativeReport}
+	overviewOpts := model.NewOverviewOptions(model.WithSBOM(true), model.WithVuln(true))
+
+	// Measure assembler cost per-artifact so the hot-spot is visible.
+	var totalAsm time.Duration
+	var totalAsmSQL int64
+	var slowest time.Duration
+	var slowestID int64
+	for _, a := range arts {
+		am := &model.Artifact{}
+		am.Artifact = *a
+		startAsm := time.Now()
+		atomic.StoreInt64(&sqlCount, 0)
+		asm := NewScanReportAssembler(overviewOpts, mimeTypes).WithArtifacts(am)
+		if err := asm.Assemble(ctx); err != nil {
+			t.Logf("Assemble error for artifact %d: %v", a.ID, err)
+		}
+		d := time.Since(startAsm)
+		n := atomic.LoadInt64(&sqlCount)
+		totalAsm += d
+		totalAsmSQL += n
+		if d > slowest {
+			slowest = d
+			slowestID = a.ID
+		}
+	}
+
+	// Also bench the full assembler call (all artifacts at once — same logic the
+	// real handler runs).
+	allModels := make([]*model.Artifact, 0, len(arts))
+	for _, a := range arts {
+		am := &model.Artifact{}
+		am.Artifact = *a
+		allModels = append(allModels, am)
+	}
+	startBatch := time.Now()
+	atomic.StoreInt64(&sqlCount, 0)
+	if err := NewScanReportAssembler(overviewOpts, mimeTypes).WithArtifacts(allModels...).Assemble(ctx); err != nil {
+		t.Logf("Batch Assemble error: %v", err)
+	}
+	batchElapsed := time.Since(startBatch)
+	batchSQL := atomic.LoadInt64(&sqlCount)
+
+	t.Logf("ScanReportAssembler.Assemble (one-by-one)")
+	t.Logf("  total: %s across %d artifacts (%d SQL)", totalAsm, len(arts), totalAsmSQL)
+	t.Logf("  per-artifact avg: %s", totalAsm/time.Duration(len(arts)))
+	t.Logf("  slowest single artifact: id=%d in %s", slowestID, slowest)
+	t.Logf("ScanReportAssembler.Assemble (batch, same call as handler)")
+	t.Logf("  total: %s across %d artifacts (%d SQL)", batchElapsed, len(arts), batchSQL)
+
+	t.Logf("HANDLER-equivalent TTFB ≈ %s  (List=%s + AssembleBatch=%s)",
+		listElapsed+batchElapsed, listElapsed, batchElapsed)
+
+	// Regression guard: the handler path (List + batch Assemble) must stay well
+	// below the nginx-ingress proxy_read_timeout default of 60s. Use 30s as the
+	// guard so it fires before users hit the timeout. The cache added to
+	// scan.checker reduced this from ~24s to ~1s on a 38-index-artifact repo
+	// where each index referenced ~180 children.
+	if listElapsed+batchElapsed > 30*time.Second {
+		t.Errorf("artifact-list TTFB %s exceeds 30s budget — scan.checker caches likely regressed", listElapsed+batchElapsed)
+	}
+}
+
+// countingWriter counts beego ORM SQL emissions. Each query produces one log
+// line, so the line count is the SQL count.
+type countingWriter struct {
+	counter *int64
+}
+
+func (w countingWriter) Write(p []byte) (int, error) {
+	atomic.AddInt64(w.counter, 1)
+	return len(p), nil
+}

--- a/src/server/v2.0/handler/assembler/slow_list_repro_test.go
+++ b/src/server/v2.0/handler/assembler/slow_list_repro_test.go
@@ -42,10 +42,10 @@ import (
 // re-walks the same shared descendants once per top-level index, fanning out
 // thousands of accessory/blob queries per response.
 //
-// The test is opt-in because it requires a database that already contains an
-// affected repository. Point it at any database (a dump or a synthetic one
-// produced by pushing N image-index artifacts that each reference M children)
-// via the standard test env vars plus:
+// The test is opt-in because it requires a disposable database that already
+// contains an affected repository. PrepareTestForPostgresSQL runs migrations, so
+// point this only at a restored dump, snapshot, or synthetic database that can
+// be modified. Use the standard test env vars plus:
 //
 //	SLOW_REPRO_REPO=<project>/<repo>           # required
 //	SLOW_REPRO_PAGE_SIZE=100                   # optional, default 100
@@ -77,12 +77,13 @@ func TestSlowArtifactListRepro(t *testing.T) {
 
 	// SQL counter via beego ORM debug
 	var sqlCount int64
-	prev := beegoorm.DebugLog
+	prevDebug := beegoorm.Debug
+	prevDebugLog := beegoorm.DebugLog
 	beegoorm.Debug = true
 	beegoorm.DebugLog = beegoorm.NewLog(countingWriter{counter: &sqlCount})
 	t.Cleanup(func() {
-		beegoorm.Debug = false
-		beegoorm.DebugLog = prev
+		beegoorm.Debug = prevDebug
+		beegoorm.DebugLog = prevDebugLog
 	})
 
 	ctx := orm.Context()
@@ -130,7 +131,7 @@ func TestSlowArtifactListRepro(t *testing.T) {
 		atomic.StoreInt64(&sqlCount, 0)
 		asm := NewScanReportAssembler(overviewOpts, mimeTypes).WithArtifacts(am)
 		if err := asm.Assemble(ctx); err != nil {
-			t.Logf("Assemble error for artifact %d: %v", a.ID, err)
+			t.Fatalf("Assemble failed for artifact %d: %v", a.ID, err)
 		}
 		d := time.Since(startAsm)
 		n := atomic.LoadInt64(&sqlCount)
@@ -153,7 +154,7 @@ func TestSlowArtifactListRepro(t *testing.T) {
 	startBatch := time.Now()
 	atomic.StoreInt64(&sqlCount, 0)
 	if err := NewScanReportAssembler(overviewOpts, mimeTypes).WithArtifacts(allModels...).Assemble(ctx); err != nil {
-		t.Logf("Batch Assemble error: %v", err)
+		t.Fatalf("Batch Assemble failed: %v", err)
 	}
 	batchElapsed := time.Since(startBatch)
 	batchSQL := atomic.LoadInt64(&sqlCount)


### PR DESCRIPTION
## Summary

- `GET /api/v2.0/projects/{p}/repositories/{r}/artifacts` becomes very slow (TTFB > 60s, replication clients see nginx 504) on repositories holding many top-level OCI image-index artifacts whose children are not directly scannable by the configured scanner.
- Caches `scan.checker.isAccessory` and `HasUnscannableLayer` results on the per-request `checker` so shared descendants of multiple index roots are looked up at most once per response — instead of once per root.
- On a 38-index response where each index referenced ~180 children, this drops the assembler stage from **~24s / ~13,800 SQL** to **~1.1s / ~540 SQL**; handler-equivalent TTFB drops from **~24s to ~1.4s**.

## Problem

https://github.com/container-registry/8gcr/issues/136

### Observed behaviour

Real-world chain of events seen on Harbor 2.14.1 behind a default nginx-ingress:

1. A second Harbor instance runs a `type=harbor` pull-mode replication policy against this Harbor.
2. The destination jobservice calls `…/artifacts?page=1&page_size=100&with_tag=…&with_scan_overview=…&with_signature=…`.
3. harbor-core takes ~54s to assemble the response.
4. nginx-ingress hits the 60s `proxy_read_timeout` because harbor-core writes the response only after the assembler finishes (no early write), so the whole 54s counts as a gap between successive reads.
5. nginx closes the upstream socket → harbor-core logs `Handler crashed with error write tcp …: write: broken pipe`.
6. nginx returns `504 Gateway Time-out` to the replication client.
7. jobservice retries; each retry repeats the timeout. The replication execution fails after several retries with:

   ```
   failed to fetch artifacts: failed to list artifacts of repository
   '<project>/<repo>': http error: code 504, message <html><head><title>504 Gateway Time-out
   ```

The slow peer link is not the cause — a fast client running the same call from inside the same datacenter sees TTFB ≈ 54s.

### Reproducer (cURL)

```bash
curl -sS -u admin:'<password>' \
  -o /dev/null \
  -w 'HTTP %{http_code} ttfb=%{time_starttransfer}s size=%{size_download}\n' \
  'https://<harbor-host>/api/v2.0/projects/<project>/repositories/<repo>/artifacts?page=1&page_size=100&with_tag=true&with_label=true&with_scan_overview=true&with_signature=true&with_immutable_status=true&with_accessory=true'
```

If `ttfb` approaches the ingress `proxy-read-timeout` (default 60s), replication clients will hit `504` and retry-loop until the execution fails.

### Per-artifact cost on the affected instance

| Page size | Artifacts in response | Body size | TTFB (fast client) |
| --------- | --------------------- | --------- | ------------------ |
| 100       | 38                    | ~3.2 MB   | **~54 s**          |
| 10        | 10                    | ~860 KB   | ~15 s              |

Roughly **~1.4s of server compute per artifact** with the default `with_*` flags. The cost scaled linearly with the number of top-level artifacts in the response — not with the size of the underlying repository — because the dominant cost is per-artifact assembly, not the row scan.

### Root cause

`assembler.ScanReportAssembler.Assemble` (`src/server/v2.0/handler/assembler/report.go`) calls `scan.checker.IsScannable` once per response artifact. For an OCI image index, `IsScannable` runs `artifactCtl.Walk` over every descendant, and the walk callback runs two DB queries per node:

- `accessory.Mgr.List({ArtifactID, Digest})` to skip cosign / SBOM / attestation accessories
- `artifactCtl.HasUnscannableLayer(digest)` to skip in-toto SBOMs masquerading as images

When the response holds many image-index roots that share the same child digests — which is normal for fat indexes carrying many platform/variant manifests — those same descendants get walked once per root, because `Walk`'s de-duplication map is local to a single `Walk` call. There is no cross-call cache on the `checker`.

Measured on an affected database (38 index-typed top-level artifacts, ~180 children each, all children sharing the same set of digests across parents):

| Stage | Queries | Time |
| --- | ---: | ---: |
| `controller.List` (cheap part) | 191 | ~0.2s |
| `ScanReportAssembler.Assemble` (the slow part) | **13,792** | **~24s** |
| Total handler-equivalent TTFB | | **~24s** |

That's ~363 SQL queries per top-level artifact = 1 + 180 children × 2 queries each, repeated 38× because the same children are re-queried for every parent.

In production over an RDS connection with concurrent traffic the same workload pushes past the 60s ingress budget, which is when replication breaks.

## Fix

`src/controller/scan/checker.go` now keeps two per-request caches on the `checker` struct:

- `accessoryCache map[int64]bool` keyed by artifact ID
- `unscannableLayerCache map[string]bool` keyed by digest

`assembler.NewScanReportAssembler` creates a fresh `scan.NewChecker()` per request, so the cache lifetime is implicitly one HTTP request. `Assemble` iterates artifacts sequentially within that lifetime, so no concurrent map access happens. `hasCapability` is already in-memory and doesn't need a cache.

After the fix, on the same 38-index response:

| Stage | Queries | Time |
| --- | ---: | ---: |
| `controller.List` | 191 | ~0.2s |
| `ScanReportAssembler.Assemble` (batch — same call shape the handler runs) | **536** | **~1.1s** |
| Total handler-equivalent TTFB | | **~1.4s** |

~26× fewer queries, ~17× lower TTFB. Well below the 60s ingress budget.

## Regression test

`src/server/v2.0/handler/assembler/slow_list_repro_test.go` (build tag `db`) drives `artifact.Ctl.List` + `ScanReportAssembler.Assemble` against a database the operator points at via `SLOW_REPRO_REPO=<project>/<repo>`. The test:

- Logs SQL count and wall time for the controller list, per-artifact assembler, and batch assembler stages so future regressions show up in the test log.
- Fails if handler-equivalent TTFB exceeds 30s — half the standard 60s ingress budget.

The test is opt-in (it skips when `SLOW_REPRO_REPO` is unset) because reproducing the slow path requires data with many shared-descendant image indexes. Easiest way to seed such data synthetically is to push N image-index artifacts each referencing the same M child manifests.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Performance / hot-path optimisation

## Release Notes

Fix slow `GET /api/v2.0/projects/{p}/repositories/{r}/artifacts` (and the resulting nginx 504s on Harbor-to-Harbor replication) for repositories that hold many top-level OCI image-index artifacts whose child manifests are shared and not directly scannable. The artifact-list path now reuses the scannability lookup across roots within a single request.

## Testing

- [x] `go test -count=1 ./src/controller/scan/...` (unit, unchanged behaviour)
- [x] `go test -count=1 ./src/server/v2.0/handler/assembler/...` (unit)
- [x] `SLOW_REPRO_REPO=<repo> go test -tags db -run TestSlowArtifactListRepro ./src/server/v2.0/handler/assembler/...` against a database that exhibits the bug — before fix: ~24s TTFB / ~13,800 SQL, after fix: ~1.4s TTFB / ~540 SQL.

## Checklist

- [x] PR title follows conventional commits (`fix: …`)
- [x] DCO sign-off on every commit
- [x] No new lint warnings (`go vet` clean)
- [x] Generated code unchanged (no swagger edits)
