### PR TITLE
ci: Fix backport workflow gh setup

### DIFF
--- a/.github/workflows/backport-suggestion.yml
+++ b/.github/workflows/backport-suggestion.yml
@@ -24,14 +24,23 @@ jobs:
       PR_TITLE: ${{ github.event.pull_request.title }}
     steps:
       - name: Install gh CLI
-        uses: actions4gh/setup-gh@44a12005484c53be5bf51bebe8c985b4be8ba8de # v1.0.2
-        with:
-          gh-version: latest
+        run: |
+          if command -v gh >/dev/null 2>&1; then
+            exit 0
+          fi
+
+          curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \
+            | sudo dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg
+          sudo chmod go+r /usr/share/keyrings/githubcli-archive-keyring.gpg
+          echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" \
+            | sudo tee /etc/apt/sources.list.d/github-cli.list > /dev/null
+          sudo apt-get update
+          sudo apt-get install -y gh
 
       - name: Comment with backport commands
         run: |
           case "${PR_TITLE}" in
-            fix:*|upstream:*|perf:*|revert:*) ;;
+            fix:*|upstream:*|perf:*|revert:*|ci:*|build:*) ;;
             *) exit 0 ;;
           esac
 

--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -25,9 +25,18 @@ jobs:
       COMMENT_BODY: ${{ github.event.comment.body }}
     steps:
       - name: Install gh CLI
-        uses: actions4gh/setup-gh@44a12005484c53be5bf51bebe8c985b4be8ba8de # v1.0.2
-        with:
-          gh-version: latest
+        run: |
+          if command -v gh >/dev/null 2>&1; then
+            exit 0
+          fi
+
+          curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \
+            | sudo dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg
+          sudo chmod go+r /usr/share/keyrings/githubcli-archive-keyring.gpg
+          echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" \
+            | sudo tee /etc/apt/sources.list.d/github-cli.list > /dev/null
+          sudo apt-get update
+          sudo apt-get install -y gh
 
       - name: Resolve backport target
         id: target


### PR DESCRIPTION
## Summary
- replace the failing `actions4gh/setup-gh` step in backport workflows with a direct `gh` install fallback
- keep using the preinstalled `gh` CLI when it is already available
- include `ci:` and `build:` PRs in automatic backport suggestions because release-pipeline changes may need maintenance backports

## Context
- Backport Suggestion ran for #267 but failed before commenting because `actions4gh/setup-gh` failed with `spawn gh ENOENT`.
- Even if that install step had succeeded, #267 would have skipped suggestions because the current title filter excludes `ci:` PRs.

## Testing
- YAML parse for `.github/workflows/backport.yml` and `.github/workflows/backport-suggestion.yml`
- `git diff --check next/main..HEAD`