### PR TITLE
ci: Fix backport merged PR detection

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -58,8 +58,8 @@ jobs:
       - name: Load source PR
         id: source
         run: |
-          merged=$(gh pr view "${PR_NUMBER}" --json merged --jq .merged)
-          if [ "${merged}" != "true" ]; then
+          merged_at=$(gh pr view "${PR_NUMBER}" --json mergedAt --jq .mergedAt)
+          if [ -z "${merged_at}" ]; then
             gh pr comment "${PR_NUMBER}" --body "Cannot backport because this PR has not been merged."
             exit 1
           fi


### PR DESCRIPTION
## Summary
- use `mergedAt` instead of unsupported `merged` in the backport workflow
- allow `/backport vX.Y` to continue after confirming the source PR was merged

## Context
- `/backport v2.15` on #269 got past GitHub CLI setup but failed at `gh pr view --json merged` because this `gh` version does not expose a `merged` field.

## Testing
- YAML parse for `.github/workflows/backport.yml`
- `git diff --check next/main..HEAD`