### PR TITLE
perf(core): Avoid eager structured-logger build on demoted auth-failure logs

### DIFF
--- a/src/server/middleware/security/basic_auth.go
+++ b/src/server/middleware/security/basic_auth.go
@@ -82,13 +82,13 @@ func (b *basicAuth) Generate(req *http.Request) security.Context {
 	})
 
 	if err != nil {
-		logEntry := log.WithField("client IP", GetClientIP(req)).WithField("user agent", GetUserAgent(req))
-		// Bad credentials are expected probe traffic (scanners/bots) -> DEBUG;
-		// unexpected backend/config errors stay at ERROR so outages stay visible.
+		// Bad credentials are expected probe traffic (scanners/bots): log at DEBUG
+		// without the eager WithField structured-logger cost on this hot path.
+		// Unexpected backend/config errors stay at ERROR with client context.
 		if _, ok := err.(auth.ErrAuth); ok {
-			logEntry.Debugf("failed to authenticate user:%s, error:%v", username, err)
+			log.Debugf("failed to authenticate user:%s, error:%v", username, err)
 		} else {
-			logEntry.Errorf("failed to authenticate user:%s, error:%v", username, err)
+			log.WithField("client IP", GetClientIP(req)).WithField("user agent", GetUserAgent(req)).Errorf("failed to authenticate user:%s, error:%v", username, err)
 		}
 		return nil
 	}


### PR DESCRIPTION
Follow-up to #313 (raised by Copilot post-merge). On the auth-failure path the basic-auth generator built `log.WithField(...).WithField(...)` unconditionally, then logged at DEBUG for expected bad credentials. Harbor's `WithField` isn't lazy — it clones the logger and `fmt.Sprintf`-formats each field regardless of level, while `Debugf` no-ops at INFO — so every bad-credential probe paid that cost for a discarded line.

Now the `WithField` chain is built only on the ERROR branch (genuine backend/config failures keep client context); the bad-credential DEBUG path logs plainly. ERROR behavior unchanged.

`gofmt` / `go build` / `go vet` clean. No release-notes impact.
