### PR TITLE
ci: Node 24 readiness for release-2.15 workflows

### DIFF
--- a/.github/actions/setup-go-cached/action.yml
+++ b/.github/actions/setup-go-cached/action.yml
@@ -44,7 +44,7 @@ runs:
     # GitHub-hosted only: restore module cache from GitHub's cache storage
     - name: Restore Go module cache
       if: runner.environment != 'self-hosted'
-      uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
+      uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
       with:
         path: ~/go/pkg/mod
         key: go-mod-${{ runner.os }}-${{ hashFiles(inputs.go-sum-path) }}
@@ -53,7 +53,7 @@ runs:
     # GitHub-hosted only: restore build cache from GitHub's cache storage
     - name: Restore Go build cache
       if: runner.environment != 'self-hosted'
-      uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
+      uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
       with:
         path: ~/.cache/go-build
         key: go-build-${{ runner.os }}-${{ hashFiles(inputs.go-sum-path) }}-${{ github.sha }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,6 +21,11 @@ concurrency:
   group: build-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
+env:
+  # arduino/setup-task (latest) still declares node20; opt in to the
+  # 2026-06-16 node24 default early.
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
 jobs:
   build:
     name: Build Binaries

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -15,8 +15,8 @@ jobs:
     if: github.event.repository.private == false || always()
     continue-on-error: true
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - uses: actions/dependency-review-action@2031cfc080254a8a887f58cffee85186f0e49e48 # v4.9.0
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - uses: actions/dependency-review-action@a1d282b36b6f3519aa1f3fc636f609c47dddb294 # v5.0.0
         with:
           fail-on-severity: high
           comment-summary-in-pr: always

--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -19,6 +19,9 @@ env:
   REGISTRY_ADDRESS: ${{ vars.REGISTRY_ADDRESS || '8gears.container-registry.com' }}
   PR_REGISTRY_PROJECT: ${{ vars.PR_REGISTRY_PROJECT }}
   PREVIEW_TAG: pr-${{ github.event.pull_request.number }}
+  # arduino/setup-task (latest) still declares node20; opt in to the
+  # 2026-06-16 node24 default early.
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
 
 jobs:
   build:

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -11,6 +11,11 @@ permissions:
   contents: write
   pull-requests: write
 
+env:
+  # arduino/setup-task and actions4gh/setup-gh (both latest) still
+  # declare node20; opt in to the 2026-06-16 node24 default early.
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
 jobs:
   validate-release-ref:
     name: Validate Release Ref

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,6 +21,11 @@ concurrency:
   group: test-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
+env:
+  # arduino/setup-task (latest) still declares node20; opt in to the
+  # 2026-06-16 node24 default early.
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
 jobs:
   # --------------------------------------------------------------------------
   # Pure unit tests — no external services, full parallelism


### PR DESCRIPTION
Backports Node 24 readiness updates to the release-2.15 maintenance branch.\n\nCherry-picked from 8157e8b1f6c73ea251ae14e9008d2f2a7b0ad288.\n\nThis PR is stacked on #278 and should be merged after #278.