### PR TITLE
ci: Keep Main Releases On V2

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -88,6 +88,12 @@ jobs:
           git switch -c "${backport_branch}"
 
           if ! git cherry-pick -x "${SOURCE_SHA}"; then
+            if git diff --quiet && git diff --cached --quiet; then
+              git cherry-pick --skip || true
+              gh pr comment "${PR_NUMBER}" --body "No backport PR opened for \`${TARGET_BRANCH}\`; the cherry-pick produced no changes."
+              exit 0
+            fi
+
             git cherry-pick --abort || true
             gh pr comment "${PR_NUMBER}" --body "Backport to \`${TARGET_BRANCH}\` has conflicts. Please cherry-pick \`${SOURCE_SHA}\` manually."
             exit 1

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,7 +22,7 @@ task dev:up       # Local dev with hot reload
 
 ## Release-please
 
-`feat:` → minor, `fix:` / `upstream:` → patch, `feat!:` / `BREAKING CHANGE:` → major. `ci:`, `build:`, `chore:`, `test:` are hidden from release notes.
+On `main`, release-please always bumps minor and never creates `v3`. On `release-X.Y`, release-please always bumps patch. `ci:`, `build:`, `chore:`, `test:` are hidden from release notes.
 
 **exclude-paths:** changes touching only `.github/`, `docs/`, or `tests/` don't bump version — use `ci:` for CI-only changes.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -52,10 +52,10 @@ Common types:
 
 | Type | When to use | Release effect |
 |------|------------|----------------|
-| `feat` | New user-facing feature | Minor version bump |
-| `fix` | Bug fix | Patch version bump |
-| `upstream` | Cherry-picked upstream Harbor change | Patch version bump |
-| `feat!` / `fix!` | Breaking change | Major version bump |
+| `feat` | New user-facing feature | Minor on `main`, patch on `release-X.Y` |
+| `fix` | Bug fix | Minor on `main`, patch on `release-X.Y` |
+| `upstream` | Cherry-picked upstream Harbor change | Minor on `main`, patch on `release-X.Y` |
+| `feat!` / `fix!` | Breaking change | Minor on `main`, patch on `release-X.Y` |
 | `refactor` | Code change, no behaviour change | No release |
 | `docs` | Documentation only | No release |
 | `ci` | CI/CD pipeline changes | No release |
@@ -197,10 +197,11 @@ For eligible merged PRs on `main`, a maintainer can comment `/backport vX.Y` on 
 
 | Commit type | Version bump | Example |
 |-------------|-------------|---------|
-| `fix:` | Patch | `2.16.0` -> `2.16.1` |
-| `upstream:` | Patch | `2.16.0` -> `2.16.1` |
+| `fix:` on `main` | Minor | `2.16.0` -> `2.17.0` |
+| `upstream:` on `main` | Minor | `2.16.0` -> `2.17.0` |
 | `feat:` | Minor | `2.16.0` -> `2.17.0` |
-| `feat!:` / `BREAKING CHANGE:` | Major | `2.16.0` -> `3.0.0` |
+| `feat!:` / `BREAKING CHANGE:` | Minor | `2.16.0` -> `2.17.0` |
+| Any release-worthy commit on `release-X.Y` | Patch | `2.16.0` -> `2.16.1` |
 | `ci:` / `chore:` / `docs:` / `test:` / `build:` | No release | - |
 
 ### What Triggers a Release PR

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -26,7 +26,7 @@ flowchart LR
 
   upstream -->|selected fixes as upstream: commits| harborMain
   harborMain -->|release-please PR merged| harborTag
-  harborTag -->|new vX.Y.0 creates| harborRelease
+  harborTag -->|new v2.Y.0 creates| harborRelease
   harborMain -->|/backport vX.Y| harborRelease
   harborRelease -->|maintenance release-please PR merged| harborTag
   harborMain -->|upstream-sync dispatch| gcrMain
@@ -92,8 +92,8 @@ sequenceDiagram
   Actions->>Registry: Build and push release images
   Actions->>Cosign: Sign release images
   Actions->>GitHub: Rewrite GitHub Release notes
