### PR TITLE
perf(core): Avoid eager structured-logger build on demoted auth-failure logs

### DIFF
--- a/src/server/middleware/security/basic_auth.go
+++ b/src/server/middleware/security/basic_auth.go
@@ -82,13 +82,13 @@ func (b *basicAuth) Generate(req *http.Request) security.Context {
 	})
 
 	if err != nil {
-		logEntry := log.WithField("client IP", GetClientIP(req)).WithField("user agent", GetUserAgent(req))
-		// Bad credentials are expected probe traffic (scanners/bots) -> DEBUG;
-		// unexpected backend/config errors stay at ERROR so outages stay visible.
+		// Bad credentials are expected probe traffic (scanners/bots): log at DEBUG
+		// without the eager WithField structured-logger cost on this hot path.
+		// Unexpected backend/config errors stay at ERROR with client context.
 		if _, ok := err.(auth.ErrAuth); ok {
-			logEntry.Debugf("failed to authenticate user:%s, error:%v", username, err)
+			log.Debugf("failed to authenticate user:%s, error:%v", username, err)
 		} else {
-			logEntry.Errorf("failed to authenticate user:%s, error:%v", username, err)
+			log.WithField("client IP", GetClientIP(req)).WithField("user agent", GetUserAgent(req)).Errorf("failed to authenticate user:%s, error:%v", username, err)
 		}
 		return nil
 	}


### PR DESCRIPTION
Backport of #317 to `release-2.15` (follow-up to #314).

On the auth-failure path the basic-auth generator built the structured logger (`log.WithField(...).WithField(...)`) unconditionally, then logged at DEBUG for the expected bad-credential case. Harbor's `WithField` → `WithFields` eagerly clones the logger, copies the field map, and `fmt.Sprintf`-formats each field regardless of level, while `Debugf` no-ops at INFO — so every bad-credential probe paid the full structured-logger cost for a discarded line. The `WithField` chain is now built only on the ERROR branch; the bad-credential DEBUG path logs plainly. ERROR behavior is unchanged.

## Type of Change

- [x] Performance / hardening (non-breaking)

## Release Notes

_None — internal logging micro-optimization on the auth-failure path._

## Testing

- [x] `gofmt`, `go build`, `go vet` clean on `server/middleware/security`
