### PR TITLE
fix: Prevent Core FD/Goroutine Leak When Registry Is Unresponsive

### DIFF
--- a/src/common/http/transport.go
+++ b/src/common/http/transport.go
@@ -21,7 +21,10 @@ import (
 	"fmt"
 	"net"
 	"net/http"
+	"os"
+	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
@@ -57,6 +60,67 @@ func AddTracingWithGlobalTransport() {
 	secureHTTPTransport = otelhttp.NewTransport(secureHTTPTransport, trace.HarborHTTPTraceOptions...)
 }
 
+const (
+	// responseHeaderTimeoutEnvKey overrides defaultResponseHeaderTimeout, in
+	// seconds. A value of 0 disables the response-header timeout entirely.
+	responseHeaderTimeoutEnvKey = "HTTP_RESPONSE_HEADER_TIMEOUT_SECONDS"
+
+	// defaultMaxIdleConnsPerHost caps idle keep-alive connections retained per
+	// host. Go's net/http default is only 2; when harbor-core proxies many
+	// concurrent requests to a single backend (notably the registry), that
+	// forces constant connection churn and the associated FD/goroutine
+	// pressure. A higher cap lets connections be reused.
+	defaultMaxIdleConnsPerHost = 32
+
+	// defaultResponseHeaderTimeout bounds how long the transport waits for a
+	// backend's response headers after the request has been written. Without
+	// it, a request that reuses a pooled keep-alive connection to an
+	// unresponsive backend (e.g. the registry pod after it is rescheduled to a
+	// new IP) blocks indefinitely, leaking one goroutine and one socket per
+	// in-flight request until the process is restarted. It does NOT limit body
+	// transfer, so large blob pushes/pulls are unaffected.
+	defaultResponseHeaderTimeout = 90 * time.Second
+)
+
+var (
+	responseHeaderTimeoutOnce  sync.Once
+	responseHeaderTimeoutValue time.Duration
+)
+
+// responseHeaderTimeout returns the response-header timeout applied to the
+// default transport. The value is read from the environment once and cached
+// for the lifetime of the process, mirroring the read-once style of
+// config.RegistryHTTPClientTimeout (goharbor/harbor#23154).
+//
+// It intentionally lives in this package rather than in lib/config: lib/config
+// already imports common/http, so importing it from here would create a
+// cycle. This setting is also complementary to REGISTRY_HTTP_CLIENT_TIMEOUT --
+// that bounds the whole request (including the body), whereas this bounds only
+// the wait for response headers, so it can be short without affecting large
+// blob transfers.
+func responseHeaderTimeout() time.Duration {
+	responseHeaderTimeoutOnce.Do(func() {
+		responseHeaderTimeoutValue = parseResponseHeaderTimeout()
+	})
+	return responseHeaderTimeoutValue
+}
+
+// parseResponseHeaderTimeout reads HTTP_RESPONSE_HEADER_TIMEOUT_SECONDS (in
+// seconds). A value of 0 disables the timeout; an empty, negative or otherwise
+// invalid value falls back to defaultResponseHeaderTimeout.
+func parseResponseHeaderTimeout() time.Duration {
+	env := os.Getenv(responseHeaderTimeoutEnvKey)
+	if env == "" {
+		return defaultResponseHeaderTimeout
+	}
+	secs, err := strconv.Atoi(env)
+	if err != nil || secs < 0 {
+		log.Warningf("invalid %s=%q, using default %s", responseHeaderTimeoutEnvKey, env, defaultResponseHeaderTimeout)
+		return defaultResponseHeaderTimeout
+	}
+	return time.Duration(secs) * time.Second
+}
+
 // Use this instead of Default Transport in library because it sets ForceAttemptHTTP2 to true
 // And that options introduced in go 1.13 will cause the https requests hang forever in replication environment
 func newDefaultTransport() *http.Transport {
@@ -69,9 +133,11 @@ func newDefaultTransport() *http.Transport {
 		}).DialContext,
 		TLSClientConfig:       &tls.Config{},
 		MaxIdleConns:          100,
+		MaxIdleConnsPerHost:   defaultMaxIdleConnsPerHost,
 		IdleConnTimeout:       90 * time.Second,
 		TLSHandshakeTimeout:   10 * time.Second,
 		ExpectContinueTimeout: 1 * time.Second,
+		ResponseHeaderTimeout: responseHeaderTimeout(),
 	}
 }
 

