### PR TITLE
fix: Bound Proxy-Cache Background Goroutines To Prevent Leak

### DIFF
--- a/src/controller/proxy/cachefill.go
+++ b/src/controller/proxy/cachefill.go
@@ -1,0 +1,73 @@
+// Copyright Project Harbor Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package proxy
+
+import (
+	"os"
+	"strconv"
+
+	"github.com/goharbor/harbor/src/lib/log"
+)
+
+const (
+	// maxConcurrentCacheFillEnvKey overrides the maximum number of concurrent
+	// background proxy-cache tasks. Empty, non-numeric or non-positive values
+	// fall back to defaultMaxConcurrentCacheFill.
+	maxConcurrentCacheFillEnvKey = "PROXY_CACHE_MAX_CONCURRENT_FILL"
+
+	// defaultMaxConcurrentCacheFill bounds the number of background proxy-cache
+	// goroutines that may run at once. Proxy-cache fills run detached from the
+	// inbound request (they outlive it on purpose, to populate the local
+	// cache), so without a cap a slow or unresponsive backend lets them
+	// accumulate one goroutine plus one held socket each, without bound. The
+	// default is well above healthy steady-state concurrency while keeping
+	// worst-case resource use bounded.
+	defaultMaxConcurrentCacheFill = 100
+)
+
+// cacheFillSem bounds concurrent background proxy-cache tasks. It is sized once
+// at process start from PROXY_CACHE_MAX_CONCURRENT_FILL.
+var cacheFillSem = make(chan struct{}, maxConcurrentCacheFill())
+
+func maxConcurrentCacheFill() int {
+	if env := os.Getenv(maxConcurrentCacheFillEnvKey); env != "" {
+		if n, err := strconv.Atoi(env); err == nil && n > 0 {
+			return n
+		}
+		log.Warningf("invalid %s=%q, using default %d", maxConcurrentCacheFillEnvKey, env, defaultMaxConcurrentCacheFill)
+	}
+	return defaultMaxConcurrentCacheFill
+}
+
+// GoCacheFill runs fn in a background goroutine bounded by a global concurrency
+// limit (PROXY_CACHE_MAX_CONCURRENT_FILL). Proxy-cache background work is
+// best-effort and intentionally outlives the inbound request, so when the limit
+// is already reached the task is skipped (and logged) rather than queued -- a
+// slow or unresponsive backend therefore cannot make these goroutines, and the
+// sockets they hold, accumulate without bound. It returns true if fn was
+// scheduled, false if it was skipped.
+func GoCacheFill(label string, fn func()) bool {
+	select {
+	case cacheFillSem <- struct{}{}:
+	default:
+		log.Warningf("proxy-cache background task %q skipped: concurrency limit (%d) reached", label, cap(cacheFillSem))
+		return false
+	}
+	go func() {
+		defer func() { <-cacheFillSem }()
+		fn()
+	}()
+	return true
+}

