### PR TITLE
chore: Refresh repository documentation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -223,6 +223,33 @@ Signed-off-by: Your Name <your@email.com>
 
 The GitHub release note will render that entry as `by @original-author in goharbor/harbor#12345`.
 
+### Commercial Patch Commits
+
+Commercial patches can use a simple subject instead of a conventional commit. The patch `Subject:` becomes the release-note title, and the patch body before `---` becomes the description:
+
+```text
+Subject: [PATCH] Branding customization
+
+Allows operators to configure product branding for the portal without rebuilding
+the Harbor Next image.
+
+Supports custom names, logos, and landing page copy from deployment
+configuration.
+---
+```
+
+This renders in the release notes as:
+
+```markdown
+- **Branding customization**
+
+  Allows operators to configure product branding for the portal without rebuilding
+  the Harbor Next image.
+
+  Supports custom names, logos, and landing page copy from deployment
+  configuration.
+```
+
 ---
 
 ## Adding Release Notes to Your PR

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ If you are an organization that wants to help shape the evolution of Harbor,
 
 ## What is Harbor Next
 
-Harbor Next is a community-driven evolution of Harbor, designed to accelerate innovation and lower the barrier of entry for contributors.
+Harbor Next is a community-driven evolution of Harbor, designed to accelerate innovation and lower the barrier to entry for contributors.
 It serves as the foundation for [8gcr](https://container-registry.com/8gcr) (8gears Container Registry), used across enterprises, government agencies, and cloud providers.
 
 We're developing Harbor Next as a [community proposal](https://github.com/goharbor/community/pull/272) with the goal of advancing Harbor and the container registry ecosystem.

--- a/README.md
+++ b/README.md
@@ -128,10 +128,6 @@ See [devenv/README.md](devenv/README.md) for detailed development environment co
 
 Contributions are welcome. See [CONTRIBUTING.md](CONTRIBUTING.md) for the PR workflow, commit conventions (Conventional Commits + DCO sign-off), squash-merge rules, and how releases work. New contributors can get a dev environment running with `task` (see [Development](#development)).
 
-## OCI Distribution Conformance Tests
-
-Check the OCI distribution conformance tests [report](https://storage.googleapis.com/harbor-conformance-test/report.html) of Harbor.
-
 ## Compatibility
 
 The [compatibility list](https://goharbor.io/docs/edge/install-config/harbor-compatibility-list/) document provides compatibility information for the Harbor components.

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ We're developing Harbor Next as a [community proposal](https://github.com/goharb
 - Versatile Helm Chart
 - Open Compose (install.sh less) supporting Docker & Podman Compose
 - Support for OpenShift, Rancher, k3s, Nutanix (NKP)
-- Prepending vetted features not yet upstream
+- Prepending vetted features not yet upstream — see the [release notes](https://github.com/container-registry/harbor-next/releases)
 - See [ROADMAP.md](/ROADMAP.md) for more...
 
 ## Harbor Features

--- a/README.md
+++ b/README.md
@@ -9,13 +9,17 @@ Harbor is hosted by the [Cloud Native Computing Foundation](https://cncf.io)
 If you are an organization that wants to help shape the evolution of Harbor,
 [reach out](https://container-registry.com/contact/) to us.
 
-# What is Harbor Next
+## What is Harbor Next
 
-Harbor Next is a community-driven evolution of Harbor, designed to accelerate innovation and lower barriers for contributors.
-It serves as the upstream foundation for 8gcr (8gears Container Registry),
-in production at enterprises, government agencies, and cloud providers.
+Harbor Next is a community-driven evolution of Harbor, designed to accelerate innovation and lower the barrier of entry for contributors.
+It serves as the foundation for [8gcr](https://container-registry.com/8gcr) (8gears Container Registry), used across enterprises, government agencies, and cloud providers.
 
-We're developing Harbor Next as a [community proposal](https://github.com/goharbor/community/pull/272) with the goal of advancing the Harbor ecosystem — whether as a standalone project or as a future contribution back to CNCF Harbor.
+We're developing Harbor Next as a [community proposal](https://github.com/goharbor/community/pull/272) with the goal of advancing Harbor and the container registry ecosystem.
+
+- Harbor Next and CNCF Harbor cross-pollinate: Harbor Next cherry-picks features and fixes from Harbor, and upstream Harbor adopts features and concepts proven in Harbor Next.
+- Harbor Next follows the same release versioning and cadence as Harbor.
+- Harbor Next is a drop-in replacement for Harbor.
+
 
 ## Notable Changes in Harbor Next
 - Contributor/Maintainer ladder automation
@@ -24,51 +28,51 @@ We're developing Harbor Next as a [community proposal](https://github.com/goharb
 - Multi-architecture artifacts
 - Scratch images with minimal size and attack surface.
 - Use of Docker Distribution V3
-- Proxy and replicate Charts in Chart Museum Format
-- Backup/replicate images straight to SFTP or S3 
+- Replicate images to SFTP endpoints
 - Harbor Satellite Support
 - Versatile Helm Chart
 - Open Compose (install.sh less) supporting Docker & Podman Compose
-- Support for OpenShift,Rancher,k0s 
+- Support for OpenShift, Rancher, k3s, Nutanix (NKP)
 - Prepending vetted features not yet upstream
-- more...
+- See [ROADMAP.md](/ROADMAP.md) for more...
 
-## Features
+## Harbor Features
 
-* **Cloud native registry**: With support for both container images and [Helm](https://helm.sh) charts, Harbor serves as registry for cloud native environments like container runtimes and orchestration platforms.
-* **Role based access control**: Users access different repositories through 'projects' and a user can have different permission for images or Helm charts under a project.
-* **Policy based replication**: Images and charts can be replicated (synchronized) between multiple registry instances based on policies with using filters (repository, tag and label). Harbor automatically retries a replication if it encounters any errors. This can be used to assist loadbalancing, achieve high availability, and facilitate multi-datacenter deployments in hybrid and multi-cloud scenarios.
-* **Vulnerability Scanning**: Harbor scans images regularly for vulnerabilities and has policy checks to prevent vulnerable images from being deployed.
-* **LDAP/AD support**: Harbor integrates with existing enterprise LDAP/AD for user authentication and management, and supports importing LDAP groups into Harbor that can then be given permissions to specific projects.
-* **OIDC support**: Harbor leverages OpenID Connect (OIDC) to verify the identity of users authenticated by an external authorization server or identity provider. Single sign-on can be enabled to log into the Harbor portal.
-* **Image deletion & garbage collection**: System admin can run garbage collection jobs so that images(dangling manifests and unreferenced blobs) can be deleted and their space can be freed up periodically.
-* **Notary**: Support signing container images using Docker Content Trust (leveraging Notary) for guaranteeing authenticity and provenance.  In addition, policies that prevent unsigned images from being deployed can also be activated.
-* **Graphical user portal**: User can easily browse, search repositories and manage projects.
-* **Auditing**: All the operations to the repositories are tracked through logs.
-* **RESTful API**: RESTful APIs are provided to facilitate administrative operations, and are easy to use for integration with external systems. An embedded Swagger UI is available for exploring and testing the API.
-* **Easy deployment**: Harbor can be deployed via Docker compose as well Helm Chart, and a Harbor Operator was added recently as well.
+* **Cloud native registry**: Stores container images and OCI artifacts, including Helm charts as OCI artifacts, for container runtimes and orchestration platforms.
+* **Role based access control**: Users access repositories through 'projects', with per-project permissions on the artifacts they contain.
+* **Policy based replication**: Replicate artifacts between registry instances by policy and filters (repository, tag, label) with automatic retries — for load balancing, high availability, and multi-datacenter/hybrid/multi-cloud deployments.
+* **Vulnerability scanning**: Scans images for vulnerabilities and enforces policy checks to block vulnerable images from being deployed.
+* **LDAP/AD support**: Integrates with enterprise LDAP/AD for authentication and group import, mapping groups to project permissions.
+* **OIDC support**: Authenticates users via OpenID Connect against an external identity provider, with single sign-on into the portal.
+* **Image deletion & garbage collection**: Delete artifacts and reclaim storage by running garbage collection on dangling manifests and unreferenced blobs.
+* **Image signing & verification**: Released images are signed with keyless [cosign](https://github.com/sigstore/cosign) signatures — see [docs/signature-verification.md](docs/signature-verification.md).
+* **Graphical user portal**: Browse, search repositories, and manage projects from the web UI.
+* **Auditing**: All repository operations are tracked through logs.
+* **RESTful API**: REST APIs for administrative operations and integration, with an embedded Swagger UI for exploring and testing.
+* **Easy deployment**: Deploy via Docker/Podman Compose or the Harbor Next Helm chart.
 
 
 ## Architecture
 
-For learning the architecture design of Harbor, check the document [Architecture Overview of Harbor](https://github.com/goharbor/harbor/wiki/Architecture-Overview-of-Harbor).
+For the architecture design of Harbor Next, see [Architecture Overview](docs/architecture-overview.md).
 
 ## API
 
-* Harbor RESTful API: The APIs for most administrative operations of Harbor and can be used to perform integrations with Harbor programmatically.
-  * Part 1: [New or changed APIs](https://editor.swagger.io/?url=https://raw.githubusercontent.com/goharbor/harbor/main/api/v2.0/swagger.yaml)
+Harbor Next exposes a RESTful API for administrative operations and integration. Explore it in the [Swagger editor](https://editor.swagger.io/?url=https://raw.githubusercontent.com/container-registry/harbor-next/main/api/v2.0/swagger.yaml) or from the source spec [`api/v2.0/swagger.yaml`](api/v2.0/swagger.yaml).
 
 ## Install & Run
 
-**System requirements:**
+**System requirements:** Docker Engine 24+ with Compose v2.24+.
 
-**On a Linux host:** docker 20.10.10-ce+ and docker-compose 1.18.0+ .
+**Docker Compose** — see [deploy/compose/README.md](deploy/compose/README.md):
 
-Download binaries of **[Harbor release ](https://github.com/goharbor/harbor/releases)** and follow **[Installation & Configuration Guide](https://goharbor.io/docs/latest/install-config/)** to install Harbor.
+```bash
+cd deploy/compose
+cp .env.example .env          # set EXT_ENDPOINT, TLS_CERT/TLS_KEY, and secrets
+docker compose up -d
+```
 
-If you want to deploy Harbor on Kubernetes, please use the **[Harbor chart](https://github.com/goharbor/harbor-helm)**.
-
-Refer to the **[documentation](https://goharbor.io/docs/)** for more details on how to use Harbor.
+**Kubernetes** — install the Harbor Next Helm chart (`deploy/chart/`, also published as an OCI artifact; under active development). Platform guides live in [deploy/chart/docs/guide/](deploy/chart/docs/guide/) (k3s, OpenShift, Rancher, Nutanix).
 
 ## Development
 
@@ -120,44 +124,9 @@ Namespace aliases: `b:` (build), `t:` (test), `img:` (image), `d:` (dev).
 
 See [devenv/README.md](devenv/README.md) for detailed development environment commands.
 
-### Release Note Commit Formats
+## Contributing
 
-Use `upstream:` commits for cherry-picked changes from `goharbor/harbor`. Keep the subject conventional, then add the upstream PR and original author as trailers in the commit body:
-
-```text
-upstream(proxy): Preserve URL path prefix during registry auth discovery
-
-Upstream-PR: goharbor/harbor#12345
-Upstream-Author: @original-author
-Signed-off-by: Your Name <your@email.com>
-```
-
-This renders in release notes as an `Upstream` entry with the original upstream PR link and author.
-
-Commercial patch commits can use a simple subject instead of a conventional commit. The patch `Subject:` becomes the release-note title, and the patch body before `---` becomes the description:
-
-```text
-Subject: [PATCH] Branding customization
-
-Allows operators to configure product branding for the portal without rebuilding
-the Harbor Next image.
-
-Supports custom names, logos, and landing page copy from deployment
-configuration.
----
-```
-
-This renders as:
-
-```markdown
-- **Branding customization**
-
-  Allows operators to configure product branding for the portal without rebuilding
-  the Harbor Next image.
-
-  Supports custom names, logos, and landing page copy from deployment
-  configuration.
-```
+Contributions are welcome. See [CONTRIBUTING.md](CONTRIBUTING.md) for the PR workflow, commit conventions (Conventional Commits + DCO sign-off), squash-merge rules, and how releases work. New contributors can get a dev environment running with `task` (see [Development](#development)).
 
 ## OCI Distribution Conformance Tests
 
@@ -180,27 +149,14 @@ The [compatibility list](https://goharbor.io/docs/edge/install-config/harbor-com
 
 ## Demos
 
-* **[Live Demo](https://demo.goharbor.io)** - A demo environment with the latest Harbor stable build installed. For additional information please refer to [this page](https://goharbor.io/docs/latest/install-config/demo-server/).
-* **[Video Demos](https://github.com/goharbor/harbor/wiki/Video-demos-for-Harbor)** - Demos for Harbor features and continuously updated.
+* **[Live Demo](https://8gcr.container-registry.dev)** - A demo environment with the latest Harbor-Next build.
+* **[Harbor Demo Videos](https://github.com/goharbor/harbor/wiki/Video-demos-for-Harbor)** - Demos for Harbor features and continuously updated.
 
 ## Partners and Users
 
 For a list of users, please refer to [ADOPTERS.md](ADOPTERS.md).
 
-## Security
-
-### Security Audit
-
-A third party security audit was performed by Cure53 in October 2019. You can see the full report [here](https://goharbor.io/docs/2.0.0/security/Harbor_Security_Audit_Oct2019.pdf).
-
-### Reporting security vulnerabilities
-
-If you've found a security related issue, a vulnerability, or a potential vulnerability in Harbor Next, please report it privately through [GitHub Security Advisories](https://github.com/container-registry/harbor-next/security/advisories/new). Maintainers will acknowledge your report and coordinate investigation, remediation, and disclosure through the private advisory.
-
-For further details please see our complete [security release process](SECURITY.md).
 
 ## License
 
 Harbor is available under the [Apache 2 license](LICENSE).
-
-## Fossa Status

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,1 +1,4 @@
-# Versioning and Release
+# Release
+
+
+- See https://github.com/container-registry/harbor-next/releases

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -17,7 +17,7 @@ Legend: ✅ Delivered · 🚧 In progress · 🗓️ Planned · 💲 Commercial 
 
 - ✅ **CI/CD Pipeline** — Continuous delivery readiness for reliable, extensible workflows locally and in pipelines.
 - ✅ **PR Builds** — Each PR gets a set of images for users to grab, verify and use.
-- ✅ **Multi-architecture builds** — Build binaires and images for different architecutures starting with ARM64 and AMD64
+- ✅ **Multi-architecture builds** — Build binaries and images for different architectures starting with ARM64 and AMD64
 - ✅ **Scratch Images** — Scratch images with minimal size and attack surface.
 - ✅ **DEV Env** — Easy contributor onboarding with out of the box local dev environments.
 - ✅ **K8s Distributions Support** — Tested support for OpenShift, Rancher, k0s

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -5,7 +5,7 @@ A high level roadmap to give users an idea where the next generation **Harbor** 
 Harbor next is focusing on 3 areas
 
 - Ease of development, deployment and operation with minimum resource utilization (compute and dependencies)
-- Extensibility for user self exension of Harbor
+- Extensibility for user self extension of Harbor
 - Vendor neutral community
 
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -45,6 +45,6 @@ Legend: ✅ Delivered · 🚧 In progress · 🗓️ Planned · 💲 Commercial 
 - 🗓 **Pluggable Scanner Spec V1.3** — Generic image analysis & chaining beyond SBOM and vulnerabilites.
 - 🗓 **Extension Points** — Users can to extend Harbor at various points.
 - 🗓 **New Portal** — Node/Angular less portal with simple HTML MPA.
-- 🗓 **Drop Redis** — With an architectual redising Redis is not needed for caching.
+- 🗓 **Drop Redis** — With an architectural redesign Redis is not needed for caching.
 - 🗓 **3-tier Stack** — One Application/Container & Database stack.
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -15,7 +15,7 @@ Legend: ✅ Delivered · 🚧 In progress · 🗓️ Planned · 💲 Commercial 
 
 ## Delivered in v2.15
 
-- ✅ **CI/CD Pipeline** — Continous delivery readiness for reliable, extensible workflows localy and in pipelines.
+- ✅ **CI/CD Pipeline** — Continuous delivery readiness for reliable, extensible workflows locally and in pipelines.
 - ✅ **PR Builds** — Each PR gets a set of images for users to grab, verify and use.
 - ✅ **Multi-architecture builds** — Build binaires and images for different architecutures starting with ARM64 and AMD64
 - ✅ **Scratch Images** — Scratch images with minimal size and attack surface.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,12 +1,12 @@
 # Harbor Next Roadmap
 
-A high level roadmap to give users an idea where the next generation **Harbor** is heading towards.
+A high-level roadmap giving users an idea of where the next-generation **Harbor** is headed.
 
-Harbor next is focusing on 3 areas
+Harbor Next focuses on three areas:
 
-- Ease of development, deployment and operation with minimum resource utilization (compute and dependencies)
-- Extensibility for user self extension of Harbor
-- Vendor neutral community
+- Ease of development, deployment, and operation with minimal resource utilization (compute and dependencies)
+- User-driven extensibility of Harbor
+- Vendor-neutral community
 
 
 Legend: ✅ Delivered · 🚧 In progress · 🗓️ Planned · 💲 Commercial feature
@@ -17,17 +17,17 @@ Legend: ✅ Delivered · 🚧 In progress · 🗓️ Planned · 💲 Commercial 
 
 - ✅ **CI/CD Pipeline** — Continuous delivery readiness for reliable, extensible workflows locally and in pipelines.
 - ✅ **PR Builds** — Each PR gets a set of images for users to grab, verify and use.
-- ✅ **Multi-architecture builds** — Build binaries and images for different architectures starting with ARM64 and AMD64
+- ✅ **Multi-architecture builds** — Build binaries and images for different architectures, starting with ARM64 and AMD64.
 - ✅ **Scratch Images** — Scratch images with minimal size and attack surface.
-- ✅ **DEV Env** — Easy contributor onboarding with out of the box local dev environments.
-- ✅ **K8s Distributions Support** — Tested support for OpenShift, Rancher, k0s
+- ✅ **DEV Env** — Easy contributor onboarding with out-of-the-box local dev environments.
+- ✅ **K8s Distributions Support** — Tested support for OpenShift, Rancher, k0s, k3s.
 - ✅ **Built-in connection pooling** — database driver upgraded to pgx/v5 including connection pooling.
 - ✅ **Public landing page** — Allow unauthenticated users to browse publicly available repositories.
-- ✅ **Compose File** — install.sh less and non-root compose file for Docker and Podman.
+- ✅ **Compose File** — install.sh-free, non-root Compose file for Docker and Podman.
 - ✅ **Docker Distribution** — Use of Docker Distribution V3.
-- ✅ **Harbor Satellite** —  Support for Harbor satellite image replication to EDGE.
+- ✅ **Harbor Satellite** — Support for Harbor Satellite image replication to the edge.
 - ✅ **Customizable Branding** 💲 — system-wide white-label branding (logo, product name, login/about skinning) via REST API and Portal.
-- ✅ **Hybrid / multi authentication** 💲 — local DB users alongside an external auth backend (LDAP/OIDC).
+- ✅ **Hybrid / multi-authentication** 💲 — local DB users alongside an external auth backend (LDAP/OIDC).
 - ✅ **SFTP replication adapter** 💲 — replication storage adapter targeting SFTP endpoints.
 - ✅ **Pluggable identity providers** 💲 — generalized identity-provider framework with Workload Identity Federation.
 - ✅ **Database observability (pgx monitoring)** 💲 — PostgreSQL connection-pool and query metrics exported via OpenTelemetry.
@@ -37,14 +37,14 @@ Legend: ✅ Delivered · 🚧 In progress · 🗓️ Planned · 💲 Commercial 
 
 ## Next
 
-- 🚧 **Helm Chart** — Versatile Helm Chart.
-- 🚧 **Helm Chart Proxy** — Proxy and replicate Charts in Chart Museum Format.
-- 🗓 **Maintainer ladder automation** — Avoid single vendor dominance by automated promoting/demotion based on KPIs.
-- 🗓 **Pull Through Cache** — True pull through proxy cache.
-- 🗓 **Feature Flags** — for easier adoption of new features and feature sandboxing.
-- 🗓 **Pluggable Scanner Spec V1.3** — Generic image analysis & chaining beyond SBOM and vulnerabilites.
-- 🗓 **Extension Points** — Users can to extend Harbor at various points.
-- 🗓 **New Portal** — Node/Angular less portal with simple HTML MPA.
-- 🗓 **Drop Redis** — With an architectural redesign Redis is not needed for caching.
-- 🗓 **3-tier Stack** — One Application/Container & Database stack.
+- 🚧 **Helm Chart** — A versatile Helm chart for Kubernetes.
+- 🚧 **Helm Chart Proxy** — Proxy and replicate charts in ChartMuseum format.
+- 🗓 **Maintainer ladder automation** — Avoid single-vendor dominance by automating promotion/demotion based on KPIs.
+- 🗓 **Pull-Through Cache** — True pull-through proxy cache.
+- 🗓 **Feature Flags** — Easier adoption of new features, plus feature sandboxing.
+- 🗓 **Pluggable Scanner Spec V1.3** — Generic image analysis & chaining beyond SBOM and vulnerabilities.
+- 🗓 **Extension Points** — Users can extend Harbor at various points.
+- 🗓 **New Portal** — A portal without Node/Angular — a simple HTML multi-page app (MPA).
+- 🗓 **Drop Redis** — With an architectural redesign, Redis is no longer needed for caching.
+- 🗓 **Simplified Stack** — Collapse to a single application container plus a database.
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,6 +1,6 @@
 # Harbor Next Roadmap
 
-A high level roadmap to give users and idea where the next generation **Harbor** is heading towards.
+A high level roadmap to give users an idea where the next generation **Harbor** is heading towards.
 
 Harbor next is focusing on 3 areas
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -22,7 +22,7 @@ Legend: ✅ Delivered · 🚧 In progress · 🗓️ Planned · 💲 Commercial 
 - ✅ **DEV Env** — Easy contributor onboarding with out of the box local dev environments.
 - ✅ **K8s Distributions Support** — Tested support for OpenShift, Rancher, k0s
 - ✅ **Built-in connection pooling** — database driver upgraded to pgx/v5 including connection pooling.
-- ✅ **Public landing page** — Allow unauthenticated users to browse publicly availibe repositories.
+- ✅ **Public landing page** — Allow unauthenticated users to browse publicly available repositories.
 - ✅ **Compose File** — install.sh less and non-root compose file for Docker and Podman.
 - ✅ **Docker Distribution** — Use of Docker Distribution V3.
 - ✅ **Harbor Satellite** —  Support for Harbor satellite image replication to EDGE.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,1 +1,50 @@
-## Harbor Next Roadmap
+# Harbor Next Roadmap
+
+A high level roadmap to give users and idea where the next generation **Harbor** is heading towards.
+
+Harbor next is focusing on 3 areas
+
+- Ease of development, deployment and operation with minimum resource utilization (compute and dependencies)
+- Extensibility for user self exension of Harbor
+- Vendor neutral community
+
+
+Legend: ✅ Delivered · 🚧 In progress · 🗓️ Planned · 💲 Commercial feature
+
+---
+
+## Delivered in v2.15
+
+- ✅ **CI/CD Pipeline** — Continous delivery readiness for reliable, extensible workflows localy and in pipelines.
+- ✅ **PR Builds** — Each PR gets a set of images for users to grab, verify and use.
+- ✅ **Multi-architecture builds** — Build binaires and images for different architecutures starting with ARM64 and AMD64
+- ✅ **Scratch Images** — Scratch images with minimal size and attack surface.
+- ✅ **DEV Env** — Easy contributor onboarding with out of the box local dev environments.
+- ✅ **K8s Distributions Support** — Tested support for OpenShift, Rancher, k0s
+- ✅ **Built-in connection pooling** — database driver upgraded to pgx/v5 including connection pooling.
+- ✅ **Public landing page** — Allow unauthenticated users to browse publicly availibe repositories.
+- ✅ **Compose File** — install.sh less and non-root compose file for Docker and Podman.
+- ✅ **Docker Distribution** — Use of Docker Distribution V3.
+- ✅ **Harbor Satellite** —  Support for Harbor satellite image replication to EDGE.
+- ✅ **Customizable Branding** 💲 — system-wide white-label branding (logo, product name, login/about skinning) via REST API and Portal.
+- ✅ **Hybrid / multi authentication** 💲 — local DB users alongside an external auth backend (LDAP/OIDC).
+- ✅ **SFTP replication adapter** 💲 — replication storage adapter targeting SFTP endpoints.
+- ✅ **Pluggable identity providers** 💲 — generalized identity-provider framework with Workload Identity Federation.
+- ✅ **Database observability (pgx monitoring)** 💲 — PostgreSQL connection-pool and query metrics exported via OpenTelemetry.
+- ✅ **AWS RDS IAM authentication** 💲 — IAM auth for PostgreSQL/S3, removing static DB passwords on RDS and S3.
+
+---
+
+## Next
+
+- 🚧 **Helm Chart** — Versatile Helm Chart.
+- 🚧 **Helm Chart Proxy** — Proxy and replicate Charts in Chart Museum Format.
+- 🗓 **Maintainer ladder automation** — Avoid single vendor dominance by automated promoting/demotion based on KPIs.
+- 🗓 **Pull Through Cache** — True pull through proxy cache.
+- 🗓 **Feature Flags** — for easier adoption of new features and feature sandboxing.
+- 🗓 **Pluggable Scanner Spec V1.3** — Generic image analysis & chaining beyond SBOM and vulnerabilites.
+- 🗓 **Extension Points** — Users can to extend Harbor at various points.
+- 🗓 **New Portal** — Node/Angular less portal with simple HTML MPA.
+- 🗓 **Drop Redis** — With an architectual redising Redis is not needed for caching.
+- 🗓 **3-tier Stack** — One Application/Container & Database stack.
+

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,2 +1,0 @@
-# Harbor Documentation
-

--- a/docs/Taskfile.yml
+++ b/docs/Taskfile.yml
@@ -10,6 +10,17 @@ version: '3'
 #   -->
 #   ![alt](https://kroki.io/svgbob/svg/<encoded>)   <- auto-generated
 #
+# '-->' handling: ASCII sequence arrows ('+----->') contain '-->', which would
+# close the surrounding HTML comment early on GitHub and leak the diagram. So
+# this task rewrites every '-->' in the diagram body to '-–>' (an EN DASH,
+# U+2013, in the middle). SVGBob renders '-–>' byte-identically to '-->' (the
+# en dash is treated as a line segment), so the image is unchanged — but the
+# literal '-->' is gone, so the comment stays closed and hidden. Edit the
+# diagram with normal '-->'; running this task escapes it for you.
+#
+# The diagram body is matched with a tempered token bounded by the closing
+# '```' line, so arrowhead '>' characters in the body don't break matching.
+#
 # If the image link is missing, it will be added automatically.
 
 tasks:
@@ -26,6 +37,8 @@ tasks:
           python3 - "{{.ITEM}}" <<'PYTHON'
           import sys, re, zlib, base64
 
+          DASH = '-–>'   # hyphen + EN DASH + '>' — renders like '-->' but isn't a comment close
+
           def encode(diagram):
               return base64.urlsafe_b64encode(zlib.compress(diagram.encode(), 9)).decode()
 
@@ -33,24 +46,27 @@ tasks:
           with open(file) as f:
               content = original = f.read()
 
-          # Pattern: <!-- ... ```SVGBob\n...``` ... -->
-          # Optionally followed by ![...](https://kroki.io/svgbob/svg/...)
-          pattern = r'(<!--\s*```SVGBob\n)(.*?)(```[^>]*-->)(\s*!\[[^\]]*\]\(https://kroki\.io/svgbob/svg/)[A-Za-z0-9_=-]*(\))?'
+          # 1=open  2=body (tempered, up to the closing ``` line)  3=close (```...-->)
+          # 4=image-prefix  5=closing-paren
+          pattern = (r'(<!--\s*```SVGBob\n)'
+                     r'((?:(?!\n```).)*?)'
+                     r'(\n```[^>]*?-->)'
+                     r'(\s*!\[[^\]]*\]\(https://kroki\.io/svgbob/svg/)[A-Za-z0-9_=-]*(\))?')
 
           def replace_existing(m):
-              diagram = m.group(2)
-              encoded = encode(diagram)
-              return m.group(1) + diagram + m.group(3) + m.group(4) + encoded + (m.group(5) or ')')
+              body = m.group(2).replace('-->', DASH)      # escape arrows; renders identically
+              encoded = encode(body)
+              return m.group(1) + body + m.group(3) + m.group(4) + encoded + (m.group(5) or ')')
 
           content = re.sub(pattern, replace_existing, content, flags=re.DOTALL)
 
-          # Add missing URLs: <!-- ```SVGBob...``` --> without following image link
-          pattern_missing = r'(<!--\s*```SVGBob\n)(.*?)(```[^>]*-->)(?!\s*!\[)'
+          # Same, but for blocks without a following image link — add one.
+          pattern_missing = r'(<!--\s*```SVGBob\n)((?:(?!\n```).)*?)(\n```[^>]*?-->)(?!\s*!\[)'
 
           def add_url(m):
-              diagram = m.group(2)
-              encoded = encode(diagram)
-              return m.group(1) + diagram + m.group(3) + f'\n![Diagram](https://kroki.io/svgbob/svg/{encoded})'
+              body = m.group(2).replace('-->', DASH)
+              encoded = encode(body)
+              return m.group(1) + body + m.group(3) + f'\n![Diagram](https://kroki.io/svgbob/svg/{encoded})'
 
           content = re.sub(pattern_missing, add_url, content, flags=re.DOTALL)
 

--- a/docs/architecture-overview.md
+++ b/docs/architecture-overview.md
@@ -1,112 +1,209 @@
 # Architecture Overview
 
 ## System at a glance
-Harbor is a multi-service container registry platform with a Go backend, Angular UI, and supporting infrastructure (PostgreSQL, Redis/Valkey, and a Docker Distribution registry). The Core service is the API gateway and orchestrator; JobService runs background tasks; RegistryCtl performs direct storage operations for garbage collection; the Portal provides the UI.
-## Architecture diagram
+Harbor is an OCI-compliant, cloud-native artifact registry. It manages container images, OCI artifacts, and Helm charts (stored as OCI artifacts), and supports multi-architecture images and OCI image indexes.
+
+It is a set of cooperating services behind a single gateway. The **Core** service is the API gateway and orchestrator; **JobService** runs background tasks; **RegistryCtl** performs direct storage operations for garbage collection; the **Portal** serves the UI. Supporting infrastructure is PostgreSQL (metadata), Redis/Valkey (cache + job queue), and a Docker Distribution registry (blob/manifest storage).
+
+## Architecture Diagram
 
 <!-- 
 ```SVGBob
 ┌──────────────────────────────────────────────────────────────────────────────┐
 │                              "CLIENTS"                                       │
 │  ┌─────────────────────┐              ┌────────────────────────────────────┐ │
-│  │ "Browser / CLI"     │              │ "Docker, OCI Client"               │ │
-│  │ "Angular app"       │              │ "docker push, pull, helm, etc"     │ │
+│  │   "Browser / CLI"   │              │       "Docker, OCI Client"         │ │
+│  │   "Angular app"     │              │   "docker push, pull, helm, etc"   │ │
 │  └──────────┬──────────┘              └──────────────────┬─────────────────┘ │
-└─────────────│───────────────────────────────────────────│────────────────────┘
-      ┌───────┴───────┐                                   │
-      │               │                                   │
-      ▼               ▼                                   ▼
-┌─────────────┐ ┌──────────────────────────────────────────────────────────────┐
-│  "Portal"   │ │                         "CORE :8080"                         │
-│  ":80"      │ │ ┌───────────────────────────┐ ┌───────────────────────────┐  │
-│  "nginx"    │ │ │ "REST API /api/v2.0/*"    │ │ "OCI Dist. v1.1 /v2/*"    │  │
-│  "static"   │ │ └─────────────┬─────────────┘ └─────────────┬─────────────┘  │
-└─────────────┘ │               └───────────┬─────────────────┘                │
-                │                           ▼                                  │
-                │ ┌──────────────────────────────────────────────────────────┐ │
-                │ │     "Middleware: Auth, RBAC, Quota, Readonly, CSRF"      │ │
-                │ └──────────────────────────────────────────────────────────┘ │
-                │                           │                                  │
-                │                           ▼                                  │
-                │ ┌──────────────────────────────────────────────────────────┐ │
-                │ │                    "Controllers"                         │ │
-                │ └──────────────────────────────────────────────────────────┘ │
-                │                           │                                  │
-                │                           ▼                                  │
-                │ ┌──────────────────────────────────────────────────────────┐ │
-                │ │                  "Data Access Layer"                     │ │
-                │ └──────────────────────────────────────────────────────────┘ │
-                └────┬───────────────┬───────────────┬───────────────┬─────────┘
-                     │               │               │               │
-                     ▼               ▼               ▼               ▼
-              ┌─────────────┐ ┌─────────────┐ ┌─────────────┐ ┌─────────────┐
-              │"JobService" │ │"PostgreSQL" │ │  "Valkey"   │ │"Distrib. V3"│
-              │  ":8888"    │ │  ":5432"    │ │  ":6379"    │ │  ":5000"    │
-              └──────┬──────┘ └─────────────┘ └─────────────┘ └──────┬──────┘
-                     │               ▲               ▲               │
-                     ├───────────────┴───────────────┘               │
-                     │                                               │
-                     ▼                                               │
-              ┌─────────────┐                                        │
-              │"RegistryCtl"│                                        │
-              │  ":8080"    │────────────────────────────────────────┤
-              └──────┬──────┘                                        │
-                     │                                               │
-                     ▼                                               ▼
+└─────────────│─────────────────────────────────────────── │───────────────────┘
+         ┌────┴─────────────────────┐                      │
+         │                          │                      │
+         ▼                          ▼                      ▼
+┌──────────────────┐ ┌─────────────────────────────────────────────────────────┐
+│   "Portal :80"   │ │                      "CORE :8080"                       │
+│                  │ │ ┌─────────────────────────┐ ┌─────────────────────────┐ │
+│     "nginx"      │ │ │ "REST API /api/v2.0/*"  │ │ "OCI Dist. v1.1 /v2/*"  │ │
+│     "static"     │ │ └─────────────────────────┘ └─────────────────────────┘ │
+└──────────────────┘ │              └─────────────┬─────────────┘              │
+                     │                            ▼                            │
+                     │ ┌─────────────────────────────────────────────────────┐ │
+                     │ │   "Middleware: Auth, RBAC, Quota, Readonly, CSRF"   │ │
+                     │ └─────────────────────────────────────────────────────┘ │
+                     │                            │                            │
+                     │                            ▼                            │
+                     │ ┌─────────────────────────────────────────────────────┐ │
+                     │ │                    "Controllers"                    │ │
+                     │ └─────────────────────────────────────────────────────┘ │
+                     │                            │                            │
+                     │                            ▼                            │
+                     │ ┌─────────────────────────────────────────────────────┐ │
+                     │ │                 "Data Access Layer"                 │ │
+                     │ └─────────────────────────────────────────────────────┘ │
+                     └─┬───────────────┬───────────────┬───────────────┬───────┘
+                       │               │               │               │
+                       ▼               ▼               ▼               ▼
+                ┌─────────────┐ ┌─────────────┐ ┌─────────────┐ ┌─────────────┐
+                │"JobService" │ │"PostgreSQL" │ │  "Valkey"   │ │"Distrib. V3"│
+                │   ":8888"   │ │   ":5432"   │ │   ":6379"   │ │   ":5000"   │
+                └──────┬──────┘ └─────────────┘ └─────────────┘ └──────┬──────┘
+                       │               ▲               ▲               │
+                       ├───────────────┴───────────────┘               │
+                       │                                               │
+                       ▼                                               │
+                ┌─────────────┐                                        │
+                │"RegistryCtl"│                                        │
+                │   ":8080"   │────────────────────────────────────────┤
+                └──────┬──────┘                                        │
+                       │                                               │
+                       ▼                                               ▼
 ┌──────────────────────────────────────────────────────────────────────────────┐
 │                          "STORAGE BACKEND"                                   │
-│    "Filesystem, S3, GCS, Azure Blob, OpenStack Swift, Alibaba OSS"           │
+│            "Filesystem, S3, GCS, Azure Blob (inmemory for tests)"            │
 └──────────────────────────────────────────────────────────────────────────────┘
 ```
 Structure for auto-update: run `task` in docs/ directory.
 The diagram must be inside a HTML comment, wrapped in ```SVGBob fences.
 The Kroki image link must follow immediately after the closing. If missing one will be created.
 -->
-![Architecture Diagram](https://kroki.io/svgbob/svg/eNrtWctu2kAU3fsrru6ysoCEPlJ2xpAoLQ0JRtkPZkosJjYaD1C6qlh34YWFvOiyS1ZVlvkavqSmCQ1gDDYOkAeWhcT4-ozv9TlnHh65P0fuj1dzOtLI7cPSA9XSafGsqiFEO3zAO9DRI5TSmcfe8ttxptPpA-a51bUphzT4VcFJvoECABYsvUm5DGX1FFRmUFNgsE5z4IrZaDPCgbRaOBUUBK__A4dW276S_V_GZLii7FoGKnRcBO6uynO4KsCbfwx33ZIO17rLu08nerf9JyCvhM_gSatofxNNN6FCDWEZrHSFeYTB7fy1QMtChMGtFEfUzvYtYCOGi-cWF4Thg1SX-G-5UoTcUeYog6tNF3P_wybAm6mYszHcqWTMhmF-w9lkfP-rFLUqKOenkCYtI905TGXSb2aicGy7BcMWKegcpA7Aj5mKmOrAFkQYOs504G7AyryN4cb2RW-h3N0NOneoa0T1m0heEgb7DA3DWZLMXZ3wi1GvM9olnOZAaQt_HlDJK6oMF21LEP8PJXXLZD0ZVK1yPGsIIcDuc6uStw6Tooxre4ImJ2hgELNMwS3GKLeXjmJ7gu4Jun2CYoEIAoquU9uGEulRjq-ZoG6ycX-38Z4UUVgRW6SIgorYIq2_o-E8nehAFn38ZNU0yjuGTnGiE3-VY4sGp9pFCR_Eh5eENWlvatKN46k6N2opuMxisOSThY1_zMzy_bZ3b7OH823vsx8-BuIymQwufqEhuh0mn8Y_UvQwGcsHf1a3hLLc_RVTmzcJVwdLHiXKjsSa2o0PFU9bCbrpY4U2xvLoqYJhjCqE62iyk7DTPbLfiWSYmAI7ZVPMTa-X_50BtWq5opwUwV_Dfi6eFTDiC7kHxWODUbtnC3otg5aV4UTVZFC-tzmFPLNqMpRb1NQE0ZugdY2vwr_IjBqpEShrMx824m6mvIDTk_4CQg_fbA==)
+![Architecture Diagram](https://kroki.io/svgbob/svg/eNrtWU1v2kAQvftXjObUVhaQ0I-UmzEkoqUhwSh3A1tiZbHReiGlp8pnDhysyIcee-RU5dhfwy-pCaGAMcY2JrQNFiCxO367M_ve8y6M7cHY_vZsXkNhbFsQeKFcLhXPawpCuMsFnIKOEyjl0Iv9xKszXExnUijMM-PWJAzS4NYFYda-XIBZ6QpG44YwESpyCWSqEZ3jUpgXXNJbXaoyUDsd9GAtgWPzARg6XfNadD8pFeGa0LYIhDdwFdzelOdoU4DjnYYdt6SjWHc5j-mEH9bau7xgu0k4wnre3yetrEX1-jDZPzIMxN2vAIh1nW6HsIXWh09vFAn5MF4YjKsUcieZBRmvM-ZKtTiJnMYGerHf4k3fg8T9crArB57krLc0_Qt6k7AAq0WlBtJFCdJqR0v3jlOZ9Cucx-DEgguayVPQO0odgRux2D8fwOQq1xroGcBONCdnJ4jR7NEPIL7HjyIMtN4sQtlLCF_ZAPsvmMNwUwoPbvFJazYpuVUZyYHU5e5eoJqXZBEuuwZX3S9EbRo67YsgK9XTxX1BALD919fGic-ajd0HMsYlo8_zydA5MyglzMSAew9kPJBxt2TEgspVkBoNYppQVvuE4TMkox3r-LWveEcILZuQLUJowYRsEVanNtjRTnmn0T55WPjBqCuE9bQGwZk23MOJyVuMKJdlnGsNr1R6Q_oLuwuc7LOZVk_BVRb9Cv-4e8mduNfyMQdzb15nj71tb7Pv3q_EZTKzI5KwjuthqBZtL55Q9Ghbxt_93NwSwHj7e0SV3kc2ogiTsSDaFUnLccCiaW2rgSysktZELn2ZU4xQi0BdZf78fLC_Z9GPLWWZABn2zKztfsT6D_9OQKVWqUpnRXAPqR-L5wUMuSQeUDzVKDH7JidtEZSsCGeyIoL0tcsI5KlRhxea3iZtg_Xhs8GAE5ObL3EV1H5OS-P8Bk8cqw8=)
 
+
+_The diagram shows the Docker Compose topology; see [Deployment topologies](#deployment-topologies) for how the same components map to Kubernetes._
+
+## Three-layer model
+Harbor is conventionally described in three layers:
+
+1. **Consumers** — clients that talk to Harbor: the Web Portal (browser), Docker/`containerd` clients, Helm, and other OCI tooling (e.g. ORAS).
+2. **Fundamental services** — the proxy plus the application services (Core, JobService, RegistryCtl, Distribution registry).
+3. **Data access** — PostgreSQL (metadata/config), Redis/Valkey (cache + job-state/queue), and the configured object/file storage backend for blobs and manifests.
 
 ## Major components
-- **Core** (`src/core/main.go`)
-  - Serves REST API (`/api/v2.0`) generated from `api/v2.0/swagger.yaml`.
-  - Proxies Docker/OCI registry requests (`/v2/*`) to the Distribution registry after auth and policy checks.
-  - Hosts the portal UI in production and manages auth, RBAC, projects, artifacts, and quotas.
-  - Entry points for business logic in `src/controller`, with data access in `src/pkg` and shared infra in `src/lib`.
 
-- **API layer**
-  - Go server stubs are generated into `src/server/v2.0/models` and `src/server/v2.0/restapi`.
-  - Controllers implement business logic; middleware lives in `src/server/middleware`.
+- **Edge / exposure** — terminates external traffic and routes browser and registry-client requests to the Portal, Core REST API, and the OCI distribution endpoints. Its form is deployment-specific (see [Deployment topologies](#deployment-topologies)): an **nginx** reverse-proxy container (built as the `nginx` image in this fork) in Docker Compose, or an Ingress / Gateway API `HTTPRoute` / OpenShift `Route` in Kubernetes.
 
-- **JobService** (`src/jobservice/main.go`)
-  - Executes background jobs (scan, replication, GC, retention, audit purge, etc.).
-  - Uses Redis-backed queues via the Harbor fork of `gocraft/work`.
-  - Communicates with Core over HTTP and reports job state.
+- **Core** (`src/core/main.go`) — the central service. It hosts:
+  - **REST API** under `/api/v2.0`, with Go server stubs generated from `api/v2.0/swagger.yaml` into `src/server/v2.0/{models,restapi}`. Business logic lives in `src/controller`, data access in `src/pkg`, and shared infrastructure in `src/lib`. Request middleware (auth, RBAC, quota, read-only, CSRF) is in `src/server/middleware`.
+  - **OCI/Docker registry proxy** (`/v2/*`) — forwards image pull/push to the Distribution registry after authentication and policy checks.
+  - **Token service** (`src/core/service/token`) — issues signed bearer tokens authorizing registry pull/push scoped to the user's role.
+  - **Authentication & authorization** — pluggable auth backends (local DB, LDAP/AD, OIDC, UAA, AuthProxy; `src/core/auth`) with project- and system-scoped RBAC enforced via Casbin.
+  - **Domain managers** invoked through controllers, including project & quota management, OCI artifact lifecycle, tag **retention** (`src/pkg/retention`), **replication** to/from external registries, **scan** orchestration, **webhook notifications** (`src/pkg/notification`), garbage-collection scheduling, and system configuration.
 
-- **RegistryCtl** (`src/registryctl/main.go`)
-  - Performs direct blob/manifest deletion in the storage backend.
-  - Used by garbage collection to remove unreferenced content.
+- **JobService** (`src/jobservice/main.go`) — executes asynchronous jobs (scan, replication, GC, retention, audit-log purge, etc.). Jobs run on Redis-backed queues via Harbor's fork of `gocraft/work` (`github.com/goharbor/work`). It communicates with Core over HTTP and reports job state. Job types are Generic (immediate), Scheduled (delayed), and Periodic (cron).
 
-- **Portal** (`src/portal`)
-  - Angular UI for projects, repositories, artifacts, and system configuration.
-  - Frontend API client is generated from Swagger into `src/portal/ng-swagger-gen`.
+- **RegistryCtl** (`src/registryctl/main.go`) — companion to the Distribution registry that performs direct blob/manifest deletion in the storage backend (wrapping `docker/distribution`'s `storage.Vacuum`). Used by garbage collection to remove unreferenced content, since the registry V2 API has no clean deletion path for GC.
 
-- **Infrastructure**
-  - **PostgreSQL**: metadata and configuration storage.
-  - **Redis/Valkey**: cache and job queue.
-  - **Distribution registry**: stores blobs and manifests in configured storage (filesystem/S3/GCS/etc).
+- **Distribution registry** — upstream `docker/distribution` **v3.0.0**, storing blobs and manifests in the configured backend. Distribution v3 supports **filesystem, S3, GCS, and Azure Blob** (plus `inmemory` for testing); the v2-era OpenStack Swift and Alibaba OSS drivers are no longer supported. Enforces access by validating Core-issued tokens.
 
-## Data flow highlights
-- **Image push/pull**
-  - Client → Core (`/v2/*`) for auth/authorization and policy checks.
-  - Core → Distribution registry for blob/manifest storage and retrieval.
-  - Core persists metadata in PostgreSQL and caches manifest metadata in Redis.
+- **Portal** (`src/portal`) — Angular UI for projects, repositories, artifacts, and system configuration. Its API client is generated from Swagger into `src/portal/ng-swagger-gen`.
 
-- **API requests**
-  - Client → Core (`/api/v2.0/*`) → generated handler → controller → DAO (`src/pkg`) → PostgreSQL/Redis.
+- **Exporter** (`src/cmd/exporter`, `src/pkg/exporter`) — exposes Prometheus metrics for the Harbor services.
 
-- **Background jobs**
-  - Core submits jobs to JobService (HTTP).
-  - JobService executes tasks, updates job status, and calls back Core when complete.
-  - GC jobs use RegistryCtl to delete blobs/manifests in the storage backend.
+- **Scanning** — pluggable scanner integration (`src/pkg/scan`). Trivy is the default adapter (`HARBOR_SCANNER_TRIVY_VERSION` in `versions.env`); vulnerability reports and SBOM generation (`src/pkg/scan/sbom`) are supported.
 
-## Development topology (dev environment)
-`task dev:up` runs Core, JobService, RegistryCtl, Trivy adapter, and supporting services in Docker with hot reload. The Portal can run natively with HMR or in a container; service ports and profiling endpoints are described in `devenv/README.md`.
+## Service-to-service authentication
+Distinct from user-facing auth (LDAP/OIDC/etc.), Harbor's components also authenticate to *one another* across the internal network. Most edges use a shared secret injected at deploy time via config; registry access additionally accepts bearer tokens minted by Core's token service:
+
+| Edge | Credential |
+|------|-----------|
+| Core → JobService | `CORE_SECRET` |
+| Core / JobService → RegistryCtl | `JOBSERVICE_SECRET` |
+| Core / JobService → Distribution registry | Basic auth / bearer token |
+| Portal → Core | session / token |
+
+## Key Sequences
+These handful interactions capture the essence of how Harbor works. Each numbered sequence below maps to a lane in the diagram.
+
+<!--
+```SVGBob
+   .--------.            .------.           .----------.           .-------.          .----------.          .--------.           .--------.           .---------.
+   | Client |            | Core |           | Registry |           | Cache |          | Postgres |          | JobSvc |           | RegCtl |           | Storage |
+   '----+---'            '---+--'           '-----+----'           '---+---'          '-----+----'          '----+---'           '----+---'           '----+----'
+        |                    |                    |                    |                    |                    |                    |                    |
+
+  "1) Docker login"
+        | "GET /v2/"         |                    |                    |                    |                    |                    |                    |
+        +---------------------------------------–>|                    |                    |                    |                    |                    |
+        | "401 + token URL"  |                    |                    |                    |                    |                    |                    |
+        |<- - - - - - - - - - - - - - - - - - - - +                    |                    |                    |                    |                    |
+        | "credentials"      |                    |                    |                    |                    |                    |                    |
+        +------------------–>|                    |                    |                    |                    |                    |                    |
+        |                    | "authenticate (backend)"                |                    |                    |                    |                    |
+        |                    +------------------------------------------------------------–>|                    |                    |                    |
+        | "signed token (cached)"                 |                    |                    |                    |                    |                    |
+        |<- - - - - - - - - -+                    |                    |                    |                    |                    |                    |
+                             |                    |                    |                    |                    |                    |                    |
+  "2) Image push / pull"
+        | "/v2/* (+token)"   |                    |                    |                    |                    |                    |                    |
+        +------------------–>|                    |                    |                    |                    |                    |                    |
+        |                    | "check manifest cache"                  |                    |                    |                    |                    |
+        |                    +---------------------------------------–>|                    |                    |                    |                    |
+        |                    | "hit / miss"       |                    |                    |                    |                    |                    |
+        |                    |<- - - - - - - - - - - - - - - - - - - - +                    |                    |                    |                    |
+        |                    | "blob & manifest"  |                    |                    |                    |                    |                    |
+        |                    +------------------–>|                    |                    |                    |                    |                    |
+        |                    |                    | "read / write"     |                    |                    |                    |                    |
+        |                    |                    +------------------------------------------------------------------------------------------------------–>|
+        |                    | "persist metadata" |                    |                    |                    |                    |                    |
+        |                    +------------------------------------------------------------–>|                    |                    |                    |
+        |                    | "write-back on miss"                    |                    |                    |                    |                    |
+        |                    +---------------------------------------–>|                    |                    |                    |                    |
+
+  "3) API request"
+        | "/api/v2.0/*"      |                    |                    |                    |                    |                    |                    |
+        +------------------–>|                    |                    |                    |                    |                    |                    |
+        |                    | "query / update"   |                    |                    |                    |                    |                    |
+        |                    +------------------------------------------------------------–>|                    |                    |                    |
+        |                    | "read / write"     |                    |                    |                    |                    |                    |
+        |                    +---------------------------------------–>|                    |                    |                    |                    |
+        | "JSON"             |                    |                    |                    |                    |                    |                    |
+        |<- - - - - - - - - -+                    |                    |                    |                    |                    |                    |
+
+  "4) Background job (auto-scan)"
+        |                    | "submit job"       |                    |                    |                    |                    |                    |
+        |                    +---------------------------------------------------------------------------------–>|                    |                    |
+        |                    | "status callback"  |                    |                    |                    |                    |                    |
+        |                    |<- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - +                    |                    |
+
+  "5) Garbage collection"
+        |                    | "submit GC job"    |                    |                    |                    |                    |                    |
+        |                    +---------------------------------------------------------------------------------–>|                    |                    |
+        |                    |                    |                    |                    | "MARK unreferenced"|                    |                    |
+        |                    |                    |                    |                    |<-------------------+                    |                    |
+        |                    |                    |                    |                    |                    | "SWEEP delete"     |                    |
+        |                    |                    |                    |                    |                    +------------------–>|                    |
+        |                    |                    |                    |                    |                    |                    | "storage.Vacuum"   |
+        |                    |                    |                    |                    |                    |                    +------------------–>|
+   .----+---.            .---+--.           .-----+----.           .---+---.          .-----+----.          .----+---.           .----+---.           .----+----.
+   | Client |            | Core |           | Registry |           | Cache |          | Postgres |          | JobSvc |           | RegCtl |           | Storage |
+   '--------'            '------'           '----------'           '-------'          '----------'          '--------'           '--------'           '---------'
+```
+-->
+![Data flow sequence (SVGBob)](https://kroki.io/svgbob/svg/eNrtWdtu2kAQfc9XjPahhqxskjR9iyqlFKGkbYqgl-e1vQEX20t316ki8dB_6B_2SzomQLks2IgEFolFCBjt2qPjMzNnGADw3PHyYGZ5y7bpRrPZK9rprTu94k7eCf4cQj2OeKrxy8xCq5B8zjaENu9GSsvHBXOdBb25rUNoCaW7kqt5663wOw_B8kXrOl4wdrSQrIsXzT10cl8pvp1ZD50no7Ngetq5ZF44bt5pvNF6o-uc_PfasPZsPEHvyHkV3ougzyXEohulZMZj0mx8gdrDRY1Y4_HkG3XLrb-__7zdg3uI3eXZOVDQos9T-Nr-SOzBbnjlQrkX3QtygeQhppyIxYpYz7rdEqwIO-MZwjLdywENmOZQ8RlGexpWiQXOlQ3jF4vtWd6pqJvycByylSCvWwaUrIlYagnrwMbKhoXtogo3SS4TBpnqQQ0_4niuuuWV7RQqdPTARw_6mGe2yjMYMEEfEpZG91xpGEUQscK5vcuFQux6kUaOJpGa1Dx7Hux-5UIhcn4sfHg1pR2xBzlqkR4tfyEiOQuRi79kpMfha4tzW8mFDYVFIe8GXCpseCHhmoVMM2Iz7_amqszYjbjl5koURDqX9Y6VItcur6tw3boByX9meUqbUy1sEKFy8c5qp8fu6Dm4iBDLR8x32QCjmBOAYxyXxm5HpeLAFR-57Xy-I5b1RxZ3lnkGvKzCOywPXSmyNIQfKPEqLNPCVQHDXq2QmCrzE1TUeM42OU1fRq48Y1ArzXSmsH2L47xCk0NsRcq_6IbEfFOFJpN-_sdCIOKYBzoSaWlCNutTTh4JuU2XskE_8-m6_QGyVPJ7Lnka8JBY49yVAT1qDXJmODvfG40WhDzm62v-7p3bSIBaM5nDfDsaZ3rfWJBlCbHIObqmN_YmQ86l2TU1TZSpadBMTVNqappdU9OYeqXxoGbXrml2bZoorzY7RTuddadX3Mn5B14QWYg=)
+
+1. **Docker login** — client hits `/v2/`; the registry returns `401` with the token-service URL; the client submits credentials to Core's token service, which authenticates against the configured backend (DB/LDAP/OIDC) and returns a signed token the client caches.
+2.  **Image push/pull** — client → Core (`/v2/*`) for authentication, authorization, and policy checks (e.g. quota on push); Core proxies blob/manifest transfer to the Distribution registry. Core persists metadata in PostgreSQL and caches manifest metadata in Redis (pull path checks the cache before the registry and writes back on a miss).
+3.  **API requests** — client → Core (`/api/v2.0/*`) → generated handler → controller → DAO (`src/pkg`) → PostgreSQL / Redis.
+4.  **Background jobs** — Core submits a job to JobService over HTTP; JobService executes it, updates status, and calls back Core on completion. Auto-scan is submitted by Core after a manifest PUT (when enabled).
+5.  **Garbage collection (two-phase)** — MARK in PostgreSQL finds unreferenced blobs/manifests; SWEEP runs as a JobService job that calls RegistryCtl to delete them from the storage backend.
+
+## Deployment topologies
+The component set above is identical across deployments. What changes is how services are exposed, which processes are co-located, and which dependencies are bundled. The diagram above depicts the **Docker Compose** topology.
+
+### Docker Compose (`deploy/compose/`)
+- Each service runs as its own container; **nginx** is the single edge proxy that routes to the Portal, the Core API, and `/v2/`.
+- **RegistryCtl runs as a separate container** alongside the registry.
+- PostgreSQL and Redis/Valkey run as containers in the same Compose project (or can be pointed at external instances).
+- Host ports are published directly (dev uses SLOT offsets).
+
+### Kubernetes / Helm (`deploy/chart/` — in development, not yet merged to this branch)
+- Core, JobService, Portal, Registry, and Exporter are separate **Deployments** fronted by ClusterIP **Services**; Trivy runs as a **StatefulSet**.
+- **No nginx proxy** — external exposure is via **Ingress**, Gateway API **HTTPRoute**, or OpenShift **Route**.
+- **RegistryCtl runs as a sidecar container in the registry pod** (it has no Deployment of its own; only its config/secret are templated).
+- **Redis/Valkey** ships as an **in-cluster subchart** (`valkey.enabled`, on by default; bundled `valkey` dependency in `Chart.yaml`) or can be pointed at an external instance (`externalRedis`). **PostgreSQL is external** — the chart has no Postgres workload, so you supply it (the 8gcr GitOps bundle provisions one via CloudNativePG through the chart's `extraManifests` hook).
+- Persistence is via **PVCs** (registry, jobservice); the chart adds Kubernetes-native resources: ServiceAccounts, PodDisruptionBudgets, and a Prometheus `ServiceMonitor`.
+- The chart (`harbor-next`, currently v3.0.0 / appVersion v2.15.0) is published as an OCI artifact and supports GitOps delivery via FluxCD (`deploy/flux/`), with platform guides for k3s, OpenShift, Rancher, Nutanix, and AWS EKS (IRSA).
+
+> The Helm chart details reflect the in-progress chart and may change before it lands.
+
+## Development topology
+`task dev:up` runs Core, JobService, RegistryCtl, the Trivy adapter, and supporting services in Docker with hot reload. The Portal can run natively with HMR or in a container. Local ports are SLOT-offset (`SLOT=N` adds `N*100`); service ports and profiling endpoints are described in `devenv/README.md`.


### PR DESCRIPTION
- README: align with Harbor Next (drop stale Notary/ChartMuseum/Operator claims, fix install to deploy/compose + Helm chart, add Contributing section, typo/structure fixes)
- CONTRIBUTING: add Commercial Patch Commits release-note format
- docs/architecture-overview: consolidate and verify against the codebase; widen Portal box in the diagram
- ROADMAP/RELEASES: content updates
- docs/Taskfile: document the SVGBob '-->' escaping for GitHub comment safety


## Type of Change

- [x] Documentation (`docs:`)


## Checklist

- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] Commits are signed off (`git commit -s`)
- [x] No new warnings introduced
