### PR TITLE
fix(security): Lower auth-failure log noise to DEBUG

### DIFF
--- a/src/server/middleware/security/basic_auth.go
+++ b/src/server/middleware/security/basic_auth.go
@@ -69,7 +69,7 @@ func (b *basicAuth) Generate(req *http.Request) security.Context {
 	})
 
 	if err != nil {
-		log.WithField("client IP", GetClientIP(req)).WithField("user agent", GetUserAgent(req)).Errorf("failed to authenticate user:%s, error:%v", username, err)
+		log.WithField("client IP", GetClientIP(req)).WithField("user agent", GetUserAgent(req)).Debugf("failed to authenticate user:%s, error:%v", username, err)
 		return nil
 	}
 	if user == nil {

--- a/src/server/middleware/security/oidc_cli.go
+++ b/src/server/middleware/security/oidc_cli.go
@@ -65,7 +65,7 @@ func (o *oidcCli) Generate(req *http.Request) security.Context {
 
 	u, err := uctl.GetByName(ctx, username)
 	if err != nil {
-		logger.Errorf("failed to get user model, username: %s, error: %v", username, err)
+		logger.Debugf("failed to get user model, username: %s, error: %v", username, err)
 		return nil
 	}
 


### PR DESCRIPTION
## Summary

Demote auth-failure logs from ERROR to DEBUG in the security middleware. Automated scanners and bots constantly probe the registry with invalid credentials, flooding harbor-core logs with ERROR-level lines. A failed login is expected background traffic, not an error condition.

- `basic_auth.go` — "failed to authenticate user" ERROR → DEBUG
- `oidc_cli.go` — "failed to get user model" ERROR → DEBUG

Split from cr/2.14.x commit `8ceca288a`. The other half of that commit (skip basic auth for non-admin users in OIDC/LDAP/UAA modes) ships as a separate PR.

## Type of Change

- [x] Bug fix / hardening (non-breaking change)

## Release Notes

Reduced harbor-core log noise from invalid-credential probes — auth-failure logs are now DEBUG level instead of ERROR.

## Testing

- [x] `go build` and `go vet` clean on `server/middleware/security`

## Checklist

- [x] Conventional Commits title (`fix:`)
- [x] DCO sign-off
- [x] No new warnings
