### PR TITLE
fix(cache): replace keyMutex with singleflight and avoid canceling cache Save (upstream #23336)

### DIFF
--- a/src/lib/cache/helper.go
+++ b/src/lib/cache/helper.go
@@ -24,8 +24,9 @@ import (
 )
 
 // FetchOrSave retrieves the value for the key if present in the cache.
-// Otherwise, it builds the value once for all concurrent callers (deduplicated
-// via singleflight), saves it to the cache, and copies it into value.
+// Otherwise, it builds the value with the builder, saves it to the cache and
+// populates value with the built result. Concurrent calls for the same key
+// share a single builder execution and its result.
 func FetchOrSave(ctx context.Context, c Cache, key string, value any, builder func() (any, error), expiration ...time.Duration) error {
 	err := c.Fetch(ctx, key, value)
 	// value found from the cache

--- a/src/lib/cache/helper.go
+++ b/src/lib/cache/helper.go
@@ -18,14 +18,9 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"sync"
 	"time"
 
 	"github.com/goharbor/harbor/src/lib/log"
-)
-
-var (
-	fetchOrSaveMu = keyMutex{m: &sync.Map{}}
 )
 
 // FetchOrSave retrieves the value for the key if present in the cache.
@@ -41,38 +36,34 @@ func FetchOrSave(ctx context.Context, c Cache, key string, value any, builder fu
 		return err
 	}
 
-	// lock the key in cache and try to build the value for the key
-	lockKey := fmt.Sprintf("%p:%s", c, key)
-	fetchOrSaveMu.Lock(lockKey)
+	// Use singleflight to deduplicate concurrent builds for the same key: only the
+	// first caller runs builder(), all concurrent callers share its result.
+	groupKey := fmt.Sprintf("%p:%s", c, key)
 
-	defer fetchOrSaveMu.Unlock(lockKey)
+	result, err, _ := fetchOrSaveGroup.Do(groupKey, func() (any, error) {
+		val, err := builder()
+		if err != nil {
+			return nil, err
+		}
 
-	// fetch again to avoid building the value multi-times
-	err = c.Fetch(ctx, key, value)
-	if err == nil {
-		return nil
-	}
-	// internal error
-	if !errors.Is(err, ErrNotFound) {
-		return err
-	}
+		// Save with a non-cancelable context so a canceled request context (e.g. the
+		// HTTP client disconnected) does not prevent the cache from being populated.
+		saveCtx := context.WithoutCancel(ctx)
+		if err := c.Save(saveCtx, key, val, expiration...); err != nil {
+			log.Warningf("failed to save value to cache, error: %v", err)
+		}
 
-	val, err := builder()
+		return val, nil
+	})
 	if err != nil {
 		return err
 	}
 
-	if err := c.Save(ctx, key, val, expiration...); err != nil {
-		log.Warningf("failed to save value to cache, error: %v", err)
-
-		// save the val to cache failed, copy it to the value using the default codec
-		data, err := codec.Encode(val)
-		if err != nil {
-			return err
-		}
-
-		return codec.Decode(data, value)
+	// Copy the shared result into the caller's value via the codec, so every caller
+	// (the leader and all waiters) gets its own populated value.
+	data, err := codec.Encode(result)
+	if err != nil {
+		return err
 	}
-
-	return c.Fetch(ctx, key, value) // after the building, fetch value again
+	return codec.Decode(data, value)
 }

--- a/src/lib/cache/helper.go
+++ b/src/lib/cache/helper.go
@@ -24,7 +24,8 @@ import (
 )
 
 // FetchOrSave retrieves the value for the key if present in the cache.
-// Otherwise, it saves the value from the builder and retrieves the value for the key again.
+// Otherwise, it builds the value once for all concurrent callers (deduplicated
+// via singleflight), saves it to the cache, and copies it into value.
 func FetchOrSave(ctx context.Context, c Cache, key string, value any, builder func() (any, error), expiration ...time.Duration) error {
 	err := c.Fetch(ctx, key, value)
 	// value found from the cache

--- a/src/lib/cache/helper_test.go
+++ b/src/lib/cache/helper_test.go
@@ -142,6 +142,22 @@ func (suite *FetchOrSaveTestSuite) TestSaveCalledEvenWhenContextCanceled() {
 	c.AssertNumberOfCalls(suite.T(), "Save", 1)
 }
 
+// The shared singleflight result is copied to each caller through the codec,
+// so a builder result the codec cannot encode must surface as an error.
+func (suite *FetchOrSaveTestSuite) TestBuildResultNotEncodable() {
+	c := &mockCache{}
+
+	mock.OnAnything(c, "Fetch").Return(ErrNotFound)
+	mock.OnAnything(c, "Save").Return(nil)
+
+	var ch chan struct{}
+	err := FetchOrSave(suite.ctx, c, "key-not-encodable", &ch, func() (any, error) {
+		return make(chan struct{}), nil
+	})
+
+	suite.Error(err)
+}
+
 // On a concurrent cold miss, builder runs exactly once (singleflight dedup)
 // and every concurrent caller receives the built value in its own pointer.
 func (suite *FetchOrSaveTestSuite) TestConcurrentCallersShareResult() {

--- a/src/lib/cache/helper_test.go
+++ b/src/lib/cache/helper_test.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"fmt"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -119,6 +120,60 @@ func (suite *FetchOrSaveTestSuite) TestSaveCalledOnlyOneTime() {
 	wg.Wait()
 
 	c.AssertNumberOfCalls(suite.T(), "Save", 1)
+}
+
+// Save must be called even if the HTTP request context is already canceled,
+// because helper.go uses context.WithoutCancel before calling Save.
+func (suite *FetchOrSaveTestSuite) TestSaveCalledEvenWhenContextCanceled() {
+	c := &mockCache{}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // simulate a canceled HTTP request context
+
+	mock.OnAnything(c, "Fetch").Return(ErrNotFound)
+	mock.OnAnything(c, "Save").Return(nil)
+
+	var str string
+	err := FetchOrSave(ctx, c, "key-canceled", &str, func() (any, error) {
+		return "str", nil
+	})
+
+	suite.Nil(err)
+	suite.Equal("str", str)
+	c.AssertNumberOfCalls(suite.T(), "Save", 1)
+}
+
+// On a concurrent cold miss, builder runs exactly once (singleflight dedup)
+// and every concurrent caller receives the built value in its own pointer.
+func (suite *FetchOrSaveTestSuite) TestConcurrentCallersShareResult() {
+	c := &mockCache{}
+	var builderCalls atomic.Int32
+
+	mock.OnAnything(c, "Fetch").Return(ErrNotFound)
+	mock.OnAnything(c, "Save").Return(nil)
+
+	const n = 100
+	var wg sync.WaitGroup
+	results := make([]string, n)
+
+	for i := range n {
+		wg.Add(1)
+		go func(idx int) {
+			defer wg.Done()
+			var str string
+			FetchOrSave(suite.ctx, c, "key", &str, func() (any, error) {
+				builderCalls.Add(1)
+				time.Sleep(10 * time.Millisecond) // widen the singleflight window
+				return "built", nil
+			})
+			results[idx] = str
+		}(i)
+	}
+	wg.Wait()
+
+	suite.Equal(int32(1), builderCalls.Load(), "builder must run exactly once for concurrent callers")
+	for _, r := range results {
+		suite.Equal("built", r, "every caller must receive the built value")
+	}
 }
 
 func TestFetchOrSaveTestSuite(t *testing.T) {

--- a/src/lib/cache/util.go
+++ b/src/lib/cache/util.go
@@ -15,31 +15,7 @@
 package cache
 
 import (
-	"sync"
+	"golang.org/x/sync/singleflight"
 )
 
-type keyMutex struct {
-	m *sync.Map
-}
-
-func (km keyMutex) Lock(key any) {
-	m := sync.Mutex{}
-	act, _ := km.m.LoadOrStore(key, &m)
-
-	mm := act.(*sync.Mutex)
-	mm.Lock()
-	if mm != &m {
-		mm.Unlock()
-		km.Lock(key)
-	}
-}
-
-func (km keyMutex) Unlock(key any) {
-	act, exist := km.m.Load(key)
-	if !exist {
-		panic("unlock of unlocked mutex")
-	}
-	m := act.(*sync.Mutex)
-	km.m.Delete(key)
-	m.Unlock()
-}
+var fetchOrSaveGroup singleflight.Group

--- a/src/lib/cache/util_test.go
+++ b/src/lib/cache/util_test.go
@@ -37,7 +37,7 @@ func TestFetchOrSaveConcurrency(t *testing.T) {
 	}
 
 	c.On("Fetch", mock.Anything, key, mock.Anything).Return(ErrNotFound)
-	c.On("Save", mock.Anything, key, "test-value", mock.Anything).Return(nil).Once()
+	c.On("Save", mock.Anything, key, "test-value").Return(nil).Once()
 
 	var wg sync.WaitGroup
 	for range 10 {

--- a/src/lib/cache/util_test.go
+++ b/src/lib/cache/util_test.go
@@ -15,29 +15,43 @@
 package cache
 
 import (
+	"context"
 	"sync"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 )
 
-func TestKeyMutex(t *testing.T) {
-	km := keyMutex{m: &sync.Map{}}
-	key := "key"
+func TestFetchOrSaveConcurrency(t *testing.T) {
+	c := newMockCache(t)
+	key := "test-key"
+	var callCount int32
+
+	builder := func() (any, error) {
+		atomic.AddInt32(&callCount, 1)
+		time.Sleep(100 * time.Millisecond)
+		return "test-value", nil
+	}
+
+	c.On("Fetch", mock.Anything, key, mock.Anything).Return(ErrNotFound)
+	c.On("Save", mock.Anything, key, "test-value", mock.Anything).Return(nil).Once()
 
 	var wg sync.WaitGroup
-	for range 100 {
+	for range 10 {
 		wg.Add(1)
-
 		go func() {
 			defer wg.Done()
-			km.Lock(key)
-			km.Unlock(key)
+			var value string
+			err := FetchOrSave(context.Background(), c, key, &value, builder)
+			assert.NoError(t, err)
+			assert.Equal(t, "test-value", value)
 		}()
 	}
 	wg.Wait()
 
-	assert.Panics(t, func() {
-		km.Unlock(key)
-	})
+	assert.Equal(t, int32(1), callCount, "builder should be called only once")
+	c.AssertNumberOfCalls(t, "Save", 1)
 }


### PR DESCRIPTION
Cherry-pick of upstream goharbor/harbor#23336 (fixes goharbor/harbor#23335), plus a doc-comment correction from its Copilot review.

- Replace the global `keyMutex` in `src/lib/cache` with `singleflight.Group` so concurrent callers on a cache miss share a single `builder()` result instead of serializing through a delete-on-unlock mutex that collapses under contention.
- Use `context.WithoutCancel(ctx)` for the inner `Save` so a canceled request context (disconnected client) no longer prevents the Redis L2 cache from being populated.

## Why we need this now

This is the root cause of the 2026-06-10 demo.goharbor.io outage: both harbor-core replicas wedged for 13+ hours at 08:05 UTC. A SIGABRT goroutine dump showed 1,201 of 1,491 goroutines blocked in `cache.keyMutex.Lock` via the security middleware → `config.AuthMode` → `FetchOrSave("cfgs")` path, which every request hits. Once a miss on the hot `cfgs` key stampedes enough concurrent requests, the keyMutex retry-recursion makes drain rate fall below arrival rate (livelock), and the canceled-context `Save` bug keeps the L2 cache empty so the condition self-sustains until pod restart. Symptoms: ~5k FDs / goroutines on harbor-core, every API and /v2 request hanging, total silence in logs.

Related but distinct from container-registry/harbor-next#255 (registry-proxy transport leak): same dashboard signature, independent mechanism.

## Changes vs upstream PR

- `eb34c5e170` cherry-picked verbatim (clean apply, no conflicts).
- One extra commit correcting the `FetchOrSave` doc comment, addressing the legitimate point from the upstream Copilot review (the function no longer re-fetches after Save). The review's other point (mock variadic mismatch in `util_test.go`) is a false positive — `go test ./lib/cache/` passes locally on go1.26.1.

## Testing

- `go test ./lib/cache/ -count=1` — all tests pass, including the new `TestFetchOrSaveConcurrency` and `FetchOrSaveTestSuite` cases (`TestSaveCalledEvenWhenContextCanceled`, `TestConcurrentCallersShareResult`).
