### PR TITLE
ci: Fix release finalization on Node 24

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -6,9 +6,6 @@ on:
       finalize_tag:
         description: Existing release tag to sign and update, for example v2.15.1
         required: false
-      finalize_version:
-        description: Version without leading v, for example 2.15.1
-        required: false
   push:
     branches:
       - main
@@ -282,7 +279,16 @@ jobs:
 
   sign:
     name: Sign and Release
-    needs: [release-please, merge]
+    needs: [validate-release-ref, release-please, merge]
+    if: >-
+      ${{
+        always() &&
+        needs.validate-release-ref.result == 'success' &&
+        (
+          needs.release-please.outputs.release_created == 'true' ||
+          inputs.finalize_tag != ''
+        )
+      }}
     runs-on: ${{ vars.RUNNER || 'ubuntu-latest' }}
     permissions:
       contents: write
@@ -290,196 +296,12 @@ jobs:
     env:
       REGISTRY_ADDRESS: ${{ vars.REGISTRY_ADDRESS || '8gears.container-registry.com' }}
       REGISTRY_PROJECT: ${{ vars.REGISTRY_PROJECT || '8gcr' }}
-      VERSION: ${{ needs.release-please.outputs.version }}
-      TAG_NAME: ${{ needs.release-please.outputs.tag_name }}
+      TAG_NAME: ${{ needs.release-please.outputs.tag_name || inputs.finalize_tag }}
       RELEASE_BRANCH: ${{ github.ref_name }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
-
-      - name: Install envsubst
-        run: command -v envsubst || (sudo apt-get update && sudo apt-get install -y gettext-base)
-
-      - name: Install gh CLI
-        run: |
-          if command -v gh >/dev/null 2>&1; then
-            gh --version
-            exit 0
-          fi
-
-          curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \
-            | sudo dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg
-          sudo chmod go+r /usr/share/keyrings/githubcli-archive-keyring.gpg
-          echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" \
-            | sudo tee /etc/apt/sources.list.d/github-cli.list > /dev/null
-          sudo apt-get update
-          sudo apt-get install -y gh
-          gh --version
-
-      - name: Install cosign
-        uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
-
-      - name: Log in to registry
-        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
-        with:
-          registry: ${{ env.REGISTRY_ADDRESS }}
-          username: ${{ vars.REGISTRY_USERNAME }}
-          password: ${{ secrets.REGISTRY_PASSWORD }}
-
-      - name: Sign images
-        run: |
-          for image in core jobservice registryctl exporter portal registry trivy-adapter; do
-            image_name="harbor-${image}"
-            if [ "${image}" = "trivy-adapter" ]; then
-              image_name="trivy-adapter"
-            fi
-
-            cosign sign --yes \
-              "${REGISTRY_ADDRESS}/${REGISTRY_PROJECT}/${image_name}:${TAG_NAME}"
-          done
-
-      - name: Generate GitHub App token
-        id: app-token
-        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
-        with:
-          app-id: ${{ vars.SYNC_APP_ID }}
-          private-key: ${{ secrets.SYNC_APP_PRIVATE_KEY }}
-          owner: container-registry
-          repositories: 8gcr
-
-      - name: Collect commercial patch descriptions
-        id: patches
-        env:
-          PATCHES_TOKEN: ${{ steps.app-token.outputs.token }}
-        run: |
-          git clone --depth=1 \
-            "https://x-access-token:${PATCHES_TOKEN}@github.com/container-registry/8gcr" \
-            /tmp/patches-repo
-          if [ -f /tmp/patches-repo/8gcr-ee/patches/series ]; then
-            while IFS= read -r patch; do
-              patch=$(echo "$patch" | sed 's/#.*//' | xargs)
-              [ -z "$patch" ] && continue
-              node .github/scripts/format-commercial-patch.mjs "/tmp/patches-repo/8gcr-ee/patches/$patch" >> applied-patches.txt
-            done < /tmp/patches-repo/8gcr-ee/patches/series
-            echo "has_patches=true" >> "$GITHUB_OUTPUT"
-          fi
-          rm -rf /tmp/patches-repo
-
-      - name: Update release notes
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          REGISTRY="${REGISTRY_ADDRESS}/${REGISTRY_PROJECT}"
-          IMAGES="core jobservice registryctl exporter portal registry trivy-adapter"
-          GENERATED_NOTES="$(mktemp)"
-          RELEASE_BODY="$(mktemp)"
-          FORMATTED_BODY="$(mktemp)"
-
-          gh api "repos/${{ github.repository }}/releases/generate-notes" \
-            -f "tag_name=${TAG_NAME}" \
-            --jq .body > "${GENERATED_NOTES}"
-          gh release view "${TAG_NAME}" --json body -q .body > "${RELEASE_BODY}"
-          node .github/scripts/format-release-notes.mjs \
-            "${RELEASE_BODY}" \
-            "${GENERATED_NOTES}" \
-            "${FORMATTED_BODY}"
-
-          HIGHLIGHTS=""
-          git fetch --tags --force
-          PREV_TAG=$(git tag --merged HEAD --sort=-creatordate \
-            | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' \
-            | grep -v "^${TAG_NAME}$" \
-            | head -n 1 || true)
-          if [ -n "${PREV_TAG}" ]; then
-            SINCE=$(gh release view "${PREV_TAG}" --json createdAt -q '.createdAt')
-            SINCE_DATE="${SINCE%T*}"
-            HIGHLIGHTS=$(gh pr list \
-              --state merged \
-              --base "${RELEASE_BRANCH}" \
-              --search "merged:>=${SINCE_DATE}" \
-              --json number,title,url,body \
-              --limit 100 \
-              --jq '
-                [.[] | select(.body | test("(?m)^## Release Notes"))] |
-                if length == 0 then ""
-                else
-                  "## Highlights\n\n" +
-                  (map(
-                    "### [#\(.number)](\(.url)) \(.title)\n" +
-                    (.body |
-                      gsub("(?s).*\n## Release Notes\n"; "") |
-                      gsub("(?s)\n## .*"; "") |
-                      gsub("<!--[\\s\\S]*?-->"; "") |
-                      ltrimstr("\n") | rtrimstr("\n")
-                    ) + "\n"
-                  ) | join("\n"))
-                end
-              ')
-          fi
-
-          {
-            if [ -f applied-patches.txt ] && [ -s applied-patches.txt ]; then
-              echo "## Commercial Features"
-              echo ""
-              echo "This release includes the following commercial enhancements:"
-              cat applied-patches.txt
-              echo ""
-            fi
-            if [ -n "${HIGHLIGHTS}" ]; then
-              printf '%s\n\n' "${HIGHLIGHTS}"
-            fi
-            echo "## Container Images"
-            echo ""
-            echo "Multi-arch images (\`linux/amd64\`, \`linux/arm64\`) signed with [cosign](https://github.com/sigstore/cosign)."
-            echo ""
-            echo "| Image | Reference |"
-            echo "|-------|-----------|"
-            for image in $IMAGES; do
-              image_name="harbor-${image}"
-              if [ "${image}" = "trivy-adapter" ]; then
-                image_name="trivy-adapter"
-              fi
-              echo "| \`${image_name}\` | \`${REGISTRY}/${image_name}:${TAG_NAME}\` |"
-            done
-            echo ""
-            echo "**Verify an image signature:**"
-            echo "\`\`\`sh"
-            echo "cosign verify \\"
-            echo "  --certificate-identity \"https://github.com/${{ github.repository }}/.github/workflows/release-please.yml@refs/heads/${RELEASE_BRANCH}\" \\"
-            echo "  --certificate-oidc-issuer \"https://token.actions.githubusercontent.com\" \\"
-            echo "  ${REGISTRY}/harbor-core:${TAG_NAME}"
-            echo "\`\`\`"
-            echo ""
-            echo "---"
-            echo ""
-            cat "${FORMATTED_BODY}"
-          } | gh release edit "${TAG_NAME}" --notes-file -
-
-  finalize-existing-release:
-    name: Finalize Existing Release
-    needs: [validate-release-ref]
-    if: ${{ github.event_name == 'workflow_dispatch' && inputs.finalize_tag != '' }}
-    runs-on: ${{ vars.RUNNER || 'ubuntu-latest' }}
-    permissions:
-      contents: write
-      id-token: write
-    env:
-      REGISTRY_ADDRESS: ${{ vars.REGISTRY_ADDRESS || '8gears.container-registry.com' }}
-      REGISTRY_PROJECT: ${{ vars.REGISTRY_PROJECT || '8gcr' }}
-      VERSION: ${{ inputs.finalize_version }}
-      TAG_NAME: ${{ inputs.finalize_tag }}
-      RELEASE_BRANCH: ${{ github.ref_name }}
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          fetch-depth: 0
-
-      - name: Load finalize version
-        run: |
-          if [ -z "${VERSION}" ]; then
-            echo "VERSION=${TAG_NAME#v}" >> "$GITHUB_ENV"
-          fi
 
       - name: Install envsubst
         run: command -v envsubst || (sudo apt-get update && sudo apt-get install -y gettext-base)

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -2,6 +2,13 @@ name: Release Please
 
 on:
   workflow_dispatch:
+    inputs:
+      finalize_tag:
+        description: Existing release tag to sign and update, for example v2.15.1
+        required: false
+      finalize_version:
+        description: Version without leading v, for example 2.15.1
+        required: false
   push:
     branches:
       - main
@@ -12,8 +19,7 @@ permissions:
   pull-requests: write
 
 env:
-  # arduino/setup-task and actions4gh/setup-gh (both latest) still
-  # declare node20; opt in to the 2026-06-16 node24 default early.
+  # Opt in to the 2026-06-16 Node 24 default early.
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
 
 jobs:
@@ -32,6 +38,7 @@ jobs:
 
   release-please:
     needs: [validate-release-ref]
+    if: ${{ github.event_name != 'workflow_dispatch' || inputs.finalize_tag == '' }}
     runs-on: ${{ vars.RUNNER || 'ubuntu-latest' }}
     outputs:
       release_created: ${{ steps.release.outputs.release_created }}
@@ -295,9 +302,203 @@ jobs:
         run: command -v envsubst || (sudo apt-get update && sudo apt-get install -y gettext-base)
 
       - name: Install gh CLI
-        uses: actions4gh/setup-gh@44a12005484c53be5bf51bebe8c985b4be8ba8de # v1.0.2
+        run: |
+          if command -v gh >/dev/null 2>&1; then
+            gh --version
+            exit 0
+          fi
+
+          curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \
+            | sudo dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg
+          sudo chmod go+r /usr/share/keyrings/githubcli-archive-keyring.gpg
+          echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" \
+            | sudo tee /etc/apt/sources.list.d/github-cli.list > /dev/null
+          sudo apt-get update
+          sudo apt-get install -y gh
+          gh --version
+
+      - name: Install cosign
+        uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
+
+      - name: Log in to registry
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
         with:
-          gh-version: latest
+          registry: ${{ env.REGISTRY_ADDRESS }}
+          username: ${{ vars.REGISTRY_USERNAME }}
+          password: ${{ secrets.REGISTRY_PASSWORD }}
+
+      - name: Sign images
+        run: |
+          for image in core jobservice registryctl exporter portal registry trivy-adapter; do
+            image_name="harbor-${image}"
+            if [ "${image}" = "trivy-adapter" ]; then
+              image_name="trivy-adapter"
+            fi
+
+            cosign sign --yes \
+              "${REGISTRY_ADDRESS}/${REGISTRY_PROJECT}/${image_name}:${TAG_NAME}"
+          done
+
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          app-id: ${{ vars.SYNC_APP_ID }}
+          private-key: ${{ secrets.SYNC_APP_PRIVATE_KEY }}
+          owner: container-registry
+          repositories: 8gcr
+
+      - name: Collect commercial patch descriptions
+        id: patches
+        env:
+          PATCHES_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          git clone --depth=1 \
+            "https://x-access-token:${PATCHES_TOKEN}@github.com/container-registry/8gcr" \
+            /tmp/patches-repo
+          if [ -f /tmp/patches-repo/8gcr-ee/patches/series ]; then
+            while IFS= read -r patch; do
+              patch=$(echo "$patch" | sed 's/#.*//' | xargs)
+              [ -z "$patch" ] && continue
+              node .github/scripts/format-commercial-patch.mjs "/tmp/patches-repo/8gcr-ee/patches/$patch" >> applied-patches.txt
+            done < /tmp/patches-repo/8gcr-ee/patches/series
+            echo "has_patches=true" >> "$GITHUB_OUTPUT"
+          fi
+          rm -rf /tmp/patches-repo
+
+      - name: Update release notes
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          REGISTRY="${REGISTRY_ADDRESS}/${REGISTRY_PROJECT}"
+          IMAGES="core jobservice registryctl exporter portal registry trivy-adapter"
+          GENERATED_NOTES="$(mktemp)"
+          RELEASE_BODY="$(mktemp)"
+          FORMATTED_BODY="$(mktemp)"
+
+          gh api "repos/${{ github.repository }}/releases/generate-notes" \
+            -f "tag_name=${TAG_NAME}" \
+            --jq .body > "${GENERATED_NOTES}"
+          gh release view "${TAG_NAME}" --json body -q .body > "${RELEASE_BODY}"
+          node .github/scripts/format-release-notes.mjs \
+            "${RELEASE_BODY}" \
+            "${GENERATED_NOTES}" \
+            "${FORMATTED_BODY}"
+
+          HIGHLIGHTS=""
+          git fetch --tags --force
+          PREV_TAG=$(git tag --merged HEAD --sort=-creatordate \
+            | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' \
+            | grep -v "^${TAG_NAME}$" \
+            | head -n 1 || true)
+          if [ -n "${PREV_TAG}" ]; then
+            SINCE=$(gh release view "${PREV_TAG}" --json createdAt -q '.createdAt')
+            SINCE_DATE="${SINCE%T*}"
+            HIGHLIGHTS=$(gh pr list \
+              --state merged \
+              --base "${RELEASE_BRANCH}" \
+              --search "merged:>=${SINCE_DATE}" \
+              --json number,title,url,body \
+              --limit 100 \
+              --jq '
+                [.[] | select(.body | test("(?m)^## Release Notes"))] |
+                if length == 0 then ""
+                else
+                  "## Highlights\n\n" +
+                  (map(
+                    "### [#\(.number)](\(.url)) \(.title)\n" +
+                    (.body |
+                      gsub("(?s).*\n## Release Notes\n"; "") |
+                      gsub("(?s)\n## .*"; "") |
+                      gsub("<!--[\\s\\S]*?-->"; "") |
+                      ltrimstr("\n") | rtrimstr("\n")
+                    ) + "\n"
+                  ) | join("\n"))
+                end
+              ')
+          fi
+
+          {
+            if [ -f applied-patches.txt ] && [ -s applied-patches.txt ]; then
+              echo "## Commercial Features"
+              echo ""
+              echo "This release includes the following commercial enhancements:"
+              cat applied-patches.txt
+              echo ""
+            fi
+            if [ -n "${HIGHLIGHTS}" ]; then
+              printf '%s\n\n' "${HIGHLIGHTS}"
+            fi
+            echo "## Container Images"
+            echo ""
+            echo "Multi-arch images (\`linux/amd64\`, \`linux/arm64\`) signed with [cosign](https://github.com/sigstore/cosign)."
+            echo ""
+            echo "| Image | Reference |"
+            echo "|-------|-----------|"
+            for image in $IMAGES; do
+              image_name="harbor-${image}"
+              if [ "${image}" = "trivy-adapter" ]; then
+                image_name="trivy-adapter"
+              fi
+              echo "| \`${image_name}\` | \`${REGISTRY}/${image_name}:${TAG_NAME}\` |"
+            done
+            echo ""
+            echo "**Verify an image signature:**"
+            echo "\`\`\`sh"
+            echo "cosign verify \\"
+            echo "  --certificate-identity \"https://github.com/${{ github.repository }}/.github/workflows/release-please.yml@refs/heads/${RELEASE_BRANCH}\" \\"
+            echo "  --certificate-oidc-issuer \"https://token.actions.githubusercontent.com\" \\"
+            echo "  ${REGISTRY}/harbor-core:${TAG_NAME}"
+            echo "\`\`\`"
+            echo ""
+            echo "---"
+            echo ""
+            cat "${FORMATTED_BODY}"
+          } | gh release edit "${TAG_NAME}" --notes-file -
+
+  finalize-existing-release:
+    name: Finalize Existing Release
+    needs: [validate-release-ref]
+    if: ${{ github.event_name == 'workflow_dispatch' && inputs.finalize_tag != '' }}
+    runs-on: ${{ vars.RUNNER || 'ubuntu-latest' }}
+    permissions:
+      contents: write
+      id-token: write
+    env:
+      REGISTRY_ADDRESS: ${{ vars.REGISTRY_ADDRESS || '8gears.container-registry.com' }}
+      REGISTRY_PROJECT: ${{ vars.REGISTRY_PROJECT || '8gcr' }}
+      VERSION: ${{ inputs.finalize_version }}
+      TAG_NAME: ${{ inputs.finalize_tag }}
+      RELEASE_BRANCH: ${{ github.ref_name }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+
+      - name: Load finalize version
+        run: |
+          if [ -z "${VERSION}" ]; then
+            echo "VERSION=${TAG_NAME#v}" >> "$GITHUB_ENV"
+          fi
+
+      - name: Install envsubst
+        run: command -v envsubst || (sudo apt-get update && sudo apt-get install -y gettext-base)
+
+      - name: Install gh CLI
+        run: |
+          if command -v gh >/dev/null 2>&1; then
+            gh --version
+            exit 0
+          fi
+
+          curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \
+            | sudo dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg
+          sudo chmod go+r /usr/share/keyrings/githubcli-archive-keyring.gpg
+          echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" \
+            | sudo tee /etc/apt/sources.list.d/github-cli.list > /dev/null
+          sudo apt-get update
+          sudo apt-get install -y gh
+          gh --version
 
       - name: Install cosign
         uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2


### PR DESCRIPTION
Fixes the release finalization failure seen in v2.15.1 where actions4gh/setup-gh failed under forced Node 24 with `spawn gh ENOENT`.\n\nChanges:\n- Replace actions4gh/setup-gh with direct gh CLI installation.\n- Add a manual workflow_dispatch finalize path for already-created releases, so v2.15.1 can be signed and release notes can be updated without rebuilding images.\n\nAfter merge, run Release Please on release-2.15 with:\n- finalize_tag: v2.15.1\n- finalize_version: 2.15.1