### PR TITLE
fix(core): Reduce auth-failure log noise and skip basic auth for non-admin in OIDC/LDAP/UAA

### DIFF
--- a/src/server/middleware/security/basic_auth.go
+++ b/src/server/middleware/security/basic_auth.go
@@ -18,10 +18,12 @@ import (
 	"net/http"
 	"os"
 
+	"github.com/goharbor/harbor/src/common"
 	"github.com/goharbor/harbor/src/common/models"
 	"github.com/goharbor/harbor/src/common/security"
 	"github.com/goharbor/harbor/src/common/security/local"
 	"github.com/goharbor/harbor/src/core/auth"
+	"github.com/goharbor/harbor/src/lib"
 	"github.com/goharbor/harbor/src/lib/log"
 )
 
@@ -63,13 +65,31 @@ func (b *basicAuth) Generate(req *http.Request) security.Context {
 	if !ok {
 		return nil
 	}
+
+	// In OIDC/LDAP/UAA modes only the admin uses basic auth; other principals are
+	// handled by earlier generators (robot, OIDC CLI), so skipping them spares a
+	// useless auth-backend round-trip. Empty mode is treated as DB auth (as in
+	// auth.Login) so a config lookup failure can't lock out basic auth.
+	authMode := lib.GetAuthMode(req.Context())
+	if authMode != "" && authMode != common.DBAuth && !auth.IsSuperUser(req.Context(), username) {
+		log.Debugf("basic auth skipped for user %s, auth mode is %s", username, authMode)
+		return nil
+	}
+
 	user, err := auth.Login(req.Context(), models.AuthModel{
 		Principal: username,
 		Password:  password,
 	})
 
 	if err != nil {
-		log.WithField("client IP", GetClientIP(req)).WithField("user agent", GetUserAgent(req)).Errorf("failed to authenticate user:%s, error:%v", username, err)
+		logEntry := log.WithField("client IP", GetClientIP(req)).WithField("user agent", GetUserAgent(req))
+		// Bad credentials are expected probe traffic (scanners/bots) -> DEBUG;
+		// unexpected backend/config errors stay at ERROR so outages stay visible.
+		if _, ok := err.(auth.ErrAuth); ok {
+			logEntry.Debugf("failed to authenticate user:%s, error:%v", username, err)
+		} else {
+			logEntry.Errorf("failed to authenticate user:%s, error:%v", username, err)
+		}
 		return nil
 	}
 	if user == nil {

--- a/src/server/middleware/security/basic_auth_test.go
+++ b/src/server/middleware/security/basic_auth_test.go
@@ -23,7 +23,9 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/goharbor/harbor/src/common"
 	_ "github.com/goharbor/harbor/src/core/auth/db"
+	"github.com/goharbor/harbor/src/lib"
 	"github.com/goharbor/harbor/src/lib/orm"
 )
 
@@ -35,6 +37,30 @@ func TestBasicAuth(t *testing.T) {
 	req = req.WithContext(orm.Context())
 	ctx := basicAuth.Generate(req)
 	assert.NotNil(t, ctx)
+}
+
+func TestBasicAuthNonDBMode(t *testing.T) {
+	basicAuth := &basicAuth{}
+
+	// admin is the super user, so the skip must not apply in OIDC mode.
+	adminReq, err := http.NewRequest(http.MethodGet, "http://127.0.0.1/api/projects/", nil)
+	require.Nil(t, err)
+	adminReq.SetBasicAuth("admin", "Harbor12345")
+	adminReq = adminReq.WithContext(lib.WithAuthMode(orm.Context(), common.OIDCAuth))
+	assert.NotNil(t, basicAuth.Generate(adminReq), "admin must still authenticate via basic auth in OIDC mode")
+
+	userReq, err := http.NewRequest(http.MethodGet, "http://127.0.0.1/api/projects/", nil)
+	require.Nil(t, err)
+	userReq.SetBasicAuth("nonadmin-probe", "whatever")
+	userReq = userReq.WithContext(lib.WithAuthMode(orm.Context(), common.OIDCAuth))
+	assert.Nil(t, basicAuth.Generate(userReq), "non-admin basic auth must be skipped in OIDC mode")
+
+	// empty auth mode is treated as DB auth, so the skip must not lock out basic auth.
+	emptyModeReq, err := http.NewRequest(http.MethodGet, "http://127.0.0.1/api/projects/", nil)
+	require.Nil(t, err)
+	emptyModeReq.SetBasicAuth("admin", "Harbor12345")
+	emptyModeReq = emptyModeReq.WithContext(orm.Context())
+	assert.NotNil(t, basicAuth.Generate(emptyModeReq), "admin must authenticate when auth mode is empty (treated as DB)")
 }
 
 func TestGetClientIP(t *testing.T) {

--- a/src/server/middleware/security/oidc_cli.go
+++ b/src/server/middleware/security/oidc_cli.go
@@ -27,6 +27,7 @@ import (
 	"github.com/goharbor/harbor/src/controller/user"
 	"github.com/goharbor/harbor/src/lib"
 	"github.com/goharbor/harbor/src/lib/config"
+	"github.com/goharbor/harbor/src/lib/errors"
 	"github.com/goharbor/harbor/src/lib/log"
 	"github.com/goharbor/harbor/src/pkg/oidc"
 )
@@ -65,7 +66,12 @@ func (o *oidcCli) Generate(req *http.Request) security.Context {
 
 	u, err := uctl.GetByName(ctx, username)
 	if err != nil {
-		logger.Errorf("failed to get user model, username: %s, error: %v", username, err)
+		// NotFound is expected probe traffic -> DEBUG; real DB/DAO errors stay ERROR.
+		if errors.IsNotFoundErr(err) {
+			logger.Debugf("failed to get user model, username: %s, error: %v", username, err)
+		} else {
+			logger.Errorf("failed to get user model, username: %s, error: %v", username, err)
+		}
 		return nil
 	}
 


### PR DESCRIPTION
In OIDC deployments the registry is hammered by internet scanners probing `/v2/` with random basic credentials. The `basicAuth` security generator ran a full `auth.Login` for every probe — even though OIDC users never authenticate via basic auth (they use OIDC CLI secrets / robot accounts, resolved by earlier generators in the chain). The result is a steady stream of ERROR log lines; and in LDAP/UAA mode each failed attempt additionally pays a backend round-trip **plus the 1.5s failed-login lockout sleep** (`frozenTime`), so sustained probing means real DB/IdP load and goroutine churn.

## Change

- **Skip the basic-auth generator for non-admins when auth mode ≠ DB.** An empty/unknown auth mode is treated as DB (matching `auth.Login`), so a config-lookup failure can never lock out basic auth.
- **Demote only *expected* failures to DEBUG** — bad credentials (`auth.ErrAuth`) and user-NotFound; unexpected backend/DAO errors stay at ERROR so outages remain visible.

**Caveat:** in LDAP/UAA mode this also stops non-admin users from logging in with their LDAP/UAA password via basic auth. Fine where those users pull via robot accounts; confirm before relying on raw-password `docker login`.

Origin: consolidates cr/2.14.x commit `8ceca288a` (which the `bat -n` alias had mangled to "les unneeded logs."). Supersedes #312. Adds `db`-tagged regression tests for the skip path.

## Release Notes

Reduced harbor-core log noise and unnecessary auth-backend work caused by invalid-credential probes when running in OIDC/LDAP/UAA mode.
