### PR TITLE
fix(cache): Defer Cache Eviction Until After Commit And Make Retry Context-Aware

### DIFF
--- a/src/lib/orm/after_commit_test.go
+++ b/src/lib/orm/after_commit_test.go
@@ -1,0 +1,66 @@
+// Copyright Project Harbor Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package orm
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestAfterCommit_NoTransaction covers the non-tx path: without an
+// enclosing WithTransaction scope, AfterCommit must run the callback
+// immediately on the caller's goroutine so no cleanup is ever lost.
+func TestAfterCommit_NoTransaction(t *testing.T) {
+	ran := false
+	AfterCommit(context.Background(), func() { ran = true })
+	assert.True(t, ran, "AfterCommit must run fn immediately when no tx hooks sink is on the ctx")
+}
+
+// TestAfterCommit_NilFn is a no-op and must not panic.
+func TestAfterCommit_NilFn(t *testing.T) {
+	assert.NotPanics(t, func() {
+		AfterCommit(context.Background(), nil)
+	})
+}
+
+// TestAfterCommit_RecoversPanic verifies hook panics are contained so
+// one broken hook cannot take out an entire commit path.
+func TestAfterCommit_RecoversPanic(t *testing.T) {
+	assert.NotPanics(t, func() {
+		AfterCommit(context.Background(), func() { panic("boom") })
+	})
+}
+
+// TestAfterCommit_QueuesWhenHooksPresent asserts that when a hooks sink
+// is attached to the context, AfterCommit queues the callback rather
+// than running it inline. This is the in-tx path; WithTransaction tests
+// live in lib/orm/test for the real-DB commit/rollback semantics.
+func TestAfterCommit_QueuesWhenHooksPresent(t *testing.T) {
+	h := &txHooks{}
+	ctx := context.WithValue(context.Background(), hooksKey{}, h)
+
+	ran := false
+	AfterCommit(ctx, func() { ran = true })
+
+	assert.False(t, ran, "hooks must not fire before commit")
+
+	cbs := h.drain()
+	assert.Len(t, cbs, 1)
+
+	cbs[0]()
+	assert.True(t, ran)
+}

--- a/src/lib/orm/after_commit_testhelper.go
+++ b/src/lib/orm/after_commit_testhelper.go
@@ -1,0 +1,33 @@
+// Copyright Project Harbor Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package orm
+
+import "context"
+
+// ContextWithAfterCommitHooksForTest returns a context that carries an
+// AfterCommit hooks sink without a real database transaction, plus a
+// drain function that runs all queued callbacks (simulating a commit).
+// It is intended only for unit tests that want to exercise code paths
+// registering AfterCommit callbacks in-transaction, without needing a
+// live ORM / Postgres harness.
+func ContextWithAfterCommitHooksForTest(ctx context.Context) (context.Context, func()) {
+	h := &txHooks{}
+	ctx = context.WithValue(ctx, hooksKey{}, h)
+	return ctx, func() {
+		for _, fn := range h.drain() {
+			safeInvoke(fn)
+		}
+	}
+}

