### PR TITLE
fix(scan): make vulnerability report persistence idempotent

### DIFF
--- a/src/pkg/scan/dao/scan/vulnerability.go
+++ b/src/pkg/scan/dao/scan/vulnerability.go
@@ -180,7 +180,7 @@ func (v *vulnerabilityRecordDao) SyncForReport(ctx context.Context, reportUUID s
 		// and could collide on the unique (report_uuid, vuln_record_id) index or interleave into a set
 		// that matches neither scan. The transaction-scoped advisory lock is released automatically on
 		// commit/rollback, and the existing rows are read only after it is held.
-		if _, err := o.Raw("SELECT pg_advisory_xact_lock(hashtext(?))", reportUUID).Exec(); err != nil {
+		if _, err := o.Raw("SELECT pg_advisory_xact_lock(hashtextextended(?, 0))", reportUUID).Exec(); err != nil {
 			return err
 		}
 

--- a/src/pkg/scan/dao/scan/vulnerability.go
+++ b/src/pkg/scan/dao/scan/vulnerability.go
@@ -16,6 +16,8 @@ package scan
 
 import (
 	"context"
+	"fmt"
+	"strings"
 
 	"github.com/goharbor/harbor/src/lib"
 	"github.com/goharbor/harbor/src/lib/log"
@@ -40,6 +42,9 @@ type VulnerabilityRecordDao interface {
 	List(ctx context.Context, query *q.Query) ([]*VulnerabilityRecord, error)
 	// InsertForReport inserts vulnerability records for a report
 	InsertForReport(ctx context.Context, reportUUID string, vulnerabilityRecordIDs ...int64) error
+	// SyncForReport makes the report's vulnerability record associations match the given set exactly,
+	// inserting the missing rows and deleting the stale ones in a single transaction
+	SyncForReport(ctx context.Context, reportUUID string, vulnerabilityRecordIDs ...int64) error
 	// GetForReport gets vulnerability records for a report
 	GetForReport(ctx context.Context, reportUUID string) ([]*VulnerabilityRecord, error)
 	// GetForScanner gets vulnerability records for a scanner
@@ -147,6 +152,93 @@ func (v *vulnerabilityRecordDao) InsertForReport(ctx context.Context, reportUUID
 		}
 		log.G(ctx).WithFields(fields).Warningf("Could not associate vulnerability record to the report")
 
+		return err
+	}
+
+	return nil
+}
+
+// SyncForReport reconciles the report_vulnerability_record rows for a report so they match the
+// provided set of vulnerability record IDs exactly: missing associations are inserted and stale
+// ones are deleted, all in a single transaction. Re-scanning an artifact whose result is unchanged
+// therefore writes nothing, which keeps the report_vulnerability_record table and its
+// (report_uuid, vuln_record_id) index from growing on every scan (see #23310).
+func (v *vulnerabilityRecordDao) SyncForReport(ctx context.Context, reportUUID string, vulnerabilityRecordIDs ...int64) error {
+	desired := make(map[int64]struct{}, len(vulnerabilityRecordIDs))
+	for _, id := range vulnerabilityRecordIDs {
+		desired[id] = struct{}{}
+	}
+
+	h := func(ctx context.Context) error {
+		o, err := orm.FromContext(ctx)
+		if err != nil {
+			return err
+		}
+
+		// Serialize reconciliation per report. Two concurrent scans of the same artifact (e.g. ScanAll
+		// racing a manual or push-triggered scan) would otherwise diff against the same stale snapshot
+		// and could collide on the unique (report_uuid, vuln_record_id) index or interleave into a set
+		// that matches neither scan. The transaction-scoped advisory lock is released automatically on
+		// commit/rollback, and the existing rows are read only after it is held.
+		if _, err := o.Raw("SELECT pg_advisory_xact_lock(hashtext(?))", reportUUID).Exec(); err != nil {
+			return err
+		}
+
+		var existingIDs []int64
+		if _, err := o.Raw("SELECT vuln_record_id FROM report_vulnerability_record WHERE report_uuid = ?", reportUUID).QueryRows(&existingIDs); err != nil {
+			return err
+		}
+		existing := make(map[int64]struct{}, len(existingIDs))
+		for _, id := range existingIDs {
+			existing[id] = struct{}{}
+		}
+
+		var toInsert []*ReportVulnerabilityRecord
+		for id := range desired {
+			if _, ok := existing[id]; !ok {
+				toInsert = append(toInsert, &ReportVulnerabilityRecord{Report: reportUUID, VulnRecordID: id})
+			}
+		}
+
+		var toDelete []int64
+		for id := range existing {
+			if _, ok := desired[id]; !ok {
+				toDelete = append(toDelete, id)
+			}
+		}
+
+		if len(toInsert) > 0 {
+			if _, err := o.InsertMulti(100, toInsert); err != nil {
+				return err
+			}
+		}
+
+		// Delete stale associations in bounded batches to keep the IN clause size reasonable.
+		const deleteBatch = 1000
+		for start := 0; start < len(toDelete); start += deleteBatch {
+			end := start + deleteBatch
+			if end > len(toDelete) {
+				end = len(toDelete)
+			}
+			batch := toDelete[start:end]
+			args := make([]any, 0, len(batch)+1)
+			args = append(args, reportUUID)
+			placeholders := make([]string, len(batch))
+			for i, id := range batch {
+				placeholders[i] = "?"
+				args = append(args, id)
+			}
+			sql := fmt.Sprintf("DELETE FROM report_vulnerability_record WHERE report_uuid = ? AND vuln_record_id IN (%s)", strings.Join(placeholders, ","))
+			if _, err := o.Raw(sql, args...).Exec(); err != nil {
+				return err
+			}
+		}
+
+		return nil
+	}
+
+	if err := orm.WithTransaction(h)(orm.SetTransactionOpNameToContext(ctx, "tx-sync-for-report")); err != nil {
+		log.G(ctx).WithFields(log.Fields{"error": err, "report": reportUUID}).Warningf("Could not sync vulnerability records for the report")
 		return err
 	}
 

--- a/src/pkg/scan/dao/scan/vulnerability_test.go
+++ b/src/pkg/scan/dao/scan/vulnerability_test.go
@@ -172,6 +172,49 @@ func (suite *VulnerabilityTestSuite) TestVulnerabilityRecordsListForReport() {
 
 }
 
+// TestSyncForReport verifies that SyncForReport reconciles the report's associations to match the
+// desired set exactly (insert missing, delete stale) and that a repeated sync with the same set is a
+// no-op. See #23310.
+func (suite *VulnerabilityTestSuite) TestSyncForReport() {
+	// SetupTest associated 10 vulnerability records with report "uuid".
+	before, err := suite.vulnerabilityRecordDao.GetForReport(suite.Context(), "uuid")
+	suite.NoError(err)
+	suite.Equal(10, len(before))
+
+	// Desired set: keep the first 6 existing records, drop the rest, and add 2 brand-new ones.
+	var desired []int64
+	for i := 0; i < 6; i++ {
+		desired = append(desired, before[i].ID)
+	}
+	newVulns := []*VulnerabilityRecord{
+		{CVEID: "CVE-NEW-1", Package: "pkg-new-1", PackageVersion: "1.0", PackageType: "Unknown", RegistrationUUID: "scannerId1", Severity: "High"},
+		{CVEID: "CVE-NEW-2", Package: "pkg-new-2", PackageVersion: "1.0", PackageType: "Unknown", RegistrationUUID: "scannerId1", Severity: "Low"},
+	}
+	for _, v := range newVulns {
+		id, err := suite.vulnerabilityRecordDao.Create(suite.Context(), v)
+		suite.NoError(err)
+		desired = append(desired, id)
+	}
+
+	// First sync reconciles to exactly the desired 8 records.
+	suite.NoError(suite.vulnerabilityRecordDao.SyncForReport(suite.Context(), "uuid", desired...))
+	after, err := suite.vulnerabilityRecordDao.GetForReport(suite.Context(), "uuid")
+	suite.NoError(err)
+	suite.ElementsMatch(desired, recordIDs(after))
+
+	// A second sync with the same set must not change anything (idempotent).
+	suite.NoError(suite.vulnerabilityRecordDao.SyncForReport(suite.Context(), "uuid", desired...))
+	again, err := suite.vulnerabilityRecordDao.GetForReport(suite.Context(), "uuid")
+	suite.NoError(err)
+	suite.ElementsMatch(recordIDs(after), recordIDs(again))
+
+	// Syncing to an empty set removes all associations.
+	suite.NoError(suite.vulnerabilityRecordDao.SyncForReport(suite.Context(), "uuid"))
+	empty, err := suite.vulnerabilityRecordDao.GetForReport(suite.Context(), "uuid")
+	suite.NoError(err)
+	suite.Equal(0, len(empty))
+}
+
 // TestGetVulnerabilityRecordsForScanner gets vulnerability records for scanner
 func (suite *VulnerabilityTestSuite) TestGetVulnerabilityRecordsForScanner() {
 
@@ -310,4 +353,12 @@ func generateVulnerabilityRecordsForReport(reportUUID string, registrationUUID s
 	}
 
 	return vulns
+}
+
+func recordIDs(records []*VulnerabilityRecord) []int64 {
+	ids := make([]int64, 0, len(records))
+	for _, r := range records {
+		ids = append(ids, r.ID)
+	}
+	return ids
 }

--- a/src/pkg/scan/postprocessors/report_converters.go
+++ b/src/pkg/scan/postprocessors/report_converters.go
@@ -58,6 +58,12 @@ func NewNativeToRelationalSchemaConverter() NativeScanReportConverter {
 func (c *nativeToRelationalSchemaConverter) ToRelationalSchema(ctx context.Context, reportUUID string, registrationUUID string, digest string, reportData string) (string, string, error) {
 	if len(reportData) == 0 {
 		log.G(ctx).Infof("There is no vulnerability report to toSchema for report UUID : %s", reportUUID)
+		// The scan_report row is now reused across re-scans (#23310), so an empty result must still
+		// clear any vulnerability associations left by a previous scan; reconcile to the empty set.
+		// (The structured "clean image" case is already handled by toSchema -> SyncForReport below.)
+		if err := c.dao.SyncForReport(ctx, reportUUID); err != nil {
+			return "", "", errors.Wrap(err, "Error when clearing vulnerability records for empty report")
+		}
 		return reportUUID, "", nil
 	}
 	// parse the raw report with the V1 schema of the report to the normalized structures

--- a/src/pkg/scan/postprocessors/report_converters.go
+++ b/src/pkg/scan/postprocessors/report_converters.go
@@ -180,7 +180,11 @@ func (c *nativeToRelationalSchemaConverter) toSchema(ctx context.Context, report
 		recordIDs = append(recordIDs, recordID)
 	}
 
-	if err := c.dao.InsertForReport(ctx, reportUUID, recordIDs...); err != nil {
+	// Reconcile the report's vulnerability associations with a set-diff instead of a bulk insert so a
+	// re-scan of an unchanged artifact (the common ScanAll case) writes nothing. Combined with the
+	// stable report UUID kept by MakePlaceHolder, this stops report_vulnerability_record from growing
+	// on every scan. See #23310.
+	if err := c.dao.SyncForReport(ctx, reportUUID, recordIDs...); err != nil {
 		fields := log.Fields{
 			"error":  err,
 			"report": reportUUID,

--- a/src/pkg/scan/vulnerability/vul.go
+++ b/src/pkg/scan/vulnerability/vul.go
@@ -70,23 +70,38 @@ func (h *scanHandler) MakePlaceHolder(ctx context.Context, art *artifact.Artifac
 		return nil, err
 	}
 
-	if len(oldReports) > 0 {
-		for _, oldReport := range oldReports {
-			if !job.Status(oldReport.Status).Final() {
-				return nil, errors.ConflictError(nil).WithMessagef("a previous scan process is %s", oldReport.Status)
-			}
+	// Refuse to start a new scan while a previous one for this artifact/scanner is still running.
+	for _, oldReport := range oldReports {
+		if !job.Status(oldReport.Status).Final() {
+			return nil, errors.ConflictError(nil).WithMessagef("a previous scan process is %s", oldReport.Status)
 		}
+	}
 
-		for _, oldReport := range oldReports {
-			if err := reportMgr.Delete(ctx, oldReport.UUID); err != nil {
-				return nil, err
-			}
-		}
+	// Reuse the existing report row (and therefore its UUID and its existing vulnerability
+	// associations) for each mime type instead of deleting it and creating a new one. Keeping a stable
+	// report UUID lets PostScan reconcile report_vulnerability_record with a set-diff, so a re-scan
+	// that produces the same result writes nothing and the unique (report_uuid, vuln_record_id) index
+	// stops churning on every ScanAll. The previous result also stays queryable while the re-scan
+	// runs. Fixes #23310.
+	existing := make(map[string]*scan.Report, len(oldReports))
+	for _, oldReport := range oldReports {
+		existing[oldReport.MimeType] = oldReport
 	}
 
 	var reports []*scan.Report
 
-	for _, pm := range r.GetProducesMimeTypes(art.ManifestMediaType, v1.ScanTypeVulnerability) {
+	for _, pm := range mimeTypes {
+		if oldReport, ok := existing[pm]; ok {
+			reports = append(reports, &scan.Report{
+				ID:               oldReport.ID,
+				UUID:             oldReport.UUID,
+				Digest:           art.Digest,
+				RegistrationUUID: r.UUID,
+				MimeType:         pm,
+			})
+			continue
+		}
+
 		rpt := &scan.Report{
 			Digest:           art.Digest,
 			RegistrationUUID: r.UUID,

--- a/src/pkg/scan/vulnerability/vul_test.go
+++ b/src/pkg/scan/vulnerability/vul_test.go
@@ -206,15 +206,37 @@ func (suite *VulHandlerTestSuite) TestMakeReportPlaceHolder() {
 			},
 		},
 	}
-	// mimeTypes := []string{v1.MimeTypeGenericVulnerabilityReport}
-	mock.OnAnything(suite.reportMgr, "GetBy").Return([]*scan.Report{{UUID: "uuid"}}, nil).Once()
-	mock.OnAnything(suite.reportMgr, "Create").Return("uuid", nil).Once()
-	mock.OnAnything(suite.reportMgr, "Delete").Return(nil).Once()
+	// A previous, finished report for the produced mime type must be reused (stable UUID), not deleted
+	// and recreated. See #23310.
+	mock.OnAnything(suite.reportMgr, "GetBy").Return([]*scan.Report{{UUID: "existing-uuid", MimeType: v1.MimeTypeGenericVulnerabilityReport}}, nil).Once()
 	mock.OnAnything(suite.taskMgr, "ListScanTasksByReportUUID").Return([]*task.Task{{Status: "Success"}}, nil)
 	mock.OnAnything(suite.handler.reportConverter, "FromRelationalSchema").Return("", nil)
 	rps, err := suite.handler.MakePlaceHolder(ctx, art, r)
 	require.NoError(suite.T(), err)
-	assert.Equal(suite.T(), 1, len(rps))
+	require.Equal(suite.T(), 1, len(rps))
+	assert.Equal(suite.T(), "existing-uuid", rps[0].UUID, "the existing report UUID should be reused")
+	suite.reportMgr.AssertNotCalled(suite.T(), "Delete", mock.Anything, mock.Anything)
+	suite.reportMgr.AssertNotCalled(suite.T(), "Create", mock.Anything, mock.Anything)
+}
+
+func (suite *VulHandlerTestSuite) TestMakeReportPlaceHolderCreatesWhenAbsent() {
+	ctx := orm.NewContext(nil, &ormtesting.FakeOrmer{})
+	art := &artifact.Artifact{Artifact: art.Artifact{ID: 1, Digest: "digest-absent", ManifestMediaType: v1.MimeTypeDockerArtifact}}
+	r := &scanner.Registration{
+		UUID: "uuid",
+		Metadata: &v1.ScannerAdapterMetadata{
+			Capabilities: []*v1.ScannerCapability{
+				{Type: v1.ScanTypeVulnerability, ConsumesMimeTypes: []string{v1.MimeTypeDockerArtifact}, ProducesMimeTypes: []string{v1.MimeTypeGenericVulnerabilityReport}},
+			},
+		},
+	}
+	// No existing report: a new one is created.
+	mock.OnAnything(suite.reportMgr, "GetBy").Return([]*scan.Report{}, nil).Once()
+	mock.OnAnything(suite.reportMgr, "Create").Return("new-uuid", nil).Once()
+	rps, err := suite.handler.MakePlaceHolder(ctx, art, r)
+	require.NoError(suite.T(), err)
+	require.Equal(suite.T(), 1, len(rps))
+	assert.Equal(suite.T(), "new-uuid", rps[0].UUID)
 }
 
 func (suite *VulHandlerTestSuite) TestGetReportPlaceHolder() {

--- a/src/pkg/task/dao/task.go
+++ b/src/pkg/task/dao/task.go
@@ -115,11 +115,11 @@ func (t *taskDAO) ListScanTasksByReportUUID(ctx context.Context, uuid string) ([
 
 	var tasks []*Task
 	param := fmt.Sprintf(`"%s"`, uuid)
-	// Order by id DESC so the latest task comes first. A report UUID can be referenced by more than
-	// one task once a report row is reused across re-scans (see #23310), and callers take tasks[0] as
-	// the current task; without an explicit order Postgres may return an older task and surface a
-	// stale status.
-	sql := `SELECT * FROM task WHERE extra_attrs::jsonb -> 'report_uuids' @> ? ORDER BY id DESC`
+	// A report UUID can be referenced by more than one task once a report row is reused across
+	// re-scans (see #23310). Every caller resolves the current task as tasks[0], so order by id DESC
+	// and return only the latest row: the ORDER BY avoids surfacing a stale older task, and the
+	// LIMIT 1 keeps the result set from growing with each re-scan.
+	sql := `SELECT * FROM task WHERE extra_attrs::jsonb -> 'report_uuids' @> ? ORDER BY id DESC LIMIT 1`
 	_, err = ormer.Raw(sql, param).QueryRows(&tasks)
 	if err != nil {
 		return nil, err

--- a/src/pkg/task/dao/task.go
+++ b/src/pkg/task/dao/task.go
@@ -115,7 +115,11 @@ func (t *taskDAO) ListScanTasksByReportUUID(ctx context.Context, uuid string) ([
 
 	var tasks []*Task
 	param := fmt.Sprintf(`"%s"`, uuid)
-	sql := `SELECT * FROM task WHERE extra_attrs::jsonb -> 'report_uuids' @> ?`
+	// Order by id DESC so the latest task comes first. A report UUID can be referenced by more than
+	// one task once a report row is reused across re-scans (see #23310), and callers take tasks[0] as
+	// the current task; without an explicit order Postgres may return an older task and surface a
+	// stale status.
+	sql := `SELECT * FROM task WHERE extra_attrs::jsonb -> 'report_uuids' @> ? ORDER BY id DESC`
 	_, err = ormer.Raw(sql, param).QueryRows(&tasks)
 	if err != nil {
 		return nil, err

--- a/src/pkg/task/dao/task_test.go
+++ b/src/pkg/task/dao/task_test.go
@@ -136,6 +136,37 @@ func (t *taskDAOTestSuite) TestListScanTasksByReportUUID() {
 	t.Equal(taskID, tasks[0].ID)
 }
 
+// TestListScanTasksByReportUUIDOrdersByLatest verifies that when a report UUID is referenced by more
+// than one task (which happens once a report row is reused across re-scans, see #23310), the latest
+// task is returned first so callers that take tasks[0] observe the current scan rather than a stale one.
+func (t *taskDAOTestSuite) TestListScanTasksByReportUUIDOrdersByLatest() {
+	reportUUID := `2b8f3a1c-1111-2222-3333-444455556666`
+	first, err := t.taskDAO.Create(t.ctx, &Task{
+		ExecutionID: t.executionID,
+		Status:      "Success",
+		StatusCode:  1,
+		ExtraAttrs:  fmt.Sprintf(`{"report_uuids": ["%s"]}`, reportUUID),
+	})
+	t.Require().Nil(err)
+	defer t.taskDAO.Delete(t.ctx, first)
+
+	second, err := t.taskDAO.Create(t.ctx, &Task{
+		ExecutionID: t.executionID,
+		Status:      "Running",
+		StatusCode:  1,
+		ExtraAttrs:  fmt.Sprintf(`{"report_uuids": ["%s"]}`, reportUUID),
+	})
+	t.Require().Nil(err)
+	defer t.taskDAO.Delete(t.ctx, second)
+
+	tasks, err := t.taskDAO.ListScanTasksByReportUUID(t.ctx, reportUUID)
+	t.Require().Nil(err)
+	t.Require().Len(tasks, 2)
+	// Latest (largest id) first.
+	t.Equal(second, tasks[0].ID)
+	t.Equal(first, tasks[1].ID)
+}
+
 func (t *taskDAOTestSuite) TestGet() {
 	// not exist
 	_, err := t.taskDAO.Get(t.ctx, 10000)

--- a/src/pkg/task/dao/task_test.go
+++ b/src/pkg/task/dao/task_test.go
@@ -137,8 +137,9 @@ func (t *taskDAOTestSuite) TestListScanTasksByReportUUID() {
 }
 
 // TestListScanTasksByReportUUIDOrdersByLatest verifies that when a report UUID is referenced by more
-// than one task (which happens once a report row is reused across re-scans, see #23310), the latest
-// task is returned first so callers that take tasks[0] observe the current scan rather than a stale one.
+// than one task (which happens once a report row is reused across re-scans, see #23310), only the
+// latest task is returned (ORDER BY id DESC LIMIT 1) so callers that take tasks[0] observe the
+// current scan rather than a stale one and the result set does not grow with each re-scan.
 func (t *taskDAOTestSuite) TestListScanTasksByReportUUIDOrdersByLatest() {
 	reportUUID := `2b8f3a1c-1111-2222-3333-444455556666`
 	first, err := t.taskDAO.Create(t.ctx, &Task{
@@ -161,10 +162,9 @@ func (t *taskDAOTestSuite) TestListScanTasksByReportUUIDOrdersByLatest() {
 
 	tasks, err := t.taskDAO.ListScanTasksByReportUUID(t.ctx, reportUUID)
 	t.Require().Nil(err)
-	t.Require().Len(tasks, 2)
-	// Latest (largest id) first.
+	// LIMIT 1 returns only the latest task (largest id); every caller consumes tasks[0].
+	t.Require().Len(tasks, 1)
 	t.Equal(second, tasks[0].ID)
-	t.Equal(first, tasks[1].ID)
 }
 
 func (t *taskDAOTestSuite) TestGet() {


### PR DESCRIPTION
Every re-scan deletes the artifact's `scan_report` row and re-inserts all of its `report_vulnerability_record` rows under a new random UUID, which is what bloats that table on registries with a daily Scan All (goharbor/harbor#23310). This PR reuses the existing report row and reconciles its associations with a set-diff, so an unchanged result writes nothing, and as a side effect the previous report stays readable while the re-scan is queued or running instead of disappearing.

## Problem

`report_vulnerability_record` grows without bound on a stable image set. The upstream reporter saw 16 GB to 96 GB at about 6 GB a day, with the unique `(report_uuid, vuln_record_id)` index alone at 40 GB, larger than the heap, correlated with the scheduled Trivy Scan All.

The cause is the contract of `MakePlaceHolder`: delete the existing report, create a new one. The `scan_report` row for `(digest, registration_uuid, mime_type)` is deleted, cascading its `report_vulnerability_record` rows, and recreated with a fresh random UUID. `PostScan` then bulk-inserts every association under that UUID. A digest is immutable and a scanner is deterministic for a given vulnerability DB, so a daily Scan All rewrites an essentially identical join set every day. The foreign keys cascade, so the logical row count stays bounded by `scan_report`; the growth is dead tuples and random-UUID B-tree churn on the unique index that autovacuum cannot keep up with.

The same delete has a second effect. Scan All calls `Scan()` for every artifact at enqueue time, so every report in the registry is gone before the first worker starts, and each artifact stays without a report until its own job finishes. During that window the vulnerabilities addition returns `{}`, which is also the response for a never-scanned artifact, and Security Hub counts the artifact as clean. Measured on a dev slot with one artifact (nginx:1.19, 424 findings) and the IMAGE_SCAN queue paused so the re-scan stays Pending:

| | before re-scan | while Pending | after re-scan |
|---|---|---|---|
| `GET .../additions/vulnerabilities` | 424 CVEs | `{}` | 424 CVEs |
| `GET /security/summary` total_vuls | 424 | 0 | 424 |
| `GET /security/vul` X-Total-Count | 424 | 0 | 424 |
| `scan_report` row | uuid A | uuid B, empty report | uuid B |
| `report_vulnerability_record` rows | 424 | 0 | 424 |

## Solution

Make report persistence idempotent.

1. Stable report row (`src/pkg/scan/vulnerability/vul.go`). `MakePlaceHolder` reuses the existing `scan_report` row, with its UUID and associations, per `(digest, registration_uuid, mime_type)` instead of deleting and recreating it. The guard that refuses a new scan while a previous one is still running is unchanged.
2. Set-diff instead of bulk insert (`src/pkg/scan/dao/scan/vulnerability.go`, `src/pkg/scan/postprocessors/report_converters.go`). A new `SyncForReport` reconciles `report_vulnerability_record` in one transaction: insert the missing rows, delete the stale ones, and clear all associations for an empty result. `PostScan` calls it instead of `InsertForReport`. An empty raw report is rejected before any write so the last successful result stays intact, and a clean image arrives as a structured report with an empty vulnerability list that reconciles to zero through `toSchema`. A re-scan with an unchanged result writes no rows. A transaction-scoped `pg_advisory_xact_lock(hashtextextended(report_uuid, 0))` serialises two reconciliations of the same report, so overlapping scans cannot collide on the unique index or interleave.
3. Deterministic task resolution (`src/pkg/task/dao/task.go`). A reused report UUID is referenced by more than one task over time, so `ListScanTasksByReportUUID` now runs `ORDER BY id DESC LIMIT 1`. Every caller takes `tasks[0]` for status and log resolution and gets the current scan rather than a stale one, and the matched set no longer grows.

With the PR applied to the same dev slot, the table above reads 424 in every column while the task is Pending, and also after the re-scan fails with status Error. The report UUID stays the same across runs.

## Benefits

- `report_vulnerability_record` stops growing on registries whose image set is stable. A re-scan with the same result writes nothing, and the unique index stops churning on random UUIDs.
- No blind window during Scan All. The last successful result stays readable until the new one replaces it, on the API, in Security Hub and in the scan export, and it survives a failed re-scan.
- A saved `GET /scan/{report_id}/log` link keeps working after a re-scan and returns the latest log.

## Details

### Behaviour changes

`report_id` is stable across re-scans for a given (artifact, scanner, mime type). It used to be a fresh random UUID per run. Anyone who needs per-run identity should use the execution or task id, or the start and end times. SBOM `report_id` is unchanged.

The previous report survives a running or failed re-scan. Surfaces that gate on status (scan badge and summary, the pull-time vulnerability gate, the P2P preheat gate) read status from the newest task, show Running or Error as before, and fail closed on anything but Success, so there is no policy bypass. The raw vulnerabilities addition, Security Hub and the scan export, which do not gate on status, return the last successful result until the next scan succeeds. Previously they returned nothing, which read as a clean artifact.

Starting a scan no longer mutates `scan_report`, so two scans of the same artifact can both be submitted in a narrow window. Reconciliation is serialised, so the second one is a redundant scan, never inconsistent associations.

Task rows per report stay bounded by the existing daily `EXECUTION_SWEEP` with retention 1; after each sweep a reused report UUID is back to about one referencing task.

### Downgrade

After re-scans under this change, a report UUID is referenced by several tasks and the `ORDER BY id DESC LIMIT 1` tie-break is what keeps status correct. Rolling `core` back to a build without it can show stale scan status, including a brief fail-open of the pull gate, until the next daily sweep, at most 24 hours. The change is on `release-2.15` as 2783f46e4 and ships from v2.15.6.

### Out of scope

This stops future growth but does not shrink a table that is already bloated. Reclaim once with `VACUUM (FULL)` or `pg_repack` plus `REINDEX` on `report_vulnerability_record`. Per-table autovacuum tuning and an orphan-record sweep are separate follow-ups. The SBOM path still deletes its report before a re-scan, so a failed SBOM regeneration loses the prior SBOM; that is goharbor/harbor#23320.

### Tests

DAO test for `SyncForReport`: reconcile to a changed set, an idempotent re-sync writes nothing, sync to empty clears. Task DAO test: a reused report UUID resolves to the latest task only. Handler tests: `MakePlaceHolder` reuses an existing report's UUID with no Create or Delete, and creates one only when none exists.

## Related Issues

Mirrors the upstream submission for the same bug. The `#23310`, `#23319` and `#23320` references in the commit message refer to goharbor/harbor.

- Upstream issue: goharbor/harbor#23310
- Upstream PR: goharbor/harbor#23319
- SBOM parity follow-up: goharbor/harbor#23320

## Type of Change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` / `fix!:`)
- [ ] Documentation (`docs:`)
- [ ] Refactoring (`refactor:`)
- [ ] CI/CD or build changes (`ci:` / `build:`)
- [ ] Upstream Harbor cherry-pick (`upstream:`)
- [ ] Dependencies update (`chore:`)
- [ ] Tests (`test:`)

## Release Notes

Vulnerability scan results no longer disappear while a re-scan is queued or running. Before this change, a Scan All deleted every existing report at the moment it was scheduled, so the vulnerabilities view, the API and Security Hub showed zero findings for each artifact until its own scan finished, which could take hours on a large registry. The last successful report now stays visible until the new one replaces it, and it also survives a failed re-scan.

The same change stops the `report_vulnerability_record` table from growing on every scheduled scan. Re-scanning an unchanged artifact now writes nothing. Databases that are already bloated should reclaim space once with `VACUUM (FULL)` or `pg_repack` plus `REINDEX` on `report_vulnerability_record`.

The vulnerability `report_id` is now stable across re-scans of the same artifact. Integrations that used it as a per-scan identifier should switch to the scan execution or task id.

## Testing

- [x] Unit tests added/updated
- [x] Manual testing performed

Verified on a dev slot with the IMAGE_SCAN queue paused: pre-fix the queued artifact returns `{}` and Security Hub drops to 0; with the fix all 424 findings stay visible through Pending, Error and the next Success, under the same report UUID.

## Checklist

- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] Commits are signed off (`git commit -s`)
- [x] No new warnings introduced

