### PR TITLE
ci: Prepare main for minor releases

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -4,6 +4,7 @@
   "pull-request-header": "This PR prepares the next release based on conventional commits.",
   "pull-request-title-pattern": "chore: release ${version}",
   "release-type": "simple",
+  "versioning": "always-bump-minor",
   "include-v-in-tag": true,
   "exclude-paths": [".github", "docs", "tests"],
   "changelog-sections": [


### PR DESCRIPTION
## Summary
- configure main-line Release Please with `versioning: always-bump-minor`
- make the next main release PR target `2.16.0` without using a one-time `release-as` override
- keep `2.15.x` patch releases on the `release-2.15` maintenance branch

## Release behavior
- `main` generates minor releases: `2.16.0`, then `2.17.0`, then `2.18.0`, etc.
- when a main release is created with patch `0`, the workflow creates `release-X.Y` from that tag, for example `release-2.16`
- maintenance branches use `release-please-config-maintenance.json` with `versioning: always-bump-patch`, so `release-2.16` produces `2.16.1`, `2.16.2`, etc.
- release automation is guarded to run only on `main` or exact `release-X.Y` refs

## Context
- closed the incorrect main release PR #265 (`2.15.1`)
- the correct maintenance release PR remains #266 (`2.15.1` against `release-2.15`)

## Testing
- `python -m json.tool release-please-config.json`
- `python -m json.tool release-please-config-maintenance.json`
- YAML parse for `.github/workflows/release-please.yml`