### PR TITLE
ci: Tolerate Backport Suggestion Comment Denial

### DIFF
--- a/.github/workflows/backport-suggestion.yml
+++ b/.github/workflows/backport-suggestion.yml
@@ -8,6 +8,7 @@ on:
 permissions:
   contents: read
   issues: write
+  pull-requests: write
 
 jobs:
   suggest:
@@ -32,15 +33,24 @@ jobs:
               owner, repo, issue_number, per_page: 100,
             });
             const mine = comments.filter(
-              (c) => c.user?.type === 'Bot' && (c.body ?? '').includes(marker),
+              (c) => c.user?.login === 'github-actions[bot]' && (c.body ?? '').includes(marker),
             );
+
+            const canIgnoreWriteError = (err) => err.status === 403 || err.status === 404;
+            const warnWriteError = (action, err) => {
+              core.warning(
+                `Could not ${action} backport suggestion comment: ${err.message}. ` +
+                'The workflow will continue because comment permissions can be unavailable for some PR events.',
+              );
+            };
 
             const removeComments = async (list) => {
               for (const c of list) {
                 try {
                   await github.rest.issues.deleteComment({ owner, repo, comment_id: c.id });
                 } catch (err) {
-                  if (err.status !== 404) throw err; // tolerate an already-deleted comment
+                  if (!canIgnoreWriteError(err)) throw err;
+                  warnWriteError('delete', err);
                 }
               }
             };
@@ -74,10 +84,20 @@ jobs:
             // Keep one comment current; delete any duplicates from earlier runs.
             const [keep, ...extra] = mine;
             if (!keep) {
-              await github.rest.issues.createComment({ owner, repo, issue_number, body });
+              try {
+                await github.rest.issues.createComment({ owner, repo, issue_number, body });
+              } catch (err) {
+                if (!canIgnoreWriteError(err)) throw err;
+                warnWriteError('create', err);
+              }
             } else {
               if (keep.body !== body) {
-                await github.rest.issues.updateComment({ owner, repo, comment_id: keep.id, body });
+                try {
+                  await github.rest.issues.updateComment({ owner, repo, comment_id: keep.id, body });
+                } catch (err) {
+                  if (!canIgnoreWriteError(err)) throw err;
+                  warnWriteError('update', err);
+                }
               }
               await removeComments(extra);
             }


### PR DESCRIPTION
Fixes the Backport Suggestion workflow for PR events where `GITHUB_TOKEN` cannot write PR comments.

Changes:

- Request `pull-requests: write` alongside `issues: write` for PR comment APIs.
- Only manage suggestion comments authored by `github-actions[bot]` and carrying the marker.
- Keep the existing single-current-comment behavior when writes are allowed.
- Warn and continue on 403/404 comment write/delete/update failures instead of failing the check.

This keeps bot comments accurate when permissions allow writes, while preventing fork/permission-denied PRs from failing before the actual CI checks run.

Verification:

- `actionlint .github/workflows/backport-suggestion.yml`
- `git diff --check`

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/container-registry/harbor-next/pull/303?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

