### PR TITLE
fix: Install gh CLI in release workflow

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -219,6 +219,11 @@ jobs:
       - name: Install envsubst
         run: command -v envsubst || (sudo apt-get update && sudo apt-get install -y gettext-base)
 
+      - name: Install gh CLI
+        uses: sersoft-gmbh/setup-gh-cli-action@3cb41a4434ca35de4d1c16e00dc7e16d38409494 # v3.0.0
+        with:
+          version: stable
+
       - name: Install cosign
         uses: sigstore/cosign-installer@cad07c2e89fa2edd6e2d7bab4c1aa38e53f76003 # v4.1.1
 

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -165,6 +165,7 @@ jobs:
       REGISTRY_ADDRESS: ${{ vars.REGISTRY_ADDRESS || '8gears.container-registry.com' }}
       REGISTRY_PROJECT: ${{ vars.REGISTRY_PROJECT || '8gcr' }}
       VERSION: ${{ needs.release-please.outputs.version }}
+      TAG_NAME: ${{ needs.release-please.outputs.tag_name }}
     steps:
       - name: Prepare BuildKit
         run: |
@@ -198,7 +199,7 @@ jobs:
         run: |
           # shellcheck disable=SC2046
           docker buildx imagetools create \
-            -t "${IMAGE}:${VERSION}" \
+            -t "${IMAGE}:${TAG_NAME}" \
             $(printf "${IMAGE}@sha256:%s " *)
 
   sign:
@@ -220,9 +221,9 @@ jobs:
         run: command -v envsubst || (sudo apt-get update && sudo apt-get install -y gettext-base)
 
       - name: Install gh CLI
-        uses: sersoft-gmbh/setup-gh-cli-action@3cb41a4434ca35de4d1c16e00dc7e16d38409494 # v3.0.0
+        uses: actions4gh/setup-gh@44a12005484c53be5bf51bebe8c985b4be8ba8de # v1.0.2
         with:
-          version: stable
+          gh-version: latest
 
       - name: Install cosign
         uses: sigstore/cosign-installer@cad07c2e89fa2edd6e2d7bab4c1aa38e53f76003 # v4.1.1
@@ -238,7 +239,7 @@ jobs:
         run: |
           for image in core jobservice registryctl exporter portal registry trivy-adapter; do
             cosign sign --yes \
-              "${REGISTRY_ADDRESS}/${REGISTRY_PROJECT}/harbor-${image}:${VERSION}"
+              "${REGISTRY_ADDRESS}/${REGISTRY_PROJECT}/harbor-${image}:${TAG_NAME}"
           done
 
       - name: Generate GitHub App token
@@ -324,7 +325,7 @@ jobs:
             echo "| Image | Reference |"
             echo "|-------|-----------|"
             for image in $IMAGES; do
-              echo "| \`harbor-${image}\` | \`${REGISTRY}/harbor-${image}:${VERSION}\` |"
+              echo "| \`harbor-${image}\` | \`${REGISTRY}/harbor-${image}:${TAG_NAME}\` |"
             done
             echo ""
             echo "**Verify an image signature:**"
@@ -332,7 +333,7 @@ jobs:
             echo "cosign verify \\"
             echo "  --certificate-identity \"https://github.com/${{ github.repository }}/.github/workflows/release-please.yml@refs/heads/main\" \\"
             echo "  --certificate-oidc-issuer \"https://token.actions.githubusercontent.com\" \\"
-            echo "  ${REGISTRY}/harbor-core:${VERSION}"
+            echo "  ${REGISTRY}/harbor-core:${TAG_NAME}"
             echo "\`\`\`"
             echo ""
             echo "---"

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -4,6 +4,7 @@
   "pull-request-header": "This PR prepares the next release based on conventional commits.",
   "pull-request-title-pattern": "chore: release ${version}",
   "release-type": "simple",
+  "changelog-type": "github",
   "include-v-in-tag": true,
   "exclude-paths": [".github", "docs", "tests"],
   "changelog-sections": [


### PR DESCRIPTION
## Summary
- Install GitHub CLI in the release signing job before release notes are updated.
- Use the pinned `actions4gh/setup-gh` action instead of inline package-manager installation.
- Generate GitHub-style release notes so contributors are included.
- Tag, sign, and document release images with the full release tag, including the `v` prefix.

## Verification
- Ran `jq empty release-please-config.json`.
- Ran `git diff --check`.
- Manually updated the `v2.15.0` release notes with contributor details and `:v2.15.0` image references.