### PR TITLE
ci: Reorder release notes sections and require Release Notes for features

### DIFF
--- a/.github/scripts/format-release-notes.mjs
+++ b/.github/scripts/format-release-notes.mjs
@@ -1,10 +1,10 @@
 import { execFileSync } from 'node:child_process';
 import { readFileSync, writeFileSync } from 'node:fs';
 
-const [releaseBodyPath, generatedNotesPath, outputPath] = process.argv.slice(2);
+const [releaseBodyPath, generatedNotesPath, outputPath, contributorsPath] = process.argv.slice(2);
 
 if (!releaseBodyPath || !generatedNotesPath || !outputPath) {
-  throw new Error('usage: format-release-notes.mjs <release-body> <generated-notes> <output>');
+  throw new Error('usage: format-release-notes.mjs <release-body> <generated-notes> <output> [contributors]');
 }
 
 const releaseBody = readFileSync(releaseBodyPath, 'utf8');
@@ -244,9 +244,15 @@ if (trailing.length > 0) {
   output.push('', ...trailing);
 }
 
-const newContributors = generatedNotes.match(/## New Contributors[\s\S]*?(?=\n\n\*\*Full Changelog\*\*|$)/)?.[0];
-if (newContributors) {
-  output.push('', newContributors.replace('## New Contributors', '### New Contributors').replace(/^\*/gm, '-'));
-}
-
 writeFileSync(outputPath, `${output.join('\n').trim()}\n`);
+
+// New Contributors is emitted as its own top-level `## New Contributors` section
+// by the release workflow, so it is written to a separate file rather than nested
+// under `## What's Changed`.
+if (contributorsPath) {
+  const newContributors = generatedNotes.match(/## New Contributors[\s\S]*?(?=\n\n\*\*Full Changelog\*\*|$)/)?.[0];
+  writeFileSync(
+    contributorsPath,
+    newContributors ? `${newContributors.replace(/^\*/gm, '-').trim()}\n` : '',
+  );
+}

--- a/.github/scripts/format-release-notes.mjs
+++ b/.github/scripts/format-release-notes.mjs
@@ -250,9 +250,9 @@ writeFileSync(outputPath, `${output.join('\n').trim()}\n`);
 // by the release workflow, so it is written to a separate file rather than nested
 // under `## What's Changed`.
 if (contributorsPath) {
-  const newContributors = generatedNotes.match(/## New Contributors[\s\S]*?(?=\n\n\*\*Full Changelog\*\*|$)/)?.[0];
+  const newContributors = generatedNotes.match(/## New Contributors[\s\S]*?(?=(?:\r?\n){2}\*\*Full Changelog\*\*|$)/)?.[0];
   writeFileSync(
     contributorsPath,
-    newContributors ? `${newContributors.replace(/^\*/gm, '-').trim()}\n` : '',
+    newContributors ? `${newContributors.replace(/^\* /gm, '- ').trim()}\n` : '',
   );
 }

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -357,6 +357,7 @@ jobs:
           GENERATED_NOTES="$(mktemp)"
           RELEASE_BODY="$(mktemp)"
           FORMATTED_BODY="$(mktemp)"
+          CONTRIBUTORS="$(mktemp)"
 
           gh api "repos/${{ github.repository }}/releases/generate-notes" \
             -f "tag_name=${TAG_NAME}" \
@@ -365,7 +366,8 @@ jobs:
           node .github/scripts/format-release-notes.mjs \
             "${RELEASE_BODY}" \
             "${GENERATED_NOTES}" \
-            "${FORMATTED_BODY}"
+            "${FORMATTED_BODY}" \
+            "${CONTRIBUTORS}"
 
           HIGHLIGHTS=""
           git fetch --tags --force
@@ -401,15 +403,19 @@ jobs:
           fi
 
           {
+            if [ -n "${HIGHLIGHTS}" ]; then
+              printf '%s\n\n' "${HIGHLIGHTS}"
+            fi
+            cat "${FORMATTED_BODY}"
+            echo ""
+            echo "---"
+            echo ""
             if [ -f applied-patches.txt ] && [ -s applied-patches.txt ]; then
               echo "## Commercial Features"
               echo ""
               echo "This release includes the following commercial enhancements:"
               cat applied-patches.txt
               echo ""
-            fi
-            if [ -n "${HIGHLIGHTS}" ]; then
-              printf '%s\n\n' "${HIGHLIGHTS}"
             fi
             echo "## Container Images"
             echo ""
@@ -432,8 +438,10 @@ jobs:
             echo "  --certificate-oidc-issuer \"https://token.actions.githubusercontent.com\" \\"
             echo "  ${REGISTRY}/harbor-core:${TAG_NAME}"
             echo "\`\`\`"
-            echo ""
-            echo "---"
-            echo ""
-            cat "${FORMATTED_BODY}"
+            if [ -s "${CONTRIBUTORS}" ]; then
+              echo ""
+              echo "---"
+              echo ""
+              cat "${CONTRIBUTORS}"
+            fi
           } | gh release edit "${TAG_NAME}" --notes-file -

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,6 +19,7 @@ task dev:up       # Local dev with hot reload
 - DCO sign-off required: `git commit -s`.
 - **Squash and merge only** — other merge types break release-please.
 - No `Co-Authored-By` / AI attribution trailers.
+- **New features (`feat:`) must add a `## Release Notes` section to the PR description.** Its prose is extracted and rendered under `## Highlights` on the GitHub Release. See CONTRIBUTING.md → "Adding Release Notes to Your PR".
 
 ## Release-please
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -277,7 +277,7 @@ See the [OIDC documentation](https://docs.example.com/oidc) for configuration de
 
 **Rules:**
 
-- Required for `feat:` PRs; recommended for any user-facing `fix:`
+- Required for `feat:` PRs; recommended for any user-facing `fix:` PRs
 - Leave it blank for `ci:`, `chore:`, `refactor:`, `docs:` PRs
 - Write for your users, not for developers (explain what changed and why it matters)
 - Links are fine and encouraged

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -121,7 +121,7 @@ Use the following template for your PR description:
 
 ## Release Notes
 <!--
-Optional. Fill in for user-facing changes (new features, breaking changes, deprecations).
+Required for new features (feat:). Fill in for any user-facing change (breaking changes, deprecations).
 Leave blank for ci:/chore:/refactor:/docs:/test: PRs.
 -->
 
@@ -264,7 +264,7 @@ This renders in the release notes as:
 
 ## Adding Release Notes to Your PR
 
-For user-facing changes (new features, breaking changes, deprecations), you can add rich release notes that appear on the GitHub Release page as a `## Highlights` section.
+**New features (`feat:`) must add a `## Release Notes` section to the PR description.** It is also expected for other user-facing changes (breaking changes, deprecations). The prose appears on the GitHub Release page under a `## Highlights` section.
 
 Fill in the `## Release Notes` section in the PR description:
 
@@ -277,6 +277,7 @@ See the [OIDC documentation](https://docs.example.com/oidc) for configuration de
 
 **Rules:**
 
+- Required for `feat:` PRs; recommended for any user-facing `fix:`
 - Leave it blank for `ci:`, `chore:`, `refactor:`, `docs:` PRs
 - Write for your users, not for developers (explain what changed and why it matters)
 - Links are fine and encouraged

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -121,7 +121,8 @@ Use the following template for your PR description:
 
 ## Release Notes
 <!--
-Required for new features (feat:). Fill in for any user-facing change (breaking changes, deprecations).
+Required for new features (feat:); recommended for user-facing fixes (fix:).
+Also fill in for breaking changes and deprecations.
 Leave blank for ci:/chore:/refactor:/docs:/test: PRs.
 -->
 


### PR DESCRIPTION
## Summary

Reorders the sections in the GitHub Release body produced by the `Update release notes` step of `release-please.yml`, and documents the `## Release Notes` PR convention.

**New section order:**

1. `## Highlights`
2. `## What's Changed`
3. `## Commercial Features`
4. `## Container Images`
5. `## New Contributors`

Previously: Commercial Features → Highlights → Container Images → What's Changed, with **New Contributors nested as a `### ` subsection** of What's Changed.

New Contributors is now a top-level `## New Contributors` section at the end. `format-release-notes.mjs` writes it to a separate file (new optional 4th argument) instead of appending it under What's Changed; the workflow prints it last, guarded by `[ -s ]` so an empty file adds no section.

The docs change makes the existing `## Release Notes` PR convention a requirement for `feat:` PRs — that section is the only input that surfaces a PR under `## Highlights`.

## Related Issues

<!-- none -->

## Type of Change

- [x] CI/CD or build changes (`ci:` / `build:`)
- [x] Documentation (`docs:`)

## Release Notes

<!-- ci: change, intentionally blank -->

## Testing

- [x] `node --check` on `format-release-notes.mjs`
- [x] YAML parse of `release-please.yml`
- [x] Functional test of `format-release-notes.mjs`: New Contributors split into a separate top-level `## New Contributors` file, bullets normalized to `-`, Full Changelog excluded, empty-input and missing-4th-arg cases handled
- [x] Simulated the assembly block end-to-end and confirmed the final section order

## Checklist

- [x] PR title follows Conventional Commits format
- [x] Commits are signed off (`git commit -s`)
- [x] No new warnings introduced
