### PR TITLE
ci: Sign Off Cherry-Picks So Backport PRs Pass DCO

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -96,7 +96,9 @@ jobs:
           fi
           git switch -c "${backport_branch}"
 
-          if ! git cherry-pick -x "${SOURCE_SHA}"; then
+          # -s adds the committer (github-actions[bot]) sign-off so the backport passes
+          # DCO even when the squashed source commit on the base branch has none.
+          if ! git cherry-pick -x -s "${SOURCE_SHA}"; then
             git cherry-pick --abort || true
             gh pr comment "${PR_NUMBER}" --body "Backport to \`${TARGET_BRANCH}\` has conflicts. Please cherry-pick \`${SOURCE_SHA}\` manually."
             exit 1


### PR DESCRIPTION
## Summary

Automated backport PRs fail the **DCO** check (e.g. #307: `Sign-off not found`). This adds `-s` to the cherry-pick in `backport.yml` so backports are signed off.

### Why backports fail DCO

The sign-off is lost at **squash-merge**, then faithfully reproduced by the backport:

1. The source PR's own commits are signed off (its DCO passes).
2. GitHub's squash-merge creates a new commit on the base branch from the PR title + body and does **not** carry the per-commit `Signed-off-by` trailer into it, so the squashed commit is unsigned. (DCO only runs on PRs, so this lands on `main` unnoticed.)
3. The backport job runs `git cherry-pick -x "${SOURCE_SHA}"` against that squashed commit. `-x` only adds a "cherry picked from…" line, so the backport commit is unsigned too.
4. DCO re-runs on the backport PR and fails.

### Fix

```diff
-          if ! git cherry-pick -x "${SOURCE_SHA}"; then
+          if ! git cherry-pick -x -s "${SOURCE_SHA}"; then
```

`-s` appends a `Signed-off-by` for the **committer**, which the job already sets to `github-actions[bot]` (`backport.yml` lines 88-89). DCO accepts a sign-off matching the author **or** committer, so every backport now passes regardless of whether the source squash commit carried one. The original author is preserved by cherry-pick.

This is the systemic fix; the already-open #307 still needs a one-off `git commit --amend --signoff` + force-push to unblock it (it was created before this change).

## Type of Change

- [x] CI / build (no runtime impact)

## Testing

- [x] `actionlint` clean on the changed lines (the two pre-existing shellcheck style/info findings are unchanged: base=2, after=2).
- [x] Verified the DCO rule: `cherry-pick -s` signs off as the committer (`github-actions[bot]`), which the cncf/dco2 app accepts as matching the committer identity.

## Checklist

- [x] Conventional Commits title (`ci:`)
- [x] DCO sign-off
- [x] No new warnings


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/container-registry/harbor-next/pull/309?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

