### PR TITLE
fix: Return 404 For Missing Repository Artifacts

### DIFF
--- a/src/server/v2.0/handler/artifact.go
+++ b/src/server/v2.0/handler/artifact.go
@@ -87,13 +87,22 @@ func (a *artifactAPI) ListArtifacts(ctx context.Context, params operation.ListAr
 	if err := a.RequireProjectAccess(ctx, params.ProjectName, rbac.ActionList, rbac.ResourceArtifact); err != nil {
 		return a.SendError(ctx, err)
 	}
+	repositoryName := fmt.Sprintf("%s/%s", params.ProjectName, params.RepositoryName)
+	_, err := a.repoCtl.GetByName(ctx, repositoryName)
+	if err != nil {
+		switch {
+		case errors.IsErr(err, errors.NotFoundCode):
+			return operation.NewListArtifactsNotFound().WithPayload(&models.Errors{Errors: []*models.Error{{Message: "Repository not found"}}})
+		}
+		return a.SendError(ctx, err)
+	}
 
 	// set query
 	query, err := a.BuildQuery(ctx, params.Q, params.Sort, params.Page, params.PageSize)
 	if err != nil {
 		return a.SendError(ctx, err)
 	}
-	query.Keywords["RepositoryName"] = fmt.Sprintf("%s/%s", params.ProjectName, params.RepositoryName)
+	query.Keywords["RepositoryName"] = repositoryName
 
 	// set option
 	option := option(params.WithTag, params.WithImmutableStatus,


### PR DESCRIPTION
## Summary

Adopts goharbor/harbor#17618 so artifact listing returns 404 for a missing repository.

## Related Issues

Part of #41

## Type of Change

- [x] Upstream Harbor cherry-pick (`upstream:`)
- [x] Bug fix (`fix:`)

## Release Notes

Returns HTTP 404 when artifacts are requested for a repository that does not exist.

## Testing

- [x] `go test ./server/v2.0/handler`

## Checklist

- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] Commits are signed off (`git commit -s`)
- [x] No new warnings introduced
