### PR TITLE
ci: Set up Node for release finalization

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -303,6 +303,11 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Set up Node.js
+        uses: actions/setup-node@2028fbc5c25fe9cf00d9f06a71cc4710d4507903 # v6.0.0
+        with:
+          node-version: '24'
+
       - name: Install envsubst
         run: command -v envsubst || (sudo apt-get update && sudo apt-get install -y gettext-base)
 


### PR DESCRIPTION
## Summary
- install Node 24 in the release sign/finalize job before local .mjs scripts run
- keep manual finalization self-contained after the existing gh/cosign setup

## Validation
- actionlint .github/workflows/release-please.yml
- git diff --check

Signed-off-by: Prasanth Baskar <bupdprasanth@gmail.com>