### PR TITLE
ci: Harden release branch workflow matching

### DIFF
--- a/.github/workflows/backport-suggestion.yml
+++ b/.github/workflows/backport-suggestion.yml
@@ -36,7 +36,7 @@ jobs:
           esac
 
           branches=$(gh api "repos/${GITHUB_REPOSITORY}/git/matching-refs/heads/release-" \
-            --jq '.[].ref | sub("refs/heads/"; "")' | sort -Vr)
+            --jq '.[].ref | sub("refs/heads/"; "") | select(test("^release-[0-9]+\\.[0-9]+$"))' | sort -Vr)
           if [ -z "${branches}" ]; then
             exit 0
           fi

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,13 +2,13 @@ name: Build
 
 on:
   pull_request:
-    branches: [main, "release-*"]
+    branches: [main, "release-[0-9]*.[0-9]*"]
     paths-ignore:
       - "**.md"
       - "docs/**"
       - "CLAUDE.md"
   push:
-    branches: [main, "release-*"]
+    branches: [main, "release-[0-9]*.[0-9]*"]
     paths-ignore:
       - "**.md"
       - "docs/**"

--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -2,7 +2,7 @@ name: PR Preview Images
 
 on:
   pull_request:
-    branches: [main, "release-*"]
+    branches: [main, "release-[0-9]*.[0-9]*"]
     paths-ignore:
       - "**.md"
       - "docs/**"

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1,6 +1,7 @@
 name: Release Please
 
 on:
+  workflow_dispatch:
   push:
     branches:
       - main

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -12,7 +12,21 @@ permissions:
   pull-requests: write
 
 jobs:
+  validate-release-ref:
+    name: Validate Release Ref
+    runs-on: ${{ vars.RUNNER || 'ubuntu-latest' }}
+    steps:
+      - name: Allow only release refs
+        run: |
+          if [[ "${GITHUB_REF_NAME}" == "main" || "${GITHUB_REF_NAME}" =~ ^release-[0-9]+\.[0-9]+$ ]]; then
+            exit 0
+          fi
+
+          echo "::error::Release Please can only run on main or release-X.Y branches. Current ref: ${GITHUB_REF_NAME}"
+          exit 1
+
   release-please:
+    needs: [validate-release-ref]
     runs-on: ${{ vars.RUNNER || 'ubuntu-latest' }}
     outputs:
       release_created: ${{ steps.release.outputs.release_created }}

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches:
       - main
-      - "release-*"
+      - "release-[0-9]*.[0-9]*"
 
 permissions:
   contents: write

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,13 +2,13 @@ name: Test
 
 on:
   pull_request:
-    branches: [main, "release-*"]
+    branches: [main, "release-[0-9]*.[0-9]*"]
     paths-ignore:
       - "**.md"
       - "docs/**"
       - "CLAUDE.md"
   push:
-    branches: [main, "release-*"]
+    branches: [main, "release-[0-9]*.[0-9]*"]
     paths-ignore:
       - "**.md"
       - "docs/**"


### PR DESCRIPTION
## Summary
- narrow CI/release workflow branch filters to maintenance-style release branches
- filter backport suggestions to release-X.Y branches only
- prevent release-please helper branches from being treated as release branches
- add `workflow_dispatch` to Release Please for manual reruns on `main` and maintenance branches
- guard manual Release Please runs so release automation only runs on `main` or exact `release-X.Y` refs

## Follow-up
- Strict digit-only CI trigger glob cleanup is tracked in #264.

## Testing
- python YAML parse for edited workflows
- `git diff --check next/main..HEAD`