### PR TITLE
ci: Scope PR preview image builds to image-affecting paths

### DIFF
--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -3,10 +3,26 @@ name: PR Preview Images
 on:
   pull_request:
     branches: [main, "release-[0-9]*.[0-9]*"]
-    paths-ignore:
-      - "**.md"
-      - "docs/**"
-      - "CLAUDE.md"
+    # Allowlist: only build preview images when an input that actually reaches
+    # one of the images changes. Each entry below is consumed by a dockerfile
+    # COPY/build-arg or by the task build steps (gen-apis / build:binary).
+    # Anything not listed (docs, tests, 8gcr-ee patches, lint config, dev
+    # taskfiles, other workflows) cannot change an image, so it is skipped.
+    paths:
+      - "src/**"                             # Go components + portal sources
+      - "api/v2.0/swagger.yaml"              # gen-apis (core) + portal API client
+      - "tools/swagger/templates/**"         # gen-apis output templates
+      - "make/migrations/**"                 # baked into harbor-core
+      - "icons/**"                           # baked into harbor-core
+      - "config/portal/**"                   # portal nginx.conf
+      - "LICENSE"                            # baked into harbor-portal
+      - "VERSION"                            # ReleaseVersion ldflag baked into the Go binaries
+      - "dockerfile/**"                      # every image
+      - "versions.env"                       # build-args + registry/trivy/distribution pins
+      - "Taskfile.yml"                       # build orchestration root
+      - "taskfile/build.yml"                 # gen-apis + build:binary recipes
+      - ".github/workflows/pr-ci.yml"        # this workflow
+      - ".github/actions/setup-go-cached/**" # Go build env used by the build jobs
 
 permissions:
   contents: read


### PR DESCRIPTION
Switch the `PR Preview Images` workflow trigger from a `paths-ignore` deny-list to an explicit `paths` allowlist.

Today the workflow runs the full matrix (7 components × 2 arch = 14 build jobs, then merge + cosign sign + SBOM attest + PR comment) on **every** PR that touches anything other than `**.md` / `docs/**` / `CLAUDE.md`. That means test-only, lint-config-only, `8gcr-ee/` patch-only, dev-taskfile-only, and other-workflow-only PRs all build, sign, and push seven preview images that are byte-for-byte unaffected.

The new allowlist contains only inputs that actually reach a built image. Each entry is consumed either by a `dockerfile` `COPY`/build-arg or by the `task build:gen-apis` / `task build:binary:<comp>` steps:

| Path | Why it affects an image |
|------|-------------------------|
| `src/**` | Go components + portal sources (compiled / `ng build`) |
| `api/v2.0/swagger.yaml` | `gen-apis` (core server code) + portal API client |
| `tools/swagger/templates/**` | `gen-apis` output templates |
| `make/migrations/**` | `COPY make/migrations` → baked into `harbor-core` |
| `icons/**` | `COPY icons` → baked into `harbor-core` |
| `config/portal/**` | `COPY config/portal/nginx.conf` → `harbor-portal` |
| `LICENSE` | `COPY LICENSE` → `harbor-portal` |
| `dockerfile/**` | build recipe for every image |
| `versions.env` | build-args + the `DISTRIBUTION_*` / `TRIVY*` / `HARBOR_SCANNER_TRIVY_VERSION` pins that define the externally-cloned `registry` and `trivy-adapter` images |
| `Taskfile.yml` | build orchestration root (dotenv, includes) |
| `taskfile/build.yml` | `gen-apis` + `build:binary` recipes |
| `.github/workflows/pr-ci.yml` | this workflow (so changes to it are exercised on their own PR) |
| `.github/actions/setup-go-cached/**` | Go build env used by the build jobs |

### Notably no longer triggers a build (cannot change any image)

- `tests/**`, `src/**/*_test.go`, `src/e2e/**` — test code, never compiled into the `main` binaries
- `8gcr-ee/**` — the patch queue; **this workflow has no "apply commercial patches" step, so preview images are built unpatched** and patch changes do not alter them
- `.golangci.yaml`, dev/test/e2e taskfiles (`taskfile/dev.yml`, `taskfile/test.yml`, …), other `.github/workflows/*.yml`, `deploy/**`, `make/**` other than `migrations/`

### Notes for the reviewer

- This is the workflow-level allowlist (build-everything model). It stops wasted builds on non-image PRs but still rebuilds all seven components when any listed path changes. A follow-up could add a `dorny/paths-filter` pre-job for per-component filtering — `registry` and `trivy-adapter` are cloned from pinned external repos and never depend on `src/**`, so a typical `src/` PR rebuilds + signs them for nothing.
- `src/core/views/**` is intentionally **not** listed separately because `src/**` already covers it.
- **Branch protection check:** `paths` filtering means PRs touching none of these paths skip the workflow entirely. If any `PR Preview Images` job is a *required* status check, a non-matching PR would block on a check that never runs. The previous `paths-ignore` form already had this behavior for docs-only PRs, so this is a widening of the same semantics, not a new class — please confirm these jobs are not required merge gates (they are previews, separate from `build.yml` / `test.yml`).

## Type of Change

- [x] CI / build configuration

## Testing

- [x] `actionlint` clean
- [x] YAML parses (`yaml.safe_load`)
- [x] Allowlist entries cross-checked against every `dockerfile/*.dockerfile` `COPY`/`ARG` and `taskfile/build.yml` `sources`/recipes

## Checklist

- [x] Conventional Commit title (`ci:` — CI-only change, no version bump)
- [x] DCO sign-off
- [x] No new warnings


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/container-registry/harbor-next/pull/311?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

