### PR TITLE
fix: Push Trivy Adapter Images Without Harbor Prefix

### DIFF
--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -36,9 +36,15 @@ jobs:
       contents: read
     steps:
       - name: Prepare
+        id: prepare
         run: |
           platform=${{ matrix.platform }}
           echo "PLATFORM_PAIR=${platform//\//-}" >> "$GITHUB_ENV"
+          if [ "${{ matrix.component }}" = "trivy-adapter" ]; then
+            echo "image_name=trivy-adapter" >> "$GITHUB_OUTPUT"
+          else
+            echo "image_name=harbor-${{ matrix.component }}" >> "$GITHUB_OUTPUT"
+          fi
           # Surface pod env var for GitHub Actions expressions
           if [ -n "$BUILDX_HOST" ]; then
             echo "BUILDX_HOST=$BUILDX_HOST" >> "$GITHUB_ENV"
@@ -103,7 +109,7 @@ jobs:
             TRIVY_VERSION=${{ env.TRIVY_VERSION }}
             TRIVY_BASE_IMAGE_VERSION=${{ env.TRIVY_BASE_IMAGE_VERSION }}
             HARBOR_SCANNER_TRIVY_VERSION=${{ env.HARBOR_SCANNER_TRIVY_VERSION }}
-          tags: ${{ env.REGISTRY_ADDRESS }}/${{ env.PR_REGISTRY_PROJECT }}/harbor-${{ matrix.component }}
+          tags: ${{ env.REGISTRY_ADDRESS }}/${{ env.PR_REGISTRY_PROJECT }}/${{ steps.prepare.outputs.image_name }}
           outputs: type=image,push-by-digest=true,name-canonical=true,push=true
 
       - name: Export digest
@@ -133,7 +139,13 @@ jobs:
       contents: read
     steps:
       - name: Prepare BuildKit
+        id: prepare
         run: |
+          if [ "${{ matrix.component }}" = "trivy-adapter" ]; then
+            echo "image_name=trivy-adapter" >> "$GITHUB_OUTPUT"
+          else
+            echo "image_name=harbor-${{ matrix.component }}" >> "$GITHUB_OUTPUT"
+          fi
           if [ -n "$BUILDX_HOST" ]; then
             echo "BUILDX_HOST=$BUILDX_HOST" >> "$GITHUB_ENV"
           fi
@@ -160,7 +172,7 @@ jobs:
       - name: Create manifest list and push
         working-directory: ${{ runner.temp }}/digests
         env:
-          IMAGE: ${{ env.REGISTRY_ADDRESS }}/${{ env.PR_REGISTRY_PROJECT }}/harbor-${{ matrix.component }}
+          IMAGE: ${{ env.REGISTRY_ADDRESS }}/${{ env.PR_REGISTRY_PROJECT }}/${{ steps.prepare.outputs.image_name }}
         run: |
           # shellcheck disable=SC2046
           docker buildx imagetools create \
@@ -206,9 +218,14 @@ jobs:
       - name: Sign images, generate SBOMs, and attest
         run: |
           for image in core jobservice registryctl exporter portal registry trivy-adapter; do
-            ref="${REGISTRY_ADDRESS}/${PR_REGISTRY_PROJECT}/harbor-${image}:${PREVIEW_TAG}"
+            image_name="harbor-${image}"
+            if [ "${image}" = "trivy-adapter" ]; then
+              image_name="trivy-adapter"
+            fi
+
+            ref="${REGISTRY_ADDRESS}/${PR_REGISTRY_PROJECT}/${image_name}:${PREVIEW_TAG}"
             digest="$(crane digest "${ref}")"
-            image_ref="${REGISTRY_ADDRESS}/${PR_REGISTRY_PROJECT}/harbor-${image}@${digest}"
+            image_ref="${REGISTRY_ADDRESS}/${PR_REGISTRY_PROJECT}/${image_name}@${digest}"
 
             cosign sign --yes "${image_ref}"
 