--- a/src/controller/proxy/cachefill.go
+++ b/src/controller/proxy/cachefill.go
@@ -59,14 +59,20 @@ func maxConcurrentCacheFill() int {
 // sockets they hold, accumulate without bound. It returns true if fn was
 // scheduled, false if it was skipped.
 func GoCacheFill(label string, fn func()) bool {
+	sem := cacheFillSem
 	select {
-	case cacheFillSem <- struct{}{}:
+	case sem <- struct{}{}:
 	default:
-		log.Warningf("proxy-cache background task %q skipped: concurrency limit (%d) reached", label, cap(cacheFillSem))
+		log.Warningf("proxy-cache background task %q skipped: concurrency limit (%d) reached", label, cap(sem))
 		return false
 	}
 	go func() {
-		defer func() { <-cacheFillSem }()
+		defer func() { <-sem }()
+		defer func() {
+			if r := recover(); r != nil {
+				log.Errorf("proxy-cache background task %q panicked: %v", label, r)
+			}
+		}()
 		fn()
 	}()
 	return true

--- a/src/controller/proxy/cachefill_test.go
+++ b/src/controller/proxy/cachefill_test.go
@@ -1,0 +1,58 @@
+// Copyright Project Harbor Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package proxy
+
+import (
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestGoCacheFillBoundsConcurrency verifies that background proxy-cache tasks
+// are capped: once the gate is full, further tasks are skipped (not queued and
+// not spawned), and a slot frees up when a running task completes.
+func TestGoCacheFillBoundsConcurrency(t *testing.T) {
+	saved := cacheFillSem
+	t.Cleanup(func() { cacheFillSem = saved })
+	cacheFillSem = make(chan struct{}, 1) // single slot for a deterministic test
+
+	started := make(chan struct{})
+	release := make(chan struct{})
+	require.True(t, GoCacheFill("first", func() {
+		close(started)
+		<-release // hold the only slot until released
+	}))
+	<-started // ensure the first task is running and holding the slot
+
+	// Gate is full: the second task must be skipped, not run.
+	var ran int32
+	require.False(t, GoCacheFill("second", func() { atomic.AddInt32(&ran, 1) }))
+	assert.Equal(t, int32(0), atomic.LoadInt32(&ran), "task must not run while the gate is full")
+
+	// Free the slot; a new task is accepted again.
+	close(release)
+	done := make(chan struct{})
+	require.Eventually(t, func() bool {
+		return GoCacheFill("third", func() { close(done) })
+	}, 2*time.Second, 5*time.Millisecond, "a slot should free up after the running task completes")
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("scheduled task did not run")
+	}
+}

--- a/src/controller/proxy/controller.go
+++ b/src/controller/proxy/controller.go
@@ -229,8 +229,11 @@ func (c *controller) ProxyManifest(ctx context.Context, art lib.ArtifactInfo, re
 		return man, err
 	}
 
-	// Push manifest in background
-	go func(operator string) {
+	// Push manifest to the local cache in the background, bounded by the global
+	// proxy-cache concurrency limit so a slow/unresponsive backend cannot make
+	// these detached goroutines accumulate without bound.
+	op := operator.FromContext(ctx)
+	GoCacheFill("manifest:"+art.Repository, func() {
 		bCtx := orm.Copy(ctx)
 		a, err := c.local.GetManifest(bCtx, art)
 		if err != nil {
@@ -253,9 +256,9 @@ func (c *controller) ProxyManifest(ctx context.Context, art lib.ArtifactInfo, re
 			}
 		}
 		if a != nil {
-			SendPullEvent(bCtx, a, art.Tag, operator)
+			SendPullEvent(bCtx, a, art.Tag, op)
 		}
-	}(operator.FromContext(ctx))
+	})
 
 	return man, nil
 }
@@ -280,12 +283,13 @@ func (c *controller) ProxyBlob(ctx context.Context, p *proModels.Project, art li
 		return 0, nil, err
 	}
 	desc := distribution.Descriptor{Size: size, Digest: digest.Digest(art.Digest)}
-	go func() {
-		err := c.putBlobToLocal(remoteRepo, art.Repository, desc, rHelper)
-		if err != nil {
+	// Populate the local cache in the background, bounded by the global
+	// proxy-cache concurrency limit (see GoCacheFill).
+	GoCacheFill("blob:"+art.Repository, func() {
+		if err := c.putBlobToLocal(remoteRepo, art.Repository, desc, rHelper); err != nil {
 			log.Errorf("error while putting blob to local repo, %v", err)
 		}
-	}()
+	})
 	return size, bReader, nil
 }
 

--- a/src/controller/proxy/controller.go
+++ b/src/controller/proxy/controller.go
@@ -233,7 +233,7 @@ func (c *controller) ProxyManifest(ctx context.Context, art lib.ArtifactInfo, re
 	// proxy-cache concurrency limit so a slow/unresponsive backend cannot make
 	// these detached goroutines accumulate without bound.
 	op := operator.FromContext(ctx)
-	GoCacheFill("manifest:"+art.Repository, func() {
+	if !GoCacheFill("manifest:"+art.Repository, func() {
 		bCtx := orm.Copy(ctx)
 		a, err := c.local.GetManifest(bCtx, art)
 		if err != nil {
@@ -258,9 +258,28 @@ func (c *controller) ProxyManifest(ctx context.Context, art lib.ArtifactInfo, re
 		if a != nil {
 			SendPullEvent(bCtx, a, art.Tag, op)
 		}
-	})
+	}) {
+		go func() {
+			defer func() {
+				if r := recover(); r != nil {
+					log.Errorf("proxy-cache pull event task for %q panicked: %v", art.Repository, r)
+				}
+			}()
+			c.sendManifestPullEvent(orm.Copy(ctx), art, op)
+		}()
+	}
 
 	return man, nil
+}
+
+func (c *controller) sendManifestPullEvent(ctx context.Context, art lib.ArtifactInfo, op string) {
+	a, err := c.local.GetManifest(ctx, art)
+	if err != nil {
+		log.Errorf("failed to get manifest, error %v", err)
+	}
+	if a != nil {
+		SendPullEvent(ctx, a, art.Tag, op)
+	}
 }
 
 func (c *controller) HeadManifest(_ context.Context, art lib.ArtifactInfo, remote RemoteInterface) (bool, *distribution.Descriptor, error) {

--- a/src/controller/proxy/controller.go
+++ b/src/controller/proxy/controller.go
@@ -245,8 +245,11 @@ func (c *controller) ProxyManifest(ctx context.Context, art lib.ArtifactInfo, re
 		return man, err
 	}
 
-	// Push manifest in background
-	go func(operator string) {
+	// Push manifest to the local cache in the background, bounded by the global
+	// proxy-cache concurrency limit so a slow/unresponsive backend cannot make
+	// these detached goroutines accumulate without bound.
+	op := operator.FromContext(ctx)
+	GoCacheFill("manifest:"+art.Repository, func() {
 		bCtx := orm.Copy(ctx)
 		a, err := c.local.GetManifest(bCtx, art)
 		if err != nil {
@@ -269,9 +272,9 @@ func (c *controller) ProxyManifest(ctx context.Context, art lib.ArtifactInfo, re
 			}
 		}
 		if a != nil {
-			SendPullEvent(bCtx, a, art.Tag, operator)
+			SendPullEvent(bCtx, a, art.Tag, op)
 		}
-	}(operator.FromContext(ctx))
+	})
 
 	return man, nil
 }
@@ -296,12 +299,13 @@ func (c *controller) ProxyBlob(ctx context.Context, p *proModels.Project, art li
 		return 0, nil, err
 	}
 	desc := distribution.Descriptor{Size: size, Digest: digest.Digest(art.Digest)}
-	go func() {
-		err := c.putBlobToLocal(remoteRepo, art.Repository, desc, rHelper)
-		if err != nil {
+	// Populate the local cache in the background, bounded by the global
+	// proxy-cache concurrency limit (see GoCacheFill).
+	GoCacheFill("blob:"+art.Repository, func() {
+		if err := c.putBlobToLocal(remoteRepo, art.Repository, desc, rHelper); err != nil {
 			log.Errorf("error while putting blob to local repo, %v", err)
 		}
-	}()
+	})
 	return size, bReader, nil
 }
 

--- a/src/server/middleware/repoproxy/ensuretag_test.go
+++ b/src/server/middleware/repoproxy/ensuretag_test.go
@@ -1,0 +1,58 @@
+// Copyright Project Harbor Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package repoproxy
+
+import (
+	"context"
+	"errors"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/goharbor/harbor/src/lib"
+)
+
+type fakeTagEnsurer struct{ calls int32 }
+
+func (f *fakeTagEnsurer) EnsureTag(_ context.Context, _ lib.ArtifactInfo, _ string) error {
+	atomic.AddInt32(&f.calls, 1)
+	return errors.New("tag not associated yet")
+}
+
+// TestEnsureTagWithRetryStopsOnContextCancel verifies the retry loop is
+// context-aware: on a cancelled/expired context it returns promptly instead of
+// sleeping the full interval, and does not keep calling EnsureTag.
+func TestEnsureTagWithRetryStopsOnContextCancel(t *testing.T) {
+	f := &fakeTagEnsurer{}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // already cancelled
+
+	done := make(chan struct{})
+	start := time.Now()
+	go func() {
+		ensureTagWithRetry(ctx, f, lib.ArtifactInfo{ProjectName: "proj", Repository: "proj/busybox", Tag: "latest"}, "sha256:abc")
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("ensureTagWithRetry did not return promptly on a cancelled context")
+	}
+	assert.Less(t, time.Since(start), 2*time.Second)
+	assert.Equal(t, int32(0), atomic.LoadInt32(&f.calls), "EnsureTag must not be called once the context is done")
+}

--- a/src/server/middleware/repoproxy/proxy.go
+++ b/src/server/middleware/repoproxy/proxy.go
@@ -401,10 +401,21 @@ type tagEnsurer interface {
 func ensureTagWithRetry(ctx context.Context, te tagEnsurer, art lib.ArtifactInfo, digest string) {
 	bArt := lib.ArtifactInfo{ProjectName: art.ProjectName, Repository: art.Repository, Digest: digest}
 	for range ensureTagMaxRetry {
+		if ctx.Err() != nil {
+			return
+		}
+
+		timer := time.NewTimer(ensureTagInterval)
 		select {
 		case <-ctx.Done():
+			if !timer.Stop() {
+				select {
+				case <-timer.C:
+				default:
+				}
+			}
 			return
-		case <-time.After(ensureTagInterval):
+		case <-timer.C:
 		}
 		err := te.EnsureTag(ctx, bArt, art.Tag)
 		if err == nil {

--- a/src/server/middleware/repoproxy/proxy.go
+++ b/src/server/middleware/repoproxy/proxy.go
@@ -367,25 +367,49 @@ func proxyManifestHead(ctx context.Context, w http.ResponseWriter, ctl proxy.Con
 	if !exist || desc == nil {
 		return errors.NotFoundError(fmt.Errorf("the tag %v:%v is not found", art.Repository, art.Tag))
 	}
-	go func(art lib.ArtifactInfo) {
-		// After docker 20.10 or containerd, the client heads the tag first,
-		// Then GET the image by digest, in order to associate the tag with the digest
-		// Ensure tag after head request, make sure tags in proxy cache keep update
-		bCtx := orm.Context()
-		for range ensureTagMaxRetry {
-			time.Sleep(ensureTagInterval)
-			bArt := lib.ArtifactInfo{ProjectName: art.ProjectName, Repository: art.Repository, Digest: string(desc.Digest)}
-			err := ctl.EnsureTag(bCtx, bArt, art.Tag)
-			if err == nil {
-				return
-			}
-			log.Debugf("Failed to ensure tag %+v , error %v", art, err)
-		}
-	}(art)
+	// Ensure the tag in the proxy cache after the HEAD, bounded by the global
+	// proxy-cache concurrency limit and an overall deadline so this retry loop
+	// can neither accumulate without bound under load nor run unbounded when
+	// EnsureTag keeps failing.
+	dgst := string(desc.Digest)
+	proxy.GoCacheFill("ensure-tag:"+art.Repository, func() {
+		bCtx, cancel := context.WithTimeout(orm.Context(), time.Duration(ensureTagMaxRetry)*ensureTagInterval)
+		defer cancel()
+		ensureTagWithRetry(bCtx, ctl, art, dgst)
+	})
 
 	w.Header().Set(contentType, desc.MediaType)
 	w.Header().Set(contentLength, fmt.Sprintf("%v", desc.Size))
 	w.Header().Set(dockerContentDigest, string(desc.Digest))
 	w.Header().Set(etag, string(desc.Digest))
 	return nil
+}
+
+// tagEnsurer is the subset of proxy.Controller used by ensureTagWithRetry.
+type tagEnsurer interface {
+	EnsureTag(ctx context.Context, art lib.ArtifactInfo, tagName string) error
+}
+
+// ensureTagWithRetry retries EnsureTag until it succeeds, the context is done,
+// or the retry budget (ensureTagMaxRetry) is exhausted. It is context-aware, so
+// it stops promptly on cancellation/deadline instead of always sleeping the
+// full interval.
+//
+// Background: after docker 20.10 or containerd, the client HEADs the tag first
+// and then GETs the image by digest; the GET is what associates the tag with
+// the digest, so we retry to keep the proxy-cache tag up to date.
+func ensureTagWithRetry(ctx context.Context, te tagEnsurer, art lib.ArtifactInfo, digest string) {
+	bArt := lib.ArtifactInfo{ProjectName: art.ProjectName, Repository: art.Repository, Digest: digest}
+	for range ensureTagMaxRetry {
+		select {
+		case <-ctx.Done():
+			return
+		case <-time.After(ensureTagInterval):
+		}
+		err := te.EnsureTag(ctx, bArt, art.Tag)
+		if err == nil {
+			return
+		}
+		log.Debugf("Failed to ensure tag %+v , error %v", art, err)
+	}
 }


### PR DESCRIPTION
## Summary

Second part of the #255 fault model. #254 fixed the **transport + reverse-proxy** path (added `ResponseHeaderTimeout` / `MaxIdleConnsPerHost`). This PR fixes the **pull-through / proxy-cache** path, where harbor-core spawns background goroutines that are **detached from the inbound request and have no timeout of their own**, so under load against a slow/unresponsive backend they accumulate one goroutine + one held socket each, without bound, until the pod is restarted.

Detached goroutines today:
- `controller/proxy/controller.go` — `ProxyManifest` (`orm.Copy(ctx)`) and `ProxyBlob` (no context) fill the local cache after the client is served.
- `server/middleware/repoproxy/proxy.go` — `proxyManifestHead` runs an `EnsureTag` retry loop of up to `ensureTagMaxRetry × ensureTagInterval` (~10 min) with a bare `time.Sleep`, spawned on every HEAD.

These intentionally outlive the request (the whole point is to populate the cache after the client disconnects), so the fix is **not** to tie them to the request context — it's to make the detached work **bounded** and **capped**.

## Changes (items A + C from #256)

- **A — global concurrency cap.** New `GoCacheFill(label, fn)` runs background proxy-cache work under a global limit (`PROXY_CACHE_MAX_CONCURRENT_FILL`, default **100**). Fills are best-effort and outlive the request, so when the limit is reached the task is **skipped and logged** rather than queued — a slow/unresponsive backend can no longer make these goroutines/sockets grow without bound. `ProxyManifest` and `ProxyBlob` now schedule through it. The existing per-artifact `inflightChecker` de-dup (`inflight.go`) is unchanged and complementary (it dedups the *same* artifact; this caps *total* concurrency).
- **C — context-aware, bounded ensure-tag loop.** The HEAD `EnsureTag` loop is extracted into `ensureTagWithRetry`, run under an overall `context.WithTimeout` deadline and the same `GoCacheFill` limiter. It now waits via `select { <-ctx.Done(); <-time.After(...) }` instead of `time.Sleep`, so it stops promptly on cancellation/deadline and can neither pile up nor run unbounded when `EnsureTag` keeps failing.

Backpressure trade-off: under sustained overload some cache fills / tag-ensures are skipped (logged at warning). That degrades cache-hit rate but keeps harbor-core stable — the next pull re-triggers the fill. Tunable via `PROXY_CACHE_MAX_CONCURRENT_FILL`.

## Future work (item B from #256) — tracked in #258

This PR does **not** make the proxy `RemoteInterface` blob reader or the local registry push interfaces context-aware, so an in-flight blob **re-pull/push** cannot yet be cancelled by the new deadline (it is still bounded at the HTTP layer by #254's `ResponseHeaderTimeout`). Threading a context through those interfaces is a larger, separate change tracked in #258.

## Related

- Fixes the proxy-cache half of #255 (reported there; transport half fixed in #254).
- Complementary upstream prior art: goharbor/harbor#23114, goharbor/harbor#21062 (context-aware retry), goharbor/harbor#22184 / goharbor/harbor#22185 (concurrent-pull de-dup), goharbor/harbor#22348 (`max_upstream_conn`).

Closes #256

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Release Notes

Bounded the background work harbor-core performs for proxy-cache (pull-through) projects. Cache population and tag-ensure tasks now run under a global concurrency limit and the tag-ensure retry loop is time-bounded and cancellable, so a slow or unreachable upstream/registry can no longer cause unbounded goroutine and file-descriptor growth in harbor-core. The limit is tunable via the `PROXY_CACHE_MAX_CONCURRENT_FILL` environment variable (default 100).

## Testing

- [x] `go test ./controller/proxy/ ./server/middleware/repoproxy/` passes (full packages, no regression), including new tests:
  - `GoCacheFill` skips work once the gate is full and frees a slot on completion
  - `ensureTagWithRetry` returns promptly on a cancelled context without calling `EnsureTag`
- [x] `go build` and `go vet` clean on both packages; `gofmt` clean

## Checklist

- [x] Conventional Commits title (`fix:`)
- [x] DCO sign-off
- [x] No new warnings