--- a/src/lib/orm/orm.go
+++ b/src/lib/orm/orm.go
@@ -20,6 +20,7 @@ import (
 	"os"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/beego/beego/v2/client/orm"
@@ -125,6 +126,61 @@ func GetTransactionOpNameFromContext(ctx context.Context) string {
 	return opName
 }
 
+// hooksKey holds the post-commit hooks sink for the enclosing transaction.
+type hooksKey struct{}
+
+// txHooks collects callbacks registered via AfterCommit. The sink is attached
+// to the context by the outermost WithTransaction call and is invoked only
+// after that outermost transaction commits successfully. Nested WithTransaction
+// calls inherit the same sink, so callbacks registered from any nesting level
+// are batched and fired together when the whole tx finally commits.
+type txHooks struct {
+	mu           sync.Mutex
+	afterCommit  []func()
+}
+
+func (h *txHooks) add(fn func()) {
+	h.mu.Lock()
+	h.afterCommit = append(h.afterCommit, fn)
+	h.mu.Unlock()
+}
+
+func (h *txHooks) drain() []func() {
+	h.mu.Lock()
+	cbs := h.afterCommit
+	h.afterCommit = nil
+	h.mu.Unlock()
+	return cbs
+}
+
+// AfterCommit registers fn to run after the enclosing WithTransaction commits
+// successfully. If the ctx is not inside a WithTransaction scope, fn runs
+// immediately on the caller's goroutine.
+//
+// This is the idiomatic way to schedule side effects that must not extend the
+// lifetime of a Postgres transaction — cache invalidation, metrics, events —
+// so Go code cannot sit holding row locks while waiting on an external system.
+// Panics raised by fn are recovered and logged.
+func AfterCommit(ctx context.Context, fn func()) {
+	if fn == nil {
+		return
+	}
+	if h, ok := ctx.Value(hooksKey{}).(*txHooks); ok && h != nil {
+		h.add(fn)
+		return
+	}
+	safeInvoke(fn)
+}
+
+func safeInvoke(fn func()) {
+	defer func() {
+		if r := recover(); r != nil {
+			log.Errorf("panic in after-commit hook: %v", r)
+		}
+	}()
+	fn()
+}
+
 // WithTransaction a decorator which make f run in transaction
 func WithTransaction(f func(ctx context.Context) error) func(ctx context.Context) error {
 	return func(ctx context.Context) error {
@@ -151,11 +207,27 @@ func WithTransaction(f func(ctx context.Context) error) func(ctx context.Context
 			return err
 		}
 
+		// Attach a post-commit hooks sink so code inside the transaction can
+		// register callbacks (via AfterCommit) that must only run after a
+		// successful commit. Only the outermost WithTransaction (i.e. the one
+		// that does not inherit an existing sink) owns the sink and is
+		// responsible for firing or discarding it.
+		var ownsHooks bool
+		hooks, _ := cx.Value(hooksKey{}).(*txHooks)
+		if hooks == nil {
+			hooks = &txHooks{}
+			cx = context.WithValue(cx, hooksKey{}, hooks)
+			ownsHooks = true
+		}
+
 		// When set multiple times, context.WithValue returns only the last ormer.
 		// To ensure that the rollback works, set TxOrmer as the ormer in the transaction.
 		cx = NewContext(cx, tx.TxOrmer)
 		if err := f(cx); err != nil {
 			span.AddEvent("rollback transaction")
+			if ownsHooks {
+				hooks.drain() // discard unfired callbacks on rollback
+			}
 			if e := tx.Rollback(); e != nil {
 				tracelib.RecordError(span, e, "rollback transaction failed")
 				log.Errorf("rollback transaction failed: %v", e)
@@ -166,9 +238,18 @@ func WithTransaction(f func(ctx context.Context) error) func(ctx context.Context
 		}
 		span.AddEvent("commit transaction")
 		if err := tx.Commit(); err != nil {
+			if ownsHooks {
+				hooks.drain() // commit failed, do not run hooks
+			}
 			tracelib.RecordError(span, err, "commit transaction failed")
 			log.Errorf("commit transaction failed: %v", err)
 			return err
+		}
+
+		if ownsHooks {
+			for _, fn := range hooks.drain() {
+				safeInvoke(fn)
+			}
 		}
 
 		return nil

--- a/src/lib/orm/orm.go
+++ b/src/lib/orm/orm.go
@@ -135,8 +135,8 @@ type hooksKey struct{}
 // calls inherit the same sink, so callbacks registered from any nesting level
 // are batched and fired together when the whole tx finally commits.
 type txHooks struct {
-	mu           sync.Mutex
-	afterCommit  []func()
+	mu          sync.Mutex
+	afterCommit []func()
 }
 
 func (h *txHooks) add(fn func()) {

--- a/src/lib/orm/test/orm_test.go
+++ b/src/lib/orm/test/orm_test.go
@@ -359,6 +359,94 @@ func (suite *OrmSuite) TestNestedSavepoint() {
 	suite.False(existFoo(ctx, id2))
 }
 
+// TestAfterCommit_FiresOnSuccess asserts that callbacks registered via
+// AfterCommit inside a transaction run only after the transaction commits.
+func (suite *OrmSuite) TestAfterCommit_FiresOnSuccess() {
+	ctx := NewContext(context.TODO(), orm.NewOrm())
+
+	ranInsideTx := false
+	ranAfter := false
+
+	err := WithTransaction(func(ctx context.Context) error {
+		AfterCommit(ctx, func() { ranAfter = true })
+		// At this point the commit has not happened yet.
+		ranInsideTx = ranAfter
+		return nil
+	})(ctx)
+
+	suite.NoError(err)
+	suite.False(ranInsideTx, "hook must not fire before commit")
+	suite.True(ranAfter, "hook must fire after successful commit")
+}
+
+// TestAfterCommit_DiscardedOnRollback asserts that rollback drops all
+// registered callbacks so side effects for rolled-back work don't execute.
+func (suite *OrmSuite) TestAfterCommit_DiscardedOnRollback() {
+	ctx := NewContext(context.TODO(), orm.NewOrm())
+
+	ran := false
+
+	err := WithTransaction(func(ctx context.Context) error {
+		AfterCommit(ctx, func() { ran = true })
+		return errors.New("oops")
+	})(ctx)
+
+	suite.Error(err)
+	suite.False(ran, "hook must be discarded on rollback")
+}
+
+// TestAfterCommit_NestedDeferredToOutermost asserts that callbacks
+// registered inside a nested WithTransaction fire only after the
+// outermost transaction commits, not after the inner savepoint release.
+func (suite *OrmSuite) TestAfterCommit_NestedDeferredToOutermost() {
+	ctx := NewContext(context.TODO(), orm.NewOrm())
+
+	var innerCommitted, outerCommitted bool
+	var ranAfterInner, ranAfterOuter bool
+
+	err := WithTransaction(func(ctx context.Context) error {
+		if err := WithTransaction(func(ctx context.Context) error {
+			AfterCommit(ctx, func() { ranAfterOuter = true })
+			return nil
+		})(ctx); err != nil {
+			return err
+		}
+		// Inner has returned (savepoint released), but outer hasn't committed yet.
+		innerCommitted = true
+		ranAfterInner = ranAfterOuter // should still be false
+		return nil
+	})(ctx)
+	outerCommitted = err == nil
+
+	suite.NoError(err)
+	suite.True(innerCommitted)
+	suite.True(outerCommitted)
+	suite.False(ranAfterInner, "hook must not fire when a nested tx returns — only after outermost commit")
+	suite.True(ranAfterOuter, "hook must fire after outermost commit")
+}
+
+// TestAfterCommit_OuterRollbackDropsNested asserts that if the outermost
+// transaction rolls back after a nested commit, nested-registered hooks
+// are still discarded.
+func (suite *OrmSuite) TestAfterCommit_OuterRollbackDropsNested() {
+	ctx := NewContext(context.TODO(), orm.NewOrm())
+
+	ran := false
+
+	err := WithTransaction(func(ctx context.Context) error {
+		if err := WithTransaction(func(ctx context.Context) error {
+			AfterCommit(ctx, func() { ran = true })
+			return nil
+		})(ctx); err != nil {
+			return err
+		}
+		return errors.New("oops")
+	})(ctx)
+
+	suite.Error(err)
+	suite.False(ran, "hooks registered in nested scope must be discarded when outer rolls back")
+}
+
 func (suite *OrmSuite) TestReadOrCreate() {
 	ctx := NewContext(context.TODO(), orm.NewOrm())
 

--- a/src/lib/retry/retry.go
+++ b/src/lib/retry/retry.go
@@ -15,6 +15,8 @@
 package retry
 
 import (
+	"context"
+	stderrors "errors"
 	"fmt"
 	"math/rand"
 	"time"
@@ -57,6 +59,7 @@ type Options struct {
 	Timeout         time.Duration                        // the total time before returning if something is wrong, default 1 minute
 	Callback        func(err error, sleep time.Duration) // the callback function for Retry when the f called failed
 	Backoff         bool
+	Ctx             context.Context // optional context; if set, Retry aborts when Ctx is done
 }
 
 // Option ...
@@ -97,6 +100,17 @@ func Backoff(backoff bool) Option {
 	}
 }
 
+// Context attaches a context to Retry so the retry loop aborts when the
+// context is canceled or its deadline is exceeded, instead of spinning until
+// the retry Timeout fires. The inter-attempt sleep also becomes cancellable.
+// When omitted, Retry still treats a context.Canceled / context.DeadlineExceeded
+// error returned by f as terminal and stops immediately.
+func Context(ctx context.Context) Option {
+	return func(opts *Options) {
+		opts.Ctx = ctx
+	}
+}
+
 // Retry retry until f run successfully or timeout
 //
 // NOTE: This function will use exponential backoff and jitter for retrying, see
@@ -133,6 +147,18 @@ func Retry(f func() error, options ...Option) error {
 		}
 	}
 
+	// ctxDone is a nil channel when no context was attached, which makes the
+	// ctx arms in the select statements below never fire (a receive on a nil
+	// channel blocks forever). Assigning opts.Ctx.Done() only when set avoids
+	// needing to branch on opts.Ctx inside the hot loop.
+	var ctxDone <-chan struct{}
+	if opts.Ctx != nil {
+		if err := opts.Ctx.Err(); err != nil {
+			return err
+		}
+		ctxDone = opts.Ctx.Done()
+	}
+
 	var err error
 
 	timeout := time.After(opts.Timeout)
@@ -140,10 +166,20 @@ func Retry(f func() error, options ...Option) error {
 		select {
 		case <-timeout:
 			return errors.New(ErrRetryTimeout).WithCause(err)
+		case <-ctxDone:
+			return opts.Ctx.Err()
 		default:
 			err = f()
 			if err == nil {
 				return nil
+			}
+
+			// A context error from f is always terminal: looping cannot
+			// recover a canceled or deadline-exceeded context and would only
+			// keep pumping load on shared resources (DB, Redis) on behalf of
+			// a caller that is already gone.
+			if stderrors.Is(err, context.Canceled) || stderrors.Is(err, context.DeadlineExceeded) {
+				return err
 			}
 
 			var ab *abort
@@ -160,7 +196,18 @@ func Retry(f func() error, options ...Option) error {
 				opts.Callback(err, sleep)
 			}
 
-			time.Sleep(sleep)
+			if sleep > 0 {
+				t := time.NewTimer(sleep)
+				select {
+				case <-timeout:
+					t.Stop()
+					return errors.New(ErrRetryTimeout).WithCause(err)
+				case <-ctxDone:
+					t.Stop()
+					return opts.Ctx.Err()
+				case <-t.C:
+				}
+			}
 		}
 	}
 }

--- a/src/lib/retry/retry_test.go
+++ b/src/lib/retry/retry_test.go
@@ -15,6 +15,7 @@
 package retry
 
 import (
+	"context"
 	"fmt"
 	"testing"
 	"time"
@@ -96,4 +97,104 @@ func TestRetry(t *testing.T) {
 	}
 	assert.Error(Retry(f4, InitialInterval(initialInterval), MaxInterval(maxInterval), Timeout(timeout)))
 	assert.LessOrEqual(i, 3)
+}
+
+func TestRetryContextAlreadyCanceled(t *testing.T) {
+	assert := assert.New(t)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	calls := 0
+	start := time.Now()
+	err := Retry(func() error {
+		calls++
+		return fmt.Errorf("should not be called")
+	}, Context(ctx), Timeout(5*time.Second))
+
+	assert.Error(err)
+	assert.ErrorIs(err, context.Canceled)
+	assert.Equal(0, calls, "f should not be called when ctx is already canceled")
+	assert.Less(time.Since(start), 100*time.Millisecond, "Retry must return immediately on pre-canceled ctx")
+}
+
+func TestRetryContextCancelMidLoop(t *testing.T) {
+	assert := assert.New(t)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	calls := 0
+	start := time.Now()
+
+	// Cancel after 200ms so we leave retry mid-backoff, well before its 5s Timeout.
+	time.AfterFunc(200*time.Millisecond, cancel)
+
+	err := Retry(func() error {
+		calls++
+		return fmt.Errorf("transient")
+	}, Context(ctx),
+		InitialInterval(50*time.Millisecond),
+		MaxInterval(100*time.Millisecond),
+		Timeout(5*time.Second),
+	)
+
+	elapsed := time.Since(start)
+	assert.Error(err)
+	assert.ErrorIs(err, context.Canceled)
+	assert.Less(elapsed, time.Second, "Retry must observe mid-loop cancellation, not wait for Timeout: elapsed=%s", elapsed)
+	assert.Greater(calls, 0)
+}
+
+func TestRetryTerminatesWhenFReturnsContextCanceled(t *testing.T) {
+	assert := assert.New(t)
+
+	calls := 0
+	start := time.Now()
+	err := Retry(func() error {
+		calls++
+		return context.Canceled
+	}, Timeout(5*time.Second))
+
+	elapsed := time.Since(start)
+	assert.ErrorIs(err, context.Canceled)
+	assert.Equal(1, calls, "f should be called exactly once — context errors are terminal")
+	assert.Less(elapsed, 100*time.Millisecond, "Retry must not sleep after a ctx error: elapsed=%s", elapsed)
+}
+
+func TestRetryTerminatesWhenFReturnsDeadlineExceeded(t *testing.T) {
+	assert := assert.New(t)
+
+	calls := 0
+	err := Retry(func() error {
+		calls++
+		return fmt.Errorf("wrapped: %w", context.DeadlineExceeded)
+	}, Timeout(5*time.Second))
+
+	assert.ErrorIs(err, context.DeadlineExceeded)
+	assert.Equal(1, calls, "wrapped ctx errors should also be terminal (via errors.Is)")
+}
+
+func TestRetryCancellableSleep(t *testing.T) {
+	assert := assert.New(t)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// First call returns a normal error so we enter the inter-attempt sleep.
+	// We configure a 2s min/max interval, then cancel the ctx 100ms in.
+	time.AfterFunc(100*time.Millisecond, cancel)
+
+	start := time.Now()
+	err := Retry(func() error {
+		return fmt.Errorf("transient")
+	}, Context(ctx),
+		InitialInterval(2*time.Second),
+		MaxInterval(2*time.Second),
+		Timeout(10*time.Second),
+	)
+	elapsed := time.Since(start)
+
+	assert.ErrorIs(err, context.Canceled)
+	assert.Less(elapsed, time.Second, "the 2s sleep must be interrupted by ctx cancellation: elapsed=%s", elapsed)
 }

--- a/src/pkg/cached/artifact/redis/manager.go
+++ b/src/pkg/cached/artifact/redis/manager.go
@@ -20,11 +20,19 @@ import (
 
 	"github.com/goharbor/harbor/src/lib/config"
 	"github.com/goharbor/harbor/src/lib/log"
+	"github.com/goharbor/harbor/src/lib/orm"
 	"github.com/goharbor/harbor/src/lib/q"
 	"github.com/goharbor/harbor/src/lib/retry"
 	"github.com/goharbor/harbor/src/pkg/artifact"
 	"github.com/goharbor/harbor/src/pkg/cached"
 )
+
+// cleanupCacheTimeout bounds a single cache-eviction attempt after the
+// enclosing transaction has committed. Cache invalidation is best-effort:
+// any stale entry expires via the configured TTL, and the next read from
+// the database repopulates it. We must not sit spinning in a retry loop
+// for the full default timeout.
+const cleanupCacheTimeout = 3 * time.Second
 
 var _ CachedManager = &Manager{}
 
@@ -140,8 +148,14 @@ func (m *Manager) Delete(ctx context.Context, id int64) error {
 	if err := m.delegator.Delete(ctx, id); err != nil {
 		return err
 	}
-	// clean cache
-	m.cleanUp(ctx, art)
+	// Defer cache invalidation until after the enclosing transaction
+	// commits. Running Redis calls inside the transaction would keep the
+	// Postgres row locks held across network round-trips; on a canceled
+	// request ctx, the retry loop would spin for a full minute while the
+	// transaction sits idle in ClientRead, blocking concurrent deletes.
+	// When there is no enclosing transaction, AfterCommit runs the hook
+	// synchronously on the caller's goroutine.
+	m.scheduleCleanUp(ctx, art)
 	return nil
 }
 
@@ -150,8 +164,8 @@ func (m *Manager) Update(ctx context.Context, artifact *artifact.Artifact, props
 	if err := m.delegator.Update(ctx, artifact, props...); err != nil {
 		return err
 	}
-	// clean cache
-	m.cleanUp(ctx, artifact)
+	// Same rationale as Delete: cache eviction must not hold the tx open.
+	m.scheduleCleanUp(ctx, artifact)
 	return nil
 }
 
@@ -169,26 +183,53 @@ func (m *Manager) UpdatePullTime(ctx context.Context, id int64, pullTime time.Ti
 	return nil
 }
 
-// cleanUp cleans up data in cache.
-func (m *Manager) cleanUp(ctx context.Context, art *artifact.Artifact) {
+// scheduleCleanUp registers the cache invalidation for art to run after the
+// enclosing transaction commits. The closure captures a value copy of the
+// fields it needs so the hook is independent of the request context and any
+// mutations to art after registration.
+func (m *Manager) scheduleCleanUp(ctx context.Context, art *artifact.Artifact) {
+	// Capture by value — the caller's art pointer may be reused or mutated.
+	id := art.ID
+	repo := art.RepositoryName
+	digest := art.Digest
+	orm.AfterCommit(ctx, func() {
+		cleanupCtx, cancel := context.WithTimeout(context.Background(), cleanupCacheTimeout)
+		defer cancel()
+		m.cleanUpKeys(cleanupCtx, id, repo, digest)
+	})
+}
+
+// cleanUpKeys best-effort deletes the cache entries for a given artifact.
+// Called after the enclosing transaction has committed with a detached
+// context, so it neither holds row locks nor observes a canceled request.
+func (m *Manager) cleanUpKeys(ctx context.Context, id int64, repo, digest string) {
 	// clean index by id
-	idIdx, err := m.keyBuilder.Format("id", art.ID)
+	idIdx, err := m.keyBuilder.Format("id", id)
 	if err != nil {
 		log.Errorf("format artifact id key error: %v", err)
 	} else {
-		// retry to avoid dirty data
-		if err = retry.Retry(func() error { return m.CacheClient(ctx).Delete(ctx, idIdx) }); err != nil {
-			log.Errorf("delete artifact cache key %s error: %v", idIdx, err)
+		// retry to avoid dirty data; capped retry + ctx-aware so we cannot
+		// block indefinitely on Redis hiccups.
+		if err = retry.Retry(
+			func() error { return m.CacheClient(ctx).Delete(ctx, idIdx) },
+			retry.Context(ctx),
+			retry.Timeout(cleanupCacheTimeout),
+		); err != nil {
+			log.Warningf("delete artifact cache key %s error: %v", idIdx, err)
 		}
 	}
 
 	// clean index by digest
-	digestIdx, err := m.keyBuilder.Format("repository", art.RepositoryName, "digest", art.Digest)
+	digestIdx, err := m.keyBuilder.Format("repository", repo, "digest", digest)
 	if err != nil {
 		log.Errorf("format artifact digest key error: %v", err)
 	} else {
-		if err = retry.Retry(func() error { return m.CacheClient(ctx).Delete(ctx, digestIdx) }); err != nil {
-			log.Errorf("delete artifact cache key %s error: %v", digestIdx, err)
+		if err = retry.Retry(
+			func() error { return m.CacheClient(ctx).Delete(ctx, digestIdx) },
+			retry.Context(ctx),
+			retry.Timeout(cleanupCacheTimeout),
+		); err != nil {
+			log.Warningf("delete artifact cache key %s error: %v", digestIdx, err)
 		}
 	}
 }
@@ -201,9 +242,13 @@ func (m *Manager) refreshCache(ctx context.Context, art *artifact.Artifact) {
 	// no need to consider lock because we only have one goroutine do this work one by one.
 
 	// refreshCache includes 2 steps:
-	//   1. cleanUp
+	//   1. cleanUp keys synchronously (we're not holding a transaction here —
+	//      the UpdatePullTime pathway is called from a background goroutine,
+	//      not inside orm.WithTransaction)
 	//   2. re-get
-	m.cleanUp(ctx, art)
+	cleanupCtx, cancel := context.WithTimeout(context.Background(), cleanupCacheTimeout)
+	defer cancel()
+	m.cleanUpKeys(cleanupCtx, art.ID, art.RepositoryName, art.Digest)
 
 	var err error
 	// re-get by id

--- a/src/pkg/cached/artifact/redis/manager_test.go
+++ b/src/pkg/cached/artifact/redis/manager_test.go
@@ -17,12 +17,14 @@ package redis
 import (
 	"context"
 	"errors"
+	"sync"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/suite"
 
 	"github.com/goharbor/harbor/src/lib/cache"
+	"github.com/goharbor/harbor/src/lib/orm"
 	"github.com/goharbor/harbor/src/pkg/artifact"
 	testcache "github.com/goharbor/harbor/src/testing/lib/cache"
 	"github.com/goharbor/harbor/src/testing/mock"
@@ -198,6 +200,89 @@ func (m *managerTestSuite) TestFlushAll() {
 	m.cache.On("Delete", mock.Anything, mock.Anything).Return(nil).Once()
 	err := m.cachedManager.FlushAll(m.ctx)
 	m.NoError(err)
+}
+
+// TestCleanUpKeys_DoesNotSpinOnCanceledContext is the key regression test for
+// https://github.com/goharbor/harbor/issues/21062. Under the old retry.Retry,
+// a canceled context passed into cache.Delete would keep the retry loop
+// spinning for the full 60-second default timeout on each of the two cache
+// keys — ~2 minutes per artifact — while the enclosing DB transaction sat
+// open in ClientRead / idle-in-transaction holding row locks. Under the fix,
+// retry observes context.Canceled as terminal and returns immediately.
+func (m *managerTestSuite) TestCleanUpKeys_DoesNotSpinOnCanceledContext() {
+	// cache.Delete always returns context.Canceled. Under the old code
+	// this would loop in retry.Retry for ~60 seconds per key; under the
+	// fix it returns on the first attempt.
+	m.cache.On("Delete", mock.Anything, mock.Anything).Return(context.Canceled)
+
+	canceled, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	mgr := m.cachedManager.(*Manager)
+	start := time.Now()
+	mgr.cleanUpKeys(canceled, 100, "repo", "sha256:deadbeef")
+	elapsed := time.Since(start)
+
+	m.Less(elapsed.Seconds(), 1.0, "cleanUpKeys must return promptly on canceled ctx, elapsed=%s", elapsed)
+}
+
+// TestDelete_ConcurrentInlineCleanup confirms that the new
+// scheduleCleanUp path still runs inline (via orm.AfterCommit's
+// non-tx fast path) when no transaction scope is present, and that
+// two concurrent Deletes each trigger their own cleanup rather than
+// being accidentally serialized or dropped. The in-transaction
+// deferral behavior is covered by lib/orm/test.TestAfterCommit_*.
+func (m *managerTestSuite) TestDelete_ConcurrentInlineCleanup() {
+	m.artMgr.On("Delete", mock.Anything, mock.Anything).Return(nil)
+	m.artMgr.On("DeleteReferences", mock.Anything, mock.Anything).Return(nil)
+	m.cache.On("Fetch", mock.Anything, mock.Anything, mock.Anything).Return(nil)
+	m.cache.On("Delete", mock.Anything, mock.Anything).Return(nil)
+
+	var wg sync.WaitGroup
+	for i := 0; i < 2; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			_ = m.cachedManager.Delete(m.ctx, 1)
+		}()
+	}
+	wg.Wait()
+
+	m.cache.AssertCalled(m.T(), "Delete", mock.Anything, mock.Anything)
+}
+
+// TestScheduleCleanUp_DefersViaAfterCommit verifies the in-transaction
+// deferral contract at unit-test level: scheduleCleanUp must register via
+// orm.AfterCommit, meaning that when the caller already has a hooks sink
+// (normally set up by WithTransaction) the cache.Delete call is NOT
+// invoked inline from Delete. We drive this by using the dedicated test
+// harness in lib/orm that exposes a ctx with an active hooks sink.
+func (m *managerTestSuite) TestScheduleCleanUp_DefersViaAfterCommit() {
+	// Install a tx-like hooks context via the orm test helper.
+	ctx, drainHooks := orm.ContextWithAfterCommitHooksForTest(context.Background())
+
+	m.artMgr.On("Delete", mock.Anything, mock.Anything).Return(nil).Once()
+	m.artMgr.On("DeleteReferences", mock.Anything, mock.Anything).Return(nil).Once()
+	m.cache.On("Fetch", mock.Anything, mock.Anything, mock.Anything).Return(nil).Once()
+	// cache.Delete is expected to be invoked *after* we drain hooks —
+	// we set up the expectation now but assert it has NOT been called
+	// yet immediately after Delete returns.
+	m.cache.On("Delete", mock.Anything, mock.Anything).Return(nil)
+
+	err := m.cachedManager.Delete(ctx, 100)
+	m.NoError(err)
+
+	// The delegator.Delete has run (simulating the in-tx work), but
+	// cache.Delete must NOT have been called yet — the hook is still
+	// pending in the sink.
+	m.cache.AssertNotCalled(m.T(), "Delete", mock.Anything, mock.Anything)
+
+	// Now simulate a successful commit: run the queued hooks.
+	drainHooks()
+
+	// After draining, cache.Delete must have been invoked for the two
+	// cache keys (id index + digest index).
+	m.cache.AssertCalled(m.T(), "Delete", mock.Anything, mock.Anything)
 }
 
 func TestManager(t *testing.T) {

--- a/src/pkg/cached/project/redis/manager.go
+++ b/src/pkg/cached/project/redis/manager.go
@@ -22,12 +22,20 @@ import (
 	"github.com/goharbor/harbor/src/common/utils"
 	"github.com/goharbor/harbor/src/lib/config"
 	"github.com/goharbor/harbor/src/lib/log"
+	"github.com/goharbor/harbor/src/lib/orm"
 	"github.com/goharbor/harbor/src/lib/q"
 	"github.com/goharbor/harbor/src/lib/retry"
 	"github.com/goharbor/harbor/src/pkg/cached"
 	"github.com/goharbor/harbor/src/pkg/project"
 	"github.com/goharbor/harbor/src/pkg/project/models"
 )
+
+// cleanupCacheTimeout bounds a single cache-eviction attempt after the
+// enclosing transaction has committed. Cache invalidation is best-effort:
+// any stale entry expires via the configured TTL, and the next read from
+// the database repopulates it. We must not sit spinning in a retry loop
+// for the full default timeout.
+const cleanupCacheTimeout = 3 * time.Second
 
 var _ CachedManager = &Manager{}
 
@@ -90,8 +98,10 @@ func (m *Manager) Delete(ctx context.Context, id int64) error {
 	if err := m.delegator.Delete(ctx, id); err != nil {
 		return err
 	}
-	// clean cache
-	m.cleanUp(ctx, p)
+	// Defer cache invalidation until after the enclosing transaction commits,
+	// so Redis round-trips never hold the Postgres row locks open. When there
+	// is no enclosing transaction, AfterCommit runs the hook synchronously.
+	m.scheduleCleanUp(ctx, p)
 	return nil
 }
 
@@ -140,26 +150,52 @@ func (m *Manager) Get(ctx context.Context, idOrName any) (*models.Project, error
 	return p, nil
 }
 
-// cleanUp cleans up data in cache.
-func (m *Manager) cleanUp(ctx context.Context, p *models.Project) {
+// scheduleCleanUp registers the cache invalidation for p to run after the
+// enclosing transaction commits. The closure captures a value copy of the
+// fields it needs so the hook is independent of the request context and any
+// mutations to p after registration.
+func (m *Manager) scheduleCleanUp(ctx context.Context, p *models.Project) {
+	// Capture by value — the caller's project pointer may be reused or mutated.
+	id := p.ProjectID
+	name := p.Name
+	orm.AfterCommit(ctx, func() {
+		cleanupCtx, cancel := context.WithTimeout(context.Background(), cleanupCacheTimeout)
+		defer cancel()
+		m.cleanUpKeys(cleanupCtx, id, name)
+	})
+}
+
+// cleanUpKeys best-effort deletes the cache entries for a given project.
+// Called after the enclosing transaction has committed with a detached
+// context, so it neither holds row locks nor observes a canceled request.
+func (m *Manager) cleanUpKeys(ctx context.Context, id int64, name string) {
 	// clean index by id
-	idIdx, err := m.keyBuilder.Format("id", p.ProjectID)
+	idIdx, err := m.keyBuilder.Format("id", id)
 	if err != nil {
 		log.Errorf("format project id key error: %v", err)
 	} else {
-		// retry to avoid dirty data
-		if err = retry.Retry(func() error { return m.CacheClient(ctx).Delete(ctx, idIdx) }); err != nil {
-			log.Errorf("delete project cache key %s error: %v", idIdx, err)
+		// retry to avoid dirty data; capped retry + ctx-aware so we cannot
+		// block indefinitely on Redis hiccups.
+		if err = retry.Retry(
+			func() error { return m.CacheClient(ctx).Delete(ctx, idIdx) },
+			retry.Context(ctx),
+			retry.Timeout(cleanupCacheTimeout),
+		); err != nil {
+			log.Warningf("delete project cache key %s error: %v", idIdx, err)
 		}
 	}
 
 	// clean index by name
-	nameIdx, err := m.keyBuilder.Format("name", p.Name)
+	nameIdx, err := m.keyBuilder.Format("name", name)
 	if err != nil {
 		log.Errorf("format project name key error: %v", err)
 	} else {
-		if err = retry.Retry(func() error { return m.CacheClient(ctx).Delete(ctx, nameIdx) }); err != nil {
-			log.Errorf("delete project cache key %s error: %v", nameIdx, err)
+		if err = retry.Retry(
+			func() error { return m.CacheClient(ctx).Delete(ctx, nameIdx) },
+			retry.Context(ctx),
+			retry.Timeout(cleanupCacheTimeout),
+		); err != nil {
+			log.Warningf("delete project cache key %s error: %v", nameIdx, err)
 		}
 	}
 }

--- a/src/pkg/cached/project/redis/manager_test.go
+++ b/src/pkg/cached/project/redis/manager_test.go
@@ -18,10 +18,12 @@ import (
 	"context"
 	"errors"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/suite"
 
 	"github.com/goharbor/harbor/src/lib/cache"
+	"github.com/goharbor/harbor/src/lib/orm"
 	"github.com/goharbor/harbor/src/lib/q"
 	"github.com/goharbor/harbor/src/pkg/project/models"
 	testcache "github.com/goharbor/harbor/src/testing/lib/cache"
@@ -134,6 +136,43 @@ func (m *managerTestSuite) TestFlushAll() {
 	m.cache.On("Delete", mock.Anything, mock.Anything).Return(nil).Once()
 	err := m.cachedManager.FlushAll(m.ctx)
 	m.NoError(err)
+}
+
+// TestCleanUpKeys_DoesNotSpinOnCanceledContext: under the old retry.Retry a
+// canceled context would keep the loop spinning for the full default timeout
+// while the enclosing DB transaction sat open holding row locks. Under the fix,
+// retry observes context.Canceled as terminal and cleanUpKeys returns promptly.
+func (m *managerTestSuite) TestCleanUpKeys_DoesNotSpinOnCanceledContext() {
+	m.cache.On("Delete", mock.Anything, mock.Anything).Return(context.Canceled)
+
+	canceled, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	mgr := m.cachedManager.(*Manager)
+	start := time.Now()
+	mgr.cleanUpKeys(canceled, 100, "proj")
+	elapsed := time.Since(start)
+
+	m.Less(elapsed.Seconds(), 1.0, "cleanUpKeys must return promptly on canceled ctx, elapsed=%s", elapsed)
+}
+
+// TestScheduleCleanUp_DefersViaAfterCommit verifies that when a hooks sink is on
+// the context (as WithTransaction sets up), Delete registers cache invalidation
+// via orm.AfterCommit instead of calling cache.Delete inline.
+func (m *managerTestSuite) TestScheduleCleanUp_DefersViaAfterCommit() {
+	ctx, drainHooks := orm.ContextWithAfterCommitHooksForTest(context.Background())
+
+	m.cache.On("Fetch", mock.Anything, mock.Anything, mock.Anything).Return(nil).Once()
+	m.projectMgr.On("Delete", mock.Anything, mock.Anything).Return(nil).Once()
+	m.cache.On("Delete", mock.Anything, mock.Anything).Return(nil)
+
+	err := m.cachedManager.Delete(ctx, 100)
+	m.NoError(err)
+
+	m.cache.AssertNotCalled(m.T(), "Delete", mock.Anything, mock.Anything)
+
+	drainHooks()
+	m.cache.AssertCalled(m.T(), "Delete", mock.Anything, mock.Anything)
 }
 
 func TestManager(t *testing.T) {

--- a/src/pkg/cached/project_metadata/redis/manager.go
+++ b/src/pkg/cached/project_metadata/redis/manager.go
@@ -21,11 +21,19 @@ import (
 
 	"github.com/goharbor/harbor/src/lib/config"
 	"github.com/goharbor/harbor/src/lib/log"
+	"github.com/goharbor/harbor/src/lib/orm"
 	"github.com/goharbor/harbor/src/lib/retry"
 	"github.com/goharbor/harbor/src/pkg/cached"
 	"github.com/goharbor/harbor/src/pkg/project/metadata"
 	"github.com/goharbor/harbor/src/pkg/project/metadata/models"
 )
+
+// cleanupCacheTimeout bounds a single cache-eviction attempt after the
+// enclosing transaction has committed. Cache invalidation is best-effort:
+// any stale entry expires via the configured TTL, and the next read from
+// the database repopulates it. We must not sit spinning in a retry loop
+// for the full default timeout.
+const cleanupCacheTimeout = 3 * time.Second
 
 var _ CachedManager = &Manager{}
 
@@ -62,8 +70,9 @@ func (m *Manager) Add(ctx context.Context, projectID int64, meta map[string]stri
 	if err := m.delegator.Add(ctx, projectID, meta); err != nil {
 		return err
 	}
-	// should cleanup cache when add metadata to project
-	m.cleanUp(ctx, projectID)
+	// should cleanup cache when add metadata to project — deferred until the
+	// enclosing transaction commits so Redis does not hold the tx open.
+	m.scheduleCleanUp(ctx, projectID)
 	return nil
 }
 
@@ -104,8 +113,10 @@ func (m *Manager) Delete(ctx context.Context, projectID int64, meta ...string) e
 	if err := m.delegator.Delete(ctx, projectID, meta...); err != nil {
 		return err
 	}
-	// clean cache
-	m.cleanUp(ctx, projectID, meta...)
+	// Defer cache invalidation until after the enclosing transaction commits,
+	// so Redis round-trips never hold the Postgres row locks open. When there
+	// is no enclosing transaction, AfterCommit runs the hook synchronously.
+	m.scheduleCleanUp(ctx, projectID, meta...)
 	return nil
 }
 
@@ -113,35 +124,64 @@ func (m *Manager) Update(ctx context.Context, projectID int64, meta map[string]s
 	if err := m.delegator.Update(ctx, projectID, meta); err != nil {
 		return err
 	}
-	// clean cache
+	// clean cache after commit: the scan + per-key deletes must not hold the
+	// transaction open across Redis round-trips.
 	prefix, err := m.keyBuilder.Format("projectID", projectID)
 	if err != nil {
 		return err
 	}
-	// lookup all keys with projectID prefix
-	iter, err := m.CacheClient(ctx).Scan(ctx, prefix)
-	if err != nil {
-		return err
-	}
-
-	for iter.Next(ctx) {
-		if err = retry.Retry(func() error { return m.CacheClient(ctx).Delete(ctx, iter.Val()) }); err != nil {
-			log.Errorf("delete project metadata cache key %s error: %v", iter.Val(), err)
+	orm.AfterCommit(ctx, func() {
+		cleanupCtx, cancel := context.WithTimeout(context.Background(), cleanupCacheTimeout)
+		defer cancel()
+		// lookup all keys with projectID prefix
+		iter, err := m.CacheClient(cleanupCtx).Scan(cleanupCtx, prefix)
+		if err != nil {
+			log.Warningf("scan project metadata cache keys with prefix %s error: %v", prefix, err)
+			return
 		}
-	}
+		for iter.Next(cleanupCtx) {
+			key := iter.Val()
+			if err := retry.Retry(
+				func() error { return m.CacheClient(cleanupCtx).Delete(cleanupCtx, key) },
+				retry.Context(cleanupCtx),
+				retry.Timeout(cleanupCacheTimeout),
+			); err != nil {
+				log.Warningf("delete project metadata cache key %s error: %v", key, err)
+			}
+		}
+	})
 
 	return nil
 }
 
-// cleanUp cleans up data in cache.
-func (m *Manager) cleanUp(ctx context.Context, projectID int64, meta ...string) {
+// scheduleCleanUp registers the cache invalidation for the project metadata to
+// run after the enclosing transaction commits. The meta slice is copied so the
+// hook is independent of the caller's backing array.
+func (m *Manager) scheduleCleanUp(ctx context.Context, projectID int64, meta ...string) {
+	metaCopy := append([]string(nil), meta...)
+	orm.AfterCommit(ctx, func() {
+		cleanupCtx, cancel := context.WithTimeout(context.Background(), cleanupCacheTimeout)
+		defer cancel()
+		m.cleanUpKeys(cleanupCtx, projectID, metaCopy...)
+	})
+}
+
+// cleanUpKeys best-effort deletes the project metadata cache entry. Called
+// after the enclosing transaction has committed with a detached context, so it
+// neither holds row locks nor observes a canceled request.
+func (m *Manager) cleanUpKeys(ctx context.Context, projectID int64, meta ...string) {
 	key, err := m.keyBuilder.Format("projectID", projectID, "meta", strings.Join(meta, ","))
 	if err != nil {
 		log.Errorf("format project metadata key error: %v", err)
-	} else {
-		// retry to avoid dirty data
-		if err = retry.Retry(func() error { return m.CacheClient(ctx).Delete(ctx, key) }); err != nil {
-			log.Errorf("delete project metadata cache key %s error: %v", key, err)
-		}
+		return
+	}
+	// retry to avoid dirty data; capped retry + ctx-aware so we cannot block
+	// indefinitely on Redis hiccups.
+	if err = retry.Retry(
+		func() error { return m.CacheClient(ctx).Delete(ctx, key) },
+		retry.Context(ctx),
+		retry.Timeout(cleanupCacheTimeout),
+	); err != nil {
+		log.Warningf("delete project metadata cache key %s error: %v", key, err)
 	}
 }

--- a/src/pkg/cached/project_metadata/redis/manager_test.go
+++ b/src/pkg/cached/project_metadata/redis/manager_test.go
@@ -18,10 +18,12 @@ import (
 	"context"
 	"errors"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/suite"
 
 	"github.com/goharbor/harbor/src/lib/cache"
+	"github.com/goharbor/harbor/src/lib/orm"
 	"github.com/goharbor/harbor/src/pkg/project/metadata/models"
 	testcache "github.com/goharbor/harbor/src/testing/lib/cache"
 	"github.com/goharbor/harbor/src/testing/mock"
@@ -119,6 +121,42 @@ func (m *managerTestSuite) TestFlushAll() {
 	m.cache.On("Delete", mock.Anything, mock.Anything).Return(nil).Once()
 	err := m.cachedManager.FlushAll(m.ctx)
 	m.NoError(err)
+}
+
+// TestCleanUpKeys_DoesNotSpinOnCanceledContext: under the old retry.Retry a
+// canceled context would keep the loop spinning for the full default timeout
+// while the enclosing DB transaction sat open holding row locks. Under the fix,
+// retry observes context.Canceled as terminal and cleanUpKeys returns promptly.
+func (m *managerTestSuite) TestCleanUpKeys_DoesNotSpinOnCanceledContext() {
+	m.cache.On("Delete", mock.Anything, mock.Anything).Return(context.Canceled)
+
+	canceled, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	mgr := m.cachedManager.(*Manager)
+	start := time.Now()
+	mgr.cleanUpKeys(canceled, 100)
+	elapsed := time.Since(start)
+
+	m.Less(elapsed.Seconds(), 1.0, "cleanUpKeys must return promptly on canceled ctx, elapsed=%s", elapsed)
+}
+
+// TestScheduleCleanUp_DefersViaAfterCommit verifies that when a hooks sink is on
+// the context (as WithTransaction sets up), Delete registers cache invalidation
+// via orm.AfterCommit instead of calling cache.Delete inline.
+func (m *managerTestSuite) TestScheduleCleanUp_DefersViaAfterCommit() {
+	ctx, drainHooks := orm.ContextWithAfterCommitHooksForTest(context.Background())
+
+	m.projectMetaMgr.On("Delete", mock.Anything, mock.Anything).Return(nil).Once()
+	m.cache.On("Delete", mock.Anything, mock.Anything).Return(nil)
+
+	err := m.cachedManager.Delete(ctx, 100)
+	m.NoError(err)
+
+	m.cache.AssertNotCalled(m.T(), "Delete", mock.Anything, mock.Anything)
+
+	drainHooks()
+	m.cache.AssertCalled(m.T(), "Delete", mock.Anything, mock.Anything)
 }
 
 func TestManager(t *testing.T) {

--- a/src/pkg/cached/repository/redis/manager.go
+++ b/src/pkg/cached/repository/redis/manager.go
@@ -20,12 +20,20 @@ import (
 
 	"github.com/goharbor/harbor/src/lib/config"
 	"github.com/goharbor/harbor/src/lib/log"
+	"github.com/goharbor/harbor/src/lib/orm"
 	"github.com/goharbor/harbor/src/lib/q"
 	"github.com/goharbor/harbor/src/lib/retry"
 	"github.com/goharbor/harbor/src/pkg/cached"
 	"github.com/goharbor/harbor/src/pkg/repository"
 	"github.com/goharbor/harbor/src/pkg/repository/model"
 )
+
+// cleanupCacheTimeout bounds a single cache-eviction attempt after the
+// enclosing transaction has committed. Cache invalidation is best-effort:
+// any stale entry expires via the configured TTL, and the next read from
+// the database repopulates it. We must not sit spinning in a retry loop
+// for the full default timeout.
+const cleanupCacheTimeout = 3 * time.Second
 
 var _ CachedManager = &Manager{}
 
@@ -133,8 +141,10 @@ func (m *Manager) Delete(ctx context.Context, id int64) error {
 	if err := m.delegator.Delete(ctx, id); err != nil {
 		return err
 	}
-	// clean cache
-	m.cleanUp(ctx, repo)
+	// Defer cache invalidation until after the enclosing transaction commits,
+	// so Redis round-trips never hold the Postgres row locks open. When there
+	// is no enclosing transaction, AfterCommit runs the hook synchronously.
+	m.scheduleCleanUp(ctx, repo)
 	return nil
 }
 
@@ -143,8 +153,10 @@ func (m *Manager) Update(ctx context.Context, repo *model.RepoRecord, props ...s
 	if err := m.delegator.Update(ctx, repo, props...); err != nil {
 		return err
 	}
-	// clean cache
-	m.cleanUp(ctx, repo)
+	// Defer cache invalidation until after the enclosing transaction commits,
+	// so Redis round-trips never hold the Postgres row locks open. When there
+	// is no enclosing transaction, AfterCommit runs the hook synchronously.
+	m.scheduleCleanUp(ctx, repo)
 	return nil
 }
 
@@ -162,26 +174,52 @@ func (m *Manager) AddPullCount(ctx context.Context, id int64, count uint64) erro
 	return nil
 }
 
-// cleanUp cleans up data in cache.
-func (m *Manager) cleanUp(ctx context.Context, repo *model.RepoRecord) {
+// scheduleCleanUp registers the cache invalidation for repo to run after the
+// enclosing transaction commits. The closure captures a value copy of the
+// fields it needs so the hook is independent of the request context and any
+// mutations to repo after registration.
+func (m *Manager) scheduleCleanUp(ctx context.Context, repo *model.RepoRecord) {
+	// Capture by value — the caller's repo pointer may be reused or mutated.
+	id := repo.RepositoryID
+	name := repo.Name
+	orm.AfterCommit(ctx, func() {
+		cleanupCtx, cancel := context.WithTimeout(context.Background(), cleanupCacheTimeout)
+		defer cancel()
+		m.cleanUpKeys(cleanupCtx, id, name)
+	})
+}
+
+// cleanUpKeys best-effort deletes the cache entries for a given repository.
+// Called after the enclosing transaction has committed with a detached
+// context, so it neither holds row locks nor observes a canceled request.
+func (m *Manager) cleanUpKeys(ctx context.Context, id int64, name string) {
 	// clean index by id
-	idIdx, err := m.keyBuilder.Format("id", repo.RepositoryID)
+	idIdx, err := m.keyBuilder.Format("id", id)
 	if err != nil {
 		log.Errorf("format repository id key error: %v", err)
 	} else {
-		// retry to avoid dirty data
-		if err = retry.Retry(func() error { return m.CacheClient(ctx).Delete(ctx, idIdx) }); err != nil {
-			log.Errorf("delete repository cache key %s error: %v", idIdx, err)
+		// retry to avoid dirty data; capped retry + ctx-aware so we cannot
+		// block indefinitely on Redis hiccups.
+		if err = retry.Retry(
+			func() error { return m.CacheClient(ctx).Delete(ctx, idIdx) },
+			retry.Context(ctx),
+			retry.Timeout(cleanupCacheTimeout),
+		); err != nil {
+			log.Warningf("delete repository cache key %s error: %v", idIdx, err)
 		}
 	}
 
 	// clean index by name
-	nameIdx, err := m.keyBuilder.Format("name", repo.Name)
+	nameIdx, err := m.keyBuilder.Format("name", name)
 	if err != nil {
 		log.Errorf("format repository name key error: %v", err)
 	} else {
-		if err = retry.Retry(func() error { return m.CacheClient(ctx).Delete(ctx, nameIdx) }); err != nil {
-			log.Errorf("delete repository cache key %s error: %v", nameIdx, err)
+		if err = retry.Retry(
+			func() error { return m.CacheClient(ctx).Delete(ctx, nameIdx) },
+			retry.Context(ctx),
+			retry.Timeout(cleanupCacheTimeout),
+		); err != nil {
+			log.Warningf("delete repository cache key %s error: %v", nameIdx, err)
 		}
 	}
 }
@@ -194,9 +232,12 @@ func (m *Manager) refreshCache(ctx context.Context, repo *model.RepoRecord) {
 	// no need to consider lock because we only have one goroutine do this work one by one.
 
 	// refreshCache includes 2 steps:
-	//   1. cleanUp
+	//   1. cleanUp keys synchronously off a detached context (AddPullCount is
+	//      driven by a background goroutine, not inside orm.WithTransaction)
 	//   2. re-get
-	m.cleanUp(ctx, repo)
+	cleanupCtx, cancel := context.WithTimeout(context.Background(), cleanupCacheTimeout)
+	defer cancel()
+	m.cleanUpKeys(cleanupCtx, repo.RepositoryID, repo.Name)
 
 	var err error
 	// re-get by id

--- a/src/pkg/cached/repository/redis/manager_test.go
+++ b/src/pkg/cached/repository/redis/manager_test.go
@@ -18,10 +18,12 @@ import (
 	"context"
 	"errors"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/suite"
 
 	"github.com/goharbor/harbor/src/lib/cache"
+	"github.com/goharbor/harbor/src/lib/orm"
 	"github.com/goharbor/harbor/src/pkg/repository/model"
 	testcache "github.com/goharbor/harbor/src/testing/lib/cache"
 	"github.com/goharbor/harbor/src/testing/mock"
@@ -187,6 +189,48 @@ func (m *managerTestSuite) TestFlushAll() {
 	m.cache.On("Delete", mock.Anything, mock.Anything).Return(nil).Once()
 	err := m.cachedManager.FlushAll(m.ctx)
 	m.NoError(err)
+}
+
+// TestCleanUpKeys_DoesNotSpinOnCanceledContext is the repository-side analogue
+// of the artifact regression test for https://github.com/goharbor/harbor/issues/21062:
+// under the old retry.Retry a canceled context would keep the loop spinning for
+// the full default timeout while the enclosing DB transaction sat open holding
+// row locks. Under the fix, retry observes context.Canceled as terminal and
+// cleanUpKeys returns immediately.
+func (m *managerTestSuite) TestCleanUpKeys_DoesNotSpinOnCanceledContext() {
+	m.cache.On("Delete", mock.Anything, mock.Anything).Return(context.Canceled)
+
+	canceled, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	mgr := m.cachedManager.(*Manager)
+	start := time.Now()
+	mgr.cleanUpKeys(canceled, 100, "repo")
+	elapsed := time.Since(start)
+
+	m.Less(elapsed.Seconds(), 1.0, "cleanUpKeys must return promptly on canceled ctx, elapsed=%s", elapsed)
+}
+
+// TestScheduleCleanUp_DefersViaAfterCommit verifies the in-transaction deferral
+// contract: when the caller already has a hooks sink (normally set up by
+// WithTransaction), Delete must register cache invalidation via orm.AfterCommit
+// rather than calling cache.Delete inline.
+func (m *managerTestSuite) TestScheduleCleanUp_DefersViaAfterCommit() {
+	ctx, drainHooks := orm.ContextWithAfterCommitHooksForTest(context.Background())
+
+	m.cache.On("Fetch", mock.Anything, mock.Anything, mock.Anything).Return(nil).Once()
+	m.repoMgr.On("Delete", mock.Anything, mock.Anything).Return(nil).Once()
+	m.cache.On("Delete", mock.Anything, mock.Anything).Return(nil)
+
+	err := m.cachedManager.Delete(ctx, 100)
+	m.NoError(err)
+
+	// The hook is still pending in the sink — cache.Delete must not have run yet.
+	m.cache.AssertNotCalled(m.T(), "Delete", mock.Anything, mock.Anything)
+
+	// Simulate a successful commit: run the queued hooks.
+	drainHooks()
+	m.cache.AssertCalled(m.T(), "Delete", mock.Anything, mock.Anything)
 }
 
 func TestManager(t *testing.T) {


### PR DESCRIPTION
Cherry-pick of upstream [goharbor/harbor#23114](https://github.com/goharbor/harbor/pull/23114) — fixes a harbor-core wedge where deleting a project with many artifacts left Postgres sessions stuck `idle in transaction` (`wait_event=ClientRead`) until the connection pool drained.

Two stacked root causes:

1. **Cache invalidation ran inside the DB transaction.** The cached artifact/repository/project/project_metadata managers called Redis `Delete` (wrapped in `retry.Retry`) from inside the transaction opened by `controller.Delete → orm.WithTransaction → deleteDeeply`. While Go spun on the Redis call, Postgres held every row lock taken so far and waited for the client to send the next statement.
2. **`retry.Retry` ignored context cancellation.** When the HTTP client canceled the request, each `Delete(ctx, key)` returned `context.Canceled` immediately, but retry slept with exponential backoff and tried again — for the full 60s default timeout, twice per artifact, multiplied again by recursion for multi-arch images. Concurrent UI deletes queued behind the held row locks and drained the pool.

### Changes

- **`lib/orm`** — new `AfterCommit(ctx, fn)` plus a `txHooks` sink attached by the outermost `WithTransaction`. Callbacks queued inside a transaction run only after the outermost tx commits successfully; on rollback (or commit failure) they are discarded. Outside any transaction scope, `fn` runs inline on the caller's goroutine so cleanup is never lost.
- **`lib/retry`** — treat `context.Canceled` / `context.DeadlineExceeded` returned from `f()` as terminal, and add an opt-in `retry.Context(ctx)` option so the loop watches `ctx.Done()` and interrupts the inter-attempt sleep. No signature change; this also hardens every existing request-scoped caller (e.g. the quota controller's retry path).
- **`pkg/cached/{artifact,repository,project,project_metadata}/redis`** — `Delete` / `Update` / `Add` now schedule cache eviction via `orm.AfterCommit` on a detached `context.Background()` bounded by a 3s timeout, so Redis round-trips can never extend the lifetime of a Postgres transaction or spin on a canceled request context.

The cached manifest manager is intentionally left unchanged: its `Delete` is called from the registry manifest HTTP handler, not inside `orm.WithTransaction`, and it returns the eviction error to its caller.

## Related Issues

- Cherry-pick of upstream goharbor/harbor#23114 (still open against goharbor `main`).
- Addresses goharbor/harbor#21062 (original pool-drain report).

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Release Notes

Fixed a harbor-core database connection-pool exhaustion that could occur when deleting a project (or many artifacts) while Redis was slow/unreachable or the client disconnected mid-request. Cache invalidation now runs after the database transaction commits and respects request cancellation, so Postgres connections are no longer held `idle in transaction`.

## Testing

- [x] `go build ./...` and `go vet` clean on affected packages
- [x] `go test ./lib/orm/ ./lib/retry/ ./pkg/cached/{artifact,project,project_metadata,repository}/redis/` pass, including the new regression tests (pre-canceled ctx returns promptly; non-tx path evicts inline; in-tx path defers cache delete until the commit runs queued hooks)

## Checklist

- [x] Conventional Commits title (`fix:`)
- [x] DCO sign-off on all commits
- [x] No new warnings


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/container-registry/harbor-next/pull/300?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