--- a/src/common/http/transport_leak_test.go
+++ b/src/common/http/transport_leak_test.go
@@ -1,0 +1,65 @@
+// Copyright Project Harbor Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package http
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestNewDefaultTransportLeakGuards verifies the default transport carries the
+// two settings that prevent harbor-core from leaking goroutines/FDs when a
+// backend (such as the registry) becomes unresponsive on a pooled connection.
+func TestNewDefaultTransportLeakGuards(t *testing.T) {
+	tr := newDefaultTransport()
+	assert.Positive(t, tr.MaxIdleConnsPerHost,
+		"MaxIdleConnsPerHost must be set (>0); Go's default of 2 forces connection churn under load")
+	assert.Equal(t, defaultMaxIdleConnsPerHost, tr.MaxIdleConnsPerHost)
+	assert.Positive(t, tr.ResponseHeaderTimeout,
+		"ResponseHeaderTimeout must be set (>0) so requests to an unresponsive backend cannot hang forever")
+	assert.Equal(t, defaultResponseHeaderTimeout, tr.ResponseHeaderTimeout)
+}
+
+// TestParseResponseHeaderTimeout covers the env parsing. It targets the
+// uncached parser directly because responseHeaderTimeout() caches its result
+// for the lifetime of the process (sync.Once), so it cannot be toggled here.
+func TestParseResponseHeaderTimeout(t *testing.T) {
+	t.Run("default when unset", func(t *testing.T) {
+		t.Setenv(responseHeaderTimeoutEnvKey, "")
+		assert.Equal(t, defaultResponseHeaderTimeout, parseResponseHeaderTimeout())
+	})
+	t.Run("override in seconds", func(t *testing.T) {
+		t.Setenv(responseHeaderTimeoutEnvKey, "15")
+		assert.Equal(t, 15*time.Second, parseResponseHeaderTimeout())
+	})
+	t.Run("zero disables the timeout", func(t *testing.T) {
+		t.Setenv(responseHeaderTimeoutEnvKey, "0")
+		assert.Equal(t, time.Duration(0), parseResponseHeaderTimeout())
+	})
+	t.Run("invalid value falls back to default", func(t *testing.T) {
+		t.Setenv(responseHeaderTimeoutEnvKey, "not-a-number")
+		assert.Equal(t, defaultResponseHeaderTimeout, parseResponseHeaderTimeout())
+	})
+	t.Run("negative value falls back to default", func(t *testing.T) {
+		t.Setenv(responseHeaderTimeoutEnvKey, "-5")
+		assert.Equal(t, defaultResponseHeaderTimeout, parseResponseHeaderTimeout())
+	})
+
+	// responseHeaderTimeout() returns a positive, cached value (the env is
+	// unset at process start, so it resolves to the default).
+	assert.Equal(t, defaultResponseHeaderTimeout, responseHeaderTimeout())
+}

--- a/src/server/registry/proxy.go
+++ b/src/server/registry/proxy.go
@@ -33,9 +33,13 @@ func newProxy() http.Handler {
 		panic(fmt.Sprintf("failed to parse the URL of registry: %v", err))
 	}
 	proxy := httputil.NewSingleHostReverseProxy(url)
-	if commonhttp.InternalTLSEnabled() {
-		proxy.Transport = commonhttp.GetHTTPTransport()
-	}
+	// Always use Harbor's transport (not http.DefaultTransport) so the proxy to
+	// the backend registry has a bounded ResponseHeaderTimeout and a sane
+	// per-host idle-connection pool. Otherwise, when the backend registry
+	// becomes unresponsive on a pooled connection, proxied /v2/ requests hang
+	// indefinitely and leak goroutines/FDs. GetHTTPTransport also applies the
+	// internal TLS configuration when it is enabled.
+	proxy.Transport = commonhttp.GetHTTPTransport()
 
 	proxy.Director = basicAuthDirector(proxy.Director)
 	return proxy


### PR DESCRIPTION
harbor-core reverse-proxies all Docker Registry v2 (`/v2/...`) requests to the backend registry. Two defects in that path let a proxied request hang forever, each hung request pinning one goroutine and one socket:

1. `newDefaultTransport()` (`src/common/http/transport.go`) sets no `ResponseHeaderTimeout` and leaves `MaxIdleConnsPerHost` at Go's default of 2. A request that reuses a pooled keep-alive connection to a backend that stops responding blocks indefinitely waiting for response headers.
2. With internal TLS disabled (a common deployment), the `/v2/` reverse proxy (`src/server/registry/proxy.go`) didn't use Harbor's transport at all — it fell back to `http.DefaultTransport`, which has neither guard. The push/pull proxy path was completely unprotected.

