### PR TITLE
fix: Preserve upstream metadata in release notes

### DIFF
--- a/.github/scripts/format-release-notes.mjs
+++ b/.github/scripts/format-release-notes.mjs
@@ -124,14 +124,11 @@ function upstreamPrLink(pr) {
 }
 
 function formatUpstreamTitle(entry) {
-  const title = entry
+  return entry
     .replace(/^[-*]\s*/, '')
     .replace(/\s*\[upstream\]\s*/i, ' ')
-    .replace(/^\s*(?:feat|fix|perf|refactor|docs|test|chore|ci|build)(?:\([^)]+\))?!?:\s*/i, '')
     .replace(/\s{2,}/g, ' ')
     .trim();
-
-  return title.charAt(0).toUpperCase() + title.slice(1);
 }
 
 function formatUpstreamEntry(entry, sha) {

--- a/.github/scripts/format-release-notes.mjs
+++ b/.github/scripts/format-release-notes.mjs
@@ -123,6 +123,17 @@ function upstreamPrLink(pr) {
   return `[goharbor/harbor#${pr}](https://github.com/goharbor/harbor/pull/${pr})`;
 }
 
+function formatUpstreamTitle(entry) {
+  const title = entry
+    .replace(/^[-*]\s*/, '')
+    .replace(/\s*\[upstream\]\s*/i, ' ')
+    .replace(/^\s*(?:feat|fix|perf|refactor|docs|test|chore|ci|build)(?:\([^)]+\))?!?:\s*/i, '')
+    .replace(/\s{2,}/g, ' ')
+    .trim();
+
+  return title.charAt(0).toUpperCase() + title.slice(1);
+}
+
 function formatUpstreamEntry(entry, sha) {
   const commitMetadata = metadataForCommit(sha);
   const inlineMetadata = parseInlineUpstreamMetadata(entry);
@@ -131,13 +142,15 @@ function formatUpstreamEntry(entry, sha) {
     author: commitMetadata?.author ?? inlineMetadata?.author,
   };
   let formatted = entry
-    .replace(/\s*\[upstream\]\s*/i, ' ')
     .replace(/\sby\s+@[A-Za-z0-9-]+(?:\[bot\])?\s+in\s+(?:\[goharbor\/harbor#\d+\]\(https:\/\/github\.com\/goharbor\/harbor\/pull\/\d+\)|https:\/\/github\.com\/goharbor\/harbor\/pull\/\d+)/i, '')
     .replace(/\s+\((?:upstream\s+)?(?:PR\s+)?(?:goharbor\/harbor#|https:\/\/github\.com\/goharbor\/harbor\/pull\/)\d+\s+by\s+@[A-Za-z0-9-]+(?:\[bot\])?\)/i, '')
     .replace(/\s{2,}/g, ' ');
+  const commitSuffix = formatted.match(/\s+\(\[[0-9a-f]+\]\(https:\/\/github\.com\/[^)]+\/commit\/[0-9a-f]+\)\)$/i);
+  const title = formatUpstreamTitle(commitSuffix ? formatted.slice(0, commitSuffix.index) : formatted);
+  formatted = `- [upstream] ${title}`;
 
   if (!metadata?.pr && !metadata?.author) {
-    return formatted;
+    return `${formatted}${commitSuffix?.[0] ?? ''}`;
   }
 
   const details = [
@@ -145,12 +158,11 @@ function formatUpstreamEntry(entry, sha) {
     metadata.pr ? `in ${upstreamPrLink(metadata.pr)}` : undefined,
   ].filter(Boolean).join(' ');
 
-  const commitSuffix = formatted.match(/\s+\(\[[0-9a-f]+\]\(https:\/\/github\.com\/[^)]+\/commit\/[0-9a-f]+\)\)$/i);
   if (!commitSuffix) {
     return `${formatted} ${details}`;
   }
 
-  return `${formatted.slice(0, commitSuffix.index)} ${details}${commitSuffix[0]}`;
+  return `${formatted} ${details}${commitSuffix[0]}`;
 }
 
 function releaseNotesLines(body) {

--- a/.github/scripts/format-release-notes.mjs
+++ b/.github/scripts/format-release-notes.mjs
@@ -144,7 +144,7 @@ function formatUpstreamEntry(entry, sha) {
     .replace(/\s{2,}/g, ' ');
   const commitSuffix = formatted.match(/\s+\(\[[0-9a-f]+\]\(https:\/\/github\.com\/[^)]+\/commit\/[0-9a-f]+\)\)$/i);
   const title = formatUpstreamTitle(commitSuffix ? formatted.slice(0, commitSuffix.index) : formatted);
-  formatted = `- [upstream] ${title}`;
+  formatted = `- ${title}`;
 
   if (!metadata?.pr && !metadata?.author) {
     return `${formatted}${commitSuffix?.[0] ?? ''}`;


### PR DESCRIPTION
## Summary
- Preserve upstream release-note entries in the expected format: `<upstream subject> by @author in goharbor/harbor#...` under the `Upstream` heading.
- Keep upstream conventional prefixes such as `fix(dao):`, `feat(gc):`, and `fix(scan):` in the displayed release-note text.
- Use existing `Upstream-Author` and `Upstream-PR` commit trailers to add the original upstream author and Harbor PR link.

## Why
Upstream cherry-picks can be merged through Harbor Next, but release notes should still make it clear which upstream Harbor PR and author each entry came from.

The `Upstream` heading already identifies the section, so individual entries do not need a redundant `[upstream]` prefix.

## Example
Input generated note:

```md
* fix(dao): use context-aware methods for database operations in MetaDAO ([cd6ddfe](https://github.com/container-registry/harbor-next/commit/cd6ddfe52219cb09b1cf5fa815689bdf0cf1a75f))
```

Formatted release note under `### Upstream`:

```md
- fix(dao): use context-aware methods for database operations in MetaDAO by @mxab in [goharbor/harbor#23074](https://github.com/goharbor/harbor/pull/23074) ([cd6ddfe](https://github.com/container-registry/harbor-next/commit/cd6ddfe52219cb09b1cf5fa815689bdf0cf1a75f))
```

## Testing
- Ran `node .github/scripts/format-release-notes.mjs` with fixture data using upstream commits from PR #220.
- Ran `git diff --check`.