### PR TITLE
ci: Parse StGit patch titles in release notes

### DIFF
--- a/.github/scripts/format-commercial-patch.mjs
+++ b/.github/scripts/format-commercial-patch.mjs
@@ -9,30 +9,56 @@ if (!patchPath) {
 const lines = readFileSync(patchPath, 'utf8').split(/\r?\n/);
 const subjectIndex = lines.findIndex(line => line.startsWith('Subject: '));
 
-if (subjectIndex === -1) {
+function cleanSubject(value) {
+  return value
+    .replace(/^Subject: /, '')
+    .replace(/^\[PATCH[^\]]*\]\s*/, '')
+    .trim();
+}
+
+function trimBody(bodyLines) {
+  while (bodyLines.length > 0 && bodyLines[0].trim() === '') {
+    bodyLines.shift();
+  }
+
+  while (bodyLines.length > 0 && bodyLines.at(-1).trim() === '') {
+    bodyLines.pop();
+  }
+
+  return bodyLines;
+}
+
+let subject;
+let bodyLines;
+
+if (subjectIndex !== -1) {
+  subject = cleanSubject(lines[subjectIndex]);
+
+  let bodyStart = lines.findIndex((line, index) => index > subjectIndex && line === '');
+  if (bodyStart === -1) {
+    bodyStart = subjectIndex;
+  }
+
+  const bodyEnd = lines.findIndex((line, index) => index > bodyStart && line === '---');
+  bodyLines = lines.slice(bodyStart + 1, bodyEnd === -1 ? lines.length : bodyEnd);
+} else {
+  const titleIndex = lines.findIndex(line => line.trim() !== '');
+  if (titleIndex === -1) {
+    process.exit(0);
+  }
+
+  subject = cleanSubject(lines[titleIndex]);
+  const bodyEnd = lines.findIndex((line, index) => index > titleIndex && line === '---');
+  bodyLines = lines
+    .slice(titleIndex + 1, bodyEnd === -1 ? lines.length : bodyEnd)
+    .filter(line => !line.startsWith('From: ') && !line.startsWith('Signed-off-by: '));
+}
+
+if (!subject) {
   process.exit(0);
 }
 
-const subject = lines[subjectIndex]
-  .replace(/^Subject: /, '')
-  .replace(/^\[PATCH[^\]]*\]\s*/, '')
-  .trim();
-
-let bodyStart = lines.findIndex((line, index) => index > subjectIndex && line === '');
-if (bodyStart === -1) {
-  bodyStart = subjectIndex;
-}
-
-const bodyEnd = lines.findIndex((line, index) => index > bodyStart && line === '---');
-const bodyLines = lines.slice(bodyStart + 1, bodyEnd === -1 ? lines.length : bodyEnd);
-
-while (bodyLines.length > 0 && bodyLines[0].trim() === '') {
-  bodyLines.shift();
-}
-
-while (bodyLines.length > 0 && bodyLines.at(-1).trim() === '') {
-  bodyLines.pop();
-}
+bodyLines = trimBody(bodyLines);
 
 console.log(`- **${subject}**`);
 


### PR DESCRIPTION
## Summary
- support StGit title-first patch exports in commercial release-note formatting
- keep existing Subject: patch parsing behavior

## Validation
- node .github/scripts/format-commercial-patch.mjs ../patch-check-after-pr282-8gcr/8gcr-ee/patches/0001-branding
- formatter run across 0001 through 0005 active patch series
- git diff --check

Signed-off-by: Prasanth Baskar <bupdprasanth@gmail.com>