### PR TITLE
ci: Drop Unneeded pull-requests Permission From Backport Suggestion

### DIFF
--- a/.github/workflows/backport-suggestion.yml
+++ b/.github/workflows/backport-suggestion.yml
@@ -8,7 +8,6 @@ on:
 permissions:
   contents: read
   issues: write
-  pull-requests: write
 
 jobs:
   suggest:


### PR DESCRIPTION
## Summary

`#302` added `pull-requests: write` to the Backport Suggestion workflow. The github-script step does not use that scope, so this drops it back to least privilege.

The step only calls:
- `github.rest.issues.listComments / createComment / updateComment / deleteComment` → covered by `issues: write`
- `github.rest.git.listMatchingRefs` → covered by `contents: read`

The two `context.payload.pull_request` reads come from the event payload and need no token permission. The `pull-requests: write` grant was a leftover from the original `gh pr comment` (GraphQL `addComment`) implementation, which no longer exists.

Resulting permissions:

```yaml
permissions:
  contents: read
  issues: write
```

## Type of Change

- [x] CI / build (no runtime impact)

## Testing

- [x] `actionlint` clean.
- [x] Functionality already verified end-to-end (create / delete / re-create) via a throwaway PR while the workflow ran on `main`; this change only removes an unused permission.

## Checklist

- [x] Conventional Commits title (`ci:`)
- [x] DCO sign-off
- [x] No new warnings


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/container-registry/harbor-next/pull/308?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

