### PR TITLE
ci: Backport workflow backport fixes to 2.15

### DIFF
--- a/.github/workflows/backport-suggestion.yml
+++ b/.github/workflows/backport-suggestion.yml
@@ -24,14 +24,23 @@ jobs:
       PR_TITLE: ${{ github.event.pull_request.title }}
     steps:
       - name: Install gh CLI
-        uses: actions4gh/setup-gh@44a12005484c53be5bf51bebe8c985b4be8ba8de # v1.0.2
-        with:
-          gh-version: latest
+        run: |
+          if command -v gh >/dev/null 2>&1; then
+            exit 0
+          fi
+
+          curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \
+            | sudo dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg
+          sudo chmod go+r /usr/share/keyrings/githubcli-archive-keyring.gpg
+          echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" \
+            | sudo tee /etc/apt/sources.list.d/github-cli.list > /dev/null
+          sudo apt-get update
+          sudo apt-get install -y gh
 
       - name: Comment with backport commands
         run: |
           case "${PR_TITLE}" in
-            fix:*|upstream:*|perf:*|revert:*) ;;
+            fix:*|upstream:*|perf:*|revert:*|ci:*|build:*) ;;
             *) exit 0 ;;
           esac
 

--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -25,9 +25,18 @@ jobs:
       COMMENT_BODY: ${{ github.event.comment.body }}
     steps:
       - name: Install gh CLI
-        uses: actions4gh/setup-gh@44a12005484c53be5bf51bebe8c985b4be8ba8de # v1.0.2
-        with:
-          gh-version: latest
+        run: |
+          if command -v gh >/dev/null 2>&1; then
+            exit 0
+          fi
+
+          curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \
+            | sudo dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg
+          sudo chmod go+r /usr/share/keyrings/githubcli-archive-keyring.gpg
+          echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" \
+            | sudo tee /etc/apt/sources.list.d/github-cli.list > /dev/null
+          sudo apt-get update
+          sudo apt-get install -y gh
 
       - name: Resolve backport target
         id: target

--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -58,8 +58,8 @@ jobs:
       - name: Load source PR
         id: source
         run: |
-          merged=$(gh pr view "${PR_NUMBER}" --json merged --jq .merged)
-          if [ "${merged}" != "true" ]; then
+          merged_at=$(gh pr view "${PR_NUMBER}" --json mergedAt --jq .mergedAt)
+          if [ -z "${merged_at}" ]; then
             gh pr comment "${PR_NUMBER}" --body "Cannot backport because this PR has not been merged."
             exit 1
           fi


### PR DESCRIPTION
## Summary
- backport #269 to fix GitHub CLI setup in backport workflows
- backport #270 to fix merged PR detection via `mergedAt`

## Context
- `/backport v2.15` on #269 correctly cherry-picked the change, but GitHub rejected the workflow-file push from `GITHUB_TOKEN` because workflow updates require `workflows` permission.
- This PR applies the same workflow fixes manually to `release-2.15`.

## Testing
- YAML parse for `.github/workflows/backport.yml` and `.github/workflows/backport-suggestion.yml`
- `git diff --check next/release-2.15..HEAD`