Two scenarios produce a backend that holds the connection open but never sends response headers:

- **Registry unreachable.** E.g. the single registry pod is rescheduled to a new IP while core still holds pooled connections to the old one. This was the production incident: one core replica ramped from ~600 to ~6,300 open FDs / ~6,500 goroutines over ~55 minutes, 504 on every push, zero proxy errors logged. It recovered only when the pod was killed.
- **Registry up, but its storage backend (e.g. an S3 bucket) slow or unresponsive.** The registry consults the storage driver *before* writing response headers: `ServeBlob` calls `statter.Stat(...)` (an S3 API call) before any header is written (distribution v3.1.1 `registry/storage/blobserver.go`), manifest GETs read from storage first, and blob-upload completion commits to storage before responding. A hung S3 backend therefore causes the exact same header-wait accumulation in core.

Full problem report and prior-art aggregation: #255.

## Solution

- **`common/http`** — `newDefaultTransport()` now sets `MaxIdleConnsPerHost: 32` and a `ResponseHeaderTimeout` (default **90s**, overridable via `HTTP_RESPONSE_HEADER_TIMEOUT_SECONDS`, `0` disables; read once and cached). The timeout bounds only the wait for response *headers* after the request is fully written, so large blob body transfers are unaffected.
- **`server/registry`** — the `/v2/` reverse proxy now always uses Harbor's transport via `GetHTTPTransport()`, which still applies the internal-TLS configuration when it is enabled.

Known limits, tracked separately:
- A streaming blob upload (PATCH) that stalls mid-body because the registry is backpressured by storage is not covered — `ResponseHeaderTimeout` only starts once the request body is fully written.
- The proxy-cache background goroutines (`ProxyManifest`/`ProxyBlob`) are detached from the inbound request context and have no timeout of their own — follow-up in #256. Running ≥2 backend registry replicas remains the complementary operational mitigation.

## Relationship to goharbor/harbor#23154

Complementary, no overlap or conflict. [goharbor/harbor#23154](https://github.com/goharbor/harbor/pull/23154) sets `http.Client.Timeout` (a cap on the *whole* request including the body, default 30 minutes) on the `pkg/registry` client and replication adapters. This PR sets `Transport.ResponseHeaderTimeout` (headers only, so it can be short) on the shared transport and on the `/v2/` reverse proxy — a code path #23154 doesn't touch. The changed files are disjoint and the two env knobs (`REGISTRY_HTTP_CLIENT_TIMEOUT`, `HTTP_RESPONSE_HEADER_TIMEOUT_SECONDS`) coexist.

## References

**Closes #255.**

Upstream `goharbor/harbor` issues addressed by this change (cross-referenced for traceability; they can't be auto-closed from this fork):
- goharbor/harbor#11645 — introduced `newDefaultTransport()` but never added per-host pool limits or a response-header timeout
- goharbor/harbor#23104 — auth/token client hangs forever on a dead keep-alive connection (same fault model, same shared transport)
- goharbor/harbor#22490 — slow/unhealthy backend wedges the `/v2/` proxy
- goharbor/harbor#20523, goharbor/harbor#18989 — connection growth / connections not released under high concurrency

The broader list of adjacent-but-separate upstream issues (proxy-cache fan-out, retry cancellation, other subsystems) is aggregated in #255.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Release Notes

Fixed a file-descriptor and goroutine leak in harbor-core that could occur when the backend registry became unreachable (for example after the registry pod was rescheduled) or was blocked on a slow/unresponsive storage backend such as S3. Requests to the registry now time out instead of hanging indefinitely, and the per-host connection pool reuses connections more efficiently. A new `HTTP_RESPONSE_HEADER_TIMEOUT_SECONDS` environment variable tunes the response-header timeout (default 90s; set to `0` to disable).

## Testing

- [x] `go test ./common/http/` passes, including new regression tests that:
  - assert `MaxIdleConnsPerHost > 0` and a non-zero `ResponseHeaderTimeout` on the default transport
  - assert env parsing (seconds / `0` disables / negative / invalid falls back to default)
- [x] `go build` and `go vet` clean on `common/http` and `server/registry`
- [x] Reproduced the leak locally against Harbor's actual transport (goroutines + FDs climb and never recover) and confirmed adding `ResponseHeaderTimeout` releases them

## Checklist

- [x] Conventional Commits title (`fix:`)
- [x] DCO sign-off on all commits
- [x] No new warnings
