### PR TITLE
fix: Restore 0171 Migration For Upstream 2.14.x Upgrade Path

### DIFF
--- a/make/migrations/postgresql/0171_2.14.1_schema.up.sql
+++ b/make/migrations/postgresql/0171_2.14.1_schema.up.sql
@@ -1,0 +1,17 @@
+/*
+Initialize skip_audit_log_database configuration based on existing audit log usage - Only insert the configuration if it doesn't already exist
+1. If tables exist and show evidence of previous usage
+   set skip_audit_log_database to false
+2. If tables exist but show no evidence of usage, don't create the configuration record
+*/
+DO $$
+BEGIN
+    IF EXISTS (SELECT 1 FROM properties WHERE k = 'skip_audit_log_database') THEN
+        RETURN;
+    END IF;
+
+    IF (SELECT last_value FROM audit_log_id_seq) > 1
+       OR (SELECT last_value FROM audit_log_ext_id_seq) > 1 THEN
+        INSERT INTO properties (k, v) VALUES ('skip_audit_log_database', 'false');
+    END IF;
+END $$;

--- a/make/migrations/postgresql/0180_2.15.0_schema.up.sql
+++ b/make/migrations/postgresql/0180_2.15.0_schema.up.sql
@@ -1,19 +1,1 @@
-/*
-Initialize skip_audit_log_database configuration based on existing audit log usage - Only insert the configuration if it doesn't already exist
-1. If tables exist and show evidence of previous usage
-   set skip_audit_log_database to false
-2. If tables exist but show no evidence of usage, don't create the configuration record
-*/
-DO $$
-BEGIN
-    IF EXISTS (SELECT 1 FROM properties WHERE k = 'skip_audit_log_database') THEN
-        RETURN;
-    END IF;
-
-    IF (SELECT last_value FROM audit_log_id_seq) > 1
-       OR (SELECT last_value FROM audit_log_ext_id_seq) > 1 THEN
-        INSERT INTO properties (k, v) VALUES ('skip_audit_log_database', 'false');
-    END IF;
-END $$;
-
 ALTER TABLE registry ADD COLUMN IF NOT EXISTS ca_certificate TEXT;


### PR DESCRIPTION
## Summary

harbor-next is missing `make/migrations/postgresql/0171_2.14.1_schema.up.sql`.

Upstream goharbor/harbor split the `skip_audit_log_database` initialization out of `0180_2.15.0` into a dedicated `0171_2.14.1` migration (goharbor/harbor#22947 and goharbor/harbor#22998) so the 2.14.1 change keeps schema version **171**, matching the released 2.14.x patch line. Those commits landed upstream *after* harbor-next's last sync, so harbor-next still carries that logic inside `0180` and has no `0171`.

### Why this breaks upgrades

An upstream Harbor **2.14.1+** database is at golang-migrate version **171**. Upgrading it to harbor-next (which jumps `0170` → `0180`) **silently skips every migration**:

- the `file://` source has no entry for `171`
- `Migrations.findPos(171)` returns `-1` (no exact index match), so `Next(171)` yields `os.ErrNotExist`
- with `count == 0`, `Up()` returns `ErrNoChange` (golang-migrate v4.19.0, `migrate.go`)
- `src/common/dao/pgsql.go` treats `ErrNoChange` as success and logs *"No change in schema, skip."*

The DB stays at 171, `0180`+ never run, and later schema (e.g. `registry.ca_certificate`) is never created — so Harbor starts "successfully" on an incomplete schema and fails at runtime. This is exactly the issue upstream goharbor/harbor#22998 ("fix db scheme migration issue") addressed.

### Fix

Restore parity with `goharbor/harbor:main`:

- **Add** `0171_2.14.1_schema.up.sql` (the `skip_audit_log_database` init only).
- **Slim** `0180_2.15.0_schema.up.sql` to the 2.15.0 `ca_certificate` change only.

Both files are now **byte-identical** to upstream `main` (blobs `a4383fc` / `288bf9b`) — the net effect of cherry-picking goharbor/harbor#22947 + #22998.

Existing harbor-next deployments already at version 180 are unaffected: `0171` (< 180) never runs and `0180` is not re-applied.

## Related Issues

N/A

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Release Notes

Fix upgrades from upstream Harbor 2.14.1+ databases. The `0171_2.14.1` schema migration was missing, which caused golang-migrate to silently skip all subsequent migrations (the schema stopped at version 171, leaving columns such as `registry.ca_certificate` uncreated). Restoring it aligns the migration sequence with upstream Harbor.

## Testing

- [x] `0171_2.14.1_schema.up.sql` and `0180_2.15.0_schema.up.sql` are byte-identical to `goharbor/harbor:main` (`git hash-object` matches blobs `a4383fc` / `288bf9b`).
- [x] Failure path verified by reading golang-migrate v4.19.0 source (`Migrations.findPos`/`Next`, `readUp`) and `src/common/dao/pgsql.go:97`.
- [ ] Manual upgrade from a real upstream 2.14.1 database (DB at version 171) → harbor-next, confirming `Up()` advances past 171 and `registry.ca_certificate` exists. *(not run in this PR)*

## Checklist

- [x] Conventional Commits title (`fix:`)
- [x] DCO sign-off
- [x] No new warnings


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/container-registry/harbor-next/pull/292?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

