### PR TITLE
chore: Grant PR write for backport suggestions

### DIFF
--- a/.github/workflows/backport-suggestion.yml
+++ b/.github/workflows/backport-suggestion.yml
@@ -8,6 +8,7 @@ on:
 permissions:
   contents: read
   issues: write
+  pull-requests: write
 
 jobs:
   suggest:


### PR DESCRIPTION
## Summary
- add `pull-requests: write` to the Backport Suggestion workflow token permissions

## Why
- PR #300 failed while creating a REST issue comment with `Resource not accessible by integration`
- GitHub returned `x-accepted-github-permissions: issues=write; pull_requests=write`, so `issues: write` alone is insufficient for commenting on pull requests from this workflow

## Testing
- `actionlint .github/workflows/backport-suggestion.yml`
- `git diff --check`

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/container-registry/harbor-next/pull/302?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