-  alt main release and patch == 0
-    Actions->>GitHub: Create release-X.Y branch from vX.Y.0
+  alt main release
+    Actions->>GitHub: Create release-2.Y branch from v2.Y.0
   end
 ```
 
@@ -101,10 +101,10 @@ sequenceDiagram
 
 | Branch | Config | Release behavior |
 |--------|--------|------------------|
-| `main` | `release-please-config.json` | Normal semver bumps |
+| `main` | `release-please-config.json` | Minor releases only |
 | `release-X.Y` | `release-please-config-maintenance.json` | Patch-only releases |
 
-`main` releases can create major, minor, or patch versions. A new `.0` release from `main` automatically creates `release-X.Y` from the release tag.
+`main` uses `versioning: always-bump-minor`. It must not create `v3` releases. A release from `main` creates the next `v2.Y.0` version and automatically creates `release-2.Y` from the release tag.
 
 `release-X.Y` uses `versioning: always-bump-patch`. Any release-worthy commit on a maintenance branch produces the next patch version.
 
@@ -112,12 +112,12 @@ sequenceDiagram
 
 | Commit type | `main` bump | `release-X.Y` bump | Notes section |
 |-------------|-------------|--------------------|---------------|
-| `fix:` | Patch | Patch | Bug Fixes |
-| `upstream:` | Patch | Patch | Upstream |
-| `perf:` | Patch | Patch | Performance Improvements |
+| `fix:` | Minor | Patch | Bug Fixes |
+| `upstream:` | Minor | Patch | Upstream |
+| `perf:` | Minor | Patch | Performance Improvements |
 | `feat:` | Minor | Patch | Features |
-| `feat!:` or `BREAKING CHANGE:` | Major | Patch | Breaking changes |
-| `revert:` | Patch when reverting releasable change | Patch when reverting releasable change | Reverts |
+| `feat!:` or `BREAKING CHANGE:` | Minor | Patch | Breaking changes |
+| `revert:` | Minor when releasable | Patch when releasable | Reverts |
 | `ci:`, `chore:`, `build:`, `test:` | No release | No release | Hidden |
 
 Release-please ignores changes that only touch:
@@ -134,13 +134,13 @@ Use `ci:` for workflow-only changes.
 2. Release-please opens or updates `chore: release X.Y.Z`.
 3. Review `VERSION`, `.release-please-manifest.json`, and `CHANGELOG.md`.
 4. Squash-merge the release PR.
-5. Release-please creates the `vX.Y.Z` tag and GitHub Release.
+5. Release-please creates the `v2.Y.0` tag and GitHub Release.
 6. The release workflow checks out the Harbor Next release source.
 7. The workflow applies 8gcr patches at release runtime.
 8. The workflow builds and pushes multi-arch images.
 9. The workflow signs images with cosign.
 10. The workflow rewrites the GitHub Release notes.
-11. If the version is `vX.Y.0`, the workflow creates `release-X.Y`.
+11. The workflow creates `release-2.Y` for the new minor line.
 
 ## Maintenance Release Flow
 
@@ -174,6 +174,7 @@ Rules:
 - The workflow cherry-picks the source merge commit with `git cherry-pick -x`.
 - The workflow opens a PR against `release-X.Y`.
 - If the cherry-pick conflicts, the workflow comments on the source PR and stops.
+- If the cherry-pick is empty or already applied, the workflow comments on the source PR and stops without opening a PR.
 
 The suggestion workflow comments with backport commands for merged `main` PRs whose unscoped titles start with `fix:`, `upstream:`, `perf:`, or `revert:`. Scoped titles like `fix(core): ...` do not currently get automatic suggestion comments, but `/backport vX.Y` still works manually.
 

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -4,6 +4,7 @@
   "pull-request-header": "This PR prepares the next release based on conventional commits.",
   "pull-request-title-pattern": "chore: release ${version}",
   "release-type": "simple",
+  "versioning": "always-bump-minor",
   "include-v-in-tag": true,
   "exclude-paths": [".github", "docs", "tests"],
   "changelog-sections": [


### PR DESCRIPTION
## Summary
- Configure release-please on main to always bump minor versions.
- Keep maintenance branches patch-only.
- Update release docs to state that release-please must not create v3 releases.