@@ -260,7 +277,7 @@ jobs:
             - \`${registryAddress}/${registryProject}/harbor-exporter:${previewTag}\`
             - \`${registryAddress}/${registryProject}/harbor-portal:${previewTag}\`
             - \`${registryAddress}/${registryProject}/harbor-registry:${previewTag}\`
-            - \`${registryAddress}/${registryProject}/harbor-trivy-adapter:${previewTag}\`
+            - \`${registryAddress}/${registryProject}/trivy-adapter:${previewTag}\`
 
             Verify a preview image:
 

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -44,9 +44,15 @@ jobs:
       VERSION: ${{ needs.release-please.outputs.version }}
     steps:
       - name: Prepare
+        id: prepare
         run: |
           platform=${{ matrix.platform }}
           echo "PLATFORM_PAIR=${platform//\//-}" >> "$GITHUB_ENV"
+          if [ "${{ matrix.component }}" = "trivy-adapter" ]; then
+            echo "image_name=trivy-adapter" >> "$GITHUB_OUTPUT"
+          else
+            echo "image_name=harbor-${{ matrix.component }}" >> "$GITHUB_OUTPUT"
+          fi
           if [ -n "$BUILDX_HOST" ]; then
             echo "BUILDX_HOST=$BUILDX_HOST" >> "$GITHUB_ENV"
           fi
@@ -135,7 +141,7 @@ jobs:
             TRIVY_VERSION=${{ env.TRIVY_VERSION }}
             TRIVY_BASE_IMAGE_VERSION=${{ env.TRIVY_BASE_IMAGE_VERSION }}
             HARBOR_SCANNER_TRIVY_VERSION=${{ env.HARBOR_SCANNER_TRIVY_VERSION }}
-          tags: ${{ env.REGISTRY_ADDRESS }}/${{ env.REGISTRY_PROJECT }}/harbor-${{ matrix.component }}
+          tags: ${{ env.REGISTRY_ADDRESS }}/${{ env.REGISTRY_PROJECT }}/${{ steps.prepare.outputs.image_name }}
           outputs: type=image,push-by-digest=true,name-canonical=true,push=true
 
       - name: Export digest
@@ -168,7 +174,13 @@ jobs:
       TAG_NAME: ${{ needs.release-please.outputs.tag_name }}
     steps:
       - name: Prepare BuildKit
+        id: prepare
         run: |
+          if [ "${{ matrix.component }}" = "trivy-adapter" ]; then
+            echo "image_name=trivy-adapter" >> "$GITHUB_OUTPUT"
+          else
+            echo "image_name=harbor-${{ matrix.component }}" >> "$GITHUB_OUTPUT"
+          fi
           if [ -n "$BUILDX_HOST" ]; then
             echo "BUILDX_HOST=$BUILDX_HOST" >> "$GITHUB_ENV"
           fi
@@ -195,7 +207,7 @@ jobs:
       - name: Create manifest list and push
         working-directory: ${{ runner.temp }}/digests
         env:
-          IMAGE: ${{ env.REGISTRY_ADDRESS }}/${{ env.REGISTRY_PROJECT }}/harbor-${{ matrix.component }}
+          IMAGE: ${{ env.REGISTRY_ADDRESS }}/${{ env.REGISTRY_PROJECT }}/${{ steps.prepare.outputs.image_name }}
         run: |
           # shellcheck disable=SC2046
           docker buildx imagetools create \
@@ -240,8 +252,13 @@ jobs:
       - name: Sign images
         run: |
           for image in core jobservice registryctl exporter portal registry trivy-adapter; do
+            image_name="harbor-${image}"
+            if [ "${image}" = "trivy-adapter" ]; then
+              image_name="trivy-adapter"
+            fi
+
             cosign sign --yes \
-              "${REGISTRY_ADDRESS}/${REGISTRY_PROJECT}/harbor-${image}:${TAG_NAME}"
+              "${REGISTRY_ADDRESS}/${REGISTRY_PROJECT}/${image_name}:${TAG_NAME}"
           done
 
       - name: Generate GitHub App token
@@ -338,7 +355,11 @@ jobs:
             echo "| Image | Reference |"
             echo "|-------|-----------|"
             for image in $IMAGES; do
-              echo "| \`harbor-${image}\` | \`${REGISTRY}/harbor-${image}:${TAG_NAME}\` |"
+              image_name="harbor-${image}"
+              if [ "${image}" = "trivy-adapter" ]; then
+                image_name="trivy-adapter"
+              fi
+              echo "| \`${image_name}\` | \`${REGISTRY}/${image_name}:${TAG_NAME}\` |"
             done
             echo ""
             echo "**Verify an image signature:**"

--- a/deploy/compose/docker-compose.yaml
+++ b/deploy/compose/docker-compose.yaml
@@ -144,7 +144,7 @@ services:
     restart: unless-stopped
 
   trivy-adapter:
-    image: ${IMAGE_REPO:-}harbor-trivy-adapter:${HARBOR_TAG}
+    image: ${IMAGE_REPO:-}trivy-adapter:${HARBOR_TAG}
     environment:
       SCANNER_LOG_LEVEL: ${LOG_LEVEL:-info}
       SCANNER_REDIS_URL: redis://${REDIS_HOST:-redis}:${REDIS_PORT:-6379}/5

--- a/taskfile/image.yml
+++ b/taskfile/image.yml
@@ -191,7 +191,7 @@ tasks:
           SERVICE: trivy-adapter
       - task: _build
         vars:
-          IMAGE_NAME: harbor-trivy-adapter
+          IMAGE_NAME: trivy-adapter
           DOCKERFILE: trivy-adapter.dockerfile
           BUILD_ARGS: '--build-arg HARBOR_SCANNER_TRIVY_VERSION={{.HARBOR_SCANNER_TRIVY_VERSION}} --build-arg TRIVY_VERSION={{.TRIVY_VERSION}} --build-arg TRIVY_BASE_IMAGE_VERSION={{.TRIVY_BASE_IMAGE_VERSION}}'
 


### PR DESCRIPTION
## Summary
Update release and PR preview image publishing so the Trivy adapter is pushed as `trivy-adapter` instead of `harbor-trivy-adapter`.

## Related Issues
N/A

## Type of Change
- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` / `fix!:`)
- [ ] Documentation (`docs:`)
- [ ] Refactoring (`refactor:`)
- [x] CI/CD or build changes (`ci:` / `build:`)
- [ ] Dependencies update (`chore:`)
- [ ] Tests (`test:`)

## Release Notes
Trivy adapter images are now published as `trivy-adapter` instead of `harbor-trivy-adapter`.

## Testing
- [ ] Unit tests added/updated
- [x] Manual testing performed

Validated with:
- `git diff --check`
- `actionlint .github/workflows/release-please.yml .github/workflows/pr-ci.yml`

## Checklist
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] Commits are signed off (`git commit -s`)
- [x] No new warnings introduced