### PR TITLE
fix(ldap): Use custom orm.ReadOrCreate to prevent LDAP login failure

### DIFF
--- a/src/lib/orm/test/orm_test.go
+++ b/src/lib/orm/test/orm_test.go
@@ -43,6 +43,10 @@ func (foo *Foo) GetID() int64 {
 	return foo.ID
 }
 
+func init() {
+	RegisterModel(&Foo{})
+}
+
 func addFoo(ctx context.Context, foo Foo) (int64, error) {
 	o, err := FromContext(ctx)
 	if err != nil {
@@ -106,7 +110,6 @@ type OrmSuite struct {
 
 // SetupSuite ...
 func (suite *OrmSuite) SetupSuite() {
-	RegisterModel(&Foo{})
 	dao.PrepareTestForPostgresSQL()
 
 	o, err := FromContext(Context())

--- a/src/lib/orm/test/readorcreate_transaction_test.go
+++ b/src/lib/orm/test/readorcreate_transaction_test.go
@@ -1,0 +1,133 @@
+//  Copyright Project Harbor Authors
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+//go:build db
+
+package test
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/beego/beego/v2/client/orm"
+	"github.com/stretchr/testify/suite"
+
+	"github.com/goharbor/harbor/src/common/dao"
+	. "github.com/goharbor/harbor/src/lib/orm"
+)
+
+// ReadOrCreateTransactionSuite compares beego's native ReadOrCreate with
+// the custom orm.ReadOrCreate to demonstrate why the custom version is needed.
+// This is a regression test for the LDAP login bug (SQLSTATE 25P02).
+type ReadOrCreateTransactionSuite struct {
+	suite.Suite
+}
+
+func (suite *ReadOrCreateTransactionSuite) SetupSuite() {
+	RegisterModel(&Foo{})
+	dao.PrepareTestForPostgresSQL()
+
+	o, err := FromContext(Context())
+	suite.Require().NoError(err)
+
+	_, err = o.Raw(`CREATE TABLE IF NOT EXISTS foo (
+		id SERIAL PRIMARY KEY NOT NULL,
+		name VARCHAR(30),
+		UNIQUE (name)
+	)`).Exec()
+	suite.Require().NoError(err)
+}
+
+func (suite *ReadOrCreateTransactionSuite) TearDownSuite() {
+	o, _ := FromContext(Context())
+	o.Raw(`DROP TABLE IF EXISTS foo`).Exec()
+}
+
+// TestBeegoNativeCorruptsTransaction demonstrates that beego's native method
+// corrupts the transaction when any database error occurs.
+// This is the ROOT CAUSE of the LDAP login bug.
+//
+// EXPECTED: This test PASSES by proving the transaction IS corrupted (25P02).
+func (suite *ReadOrCreateTransactionSuite) TestBeegoNativeCorruptsTransaction() {
+	ctx := NewContext(context.TODO(), orm.NewOrm())
+	uniqueName := fmt.Sprintf("beego%d", time.Now().UnixNano())
+	var gotError25P02 bool
+
+	WithTransaction(func(txCtx context.Context) error {
+		o, err := FromContext(txCtx)
+		suite.Require().NoError(err)
+
+		// Insert a record, then try to insert duplicate (simulates race condition)
+		_, err = o.Insert(&Foo{Name: uniqueName})
+		suite.Require().NoError(err)
+		_, err = o.Insert(&Foo{Name: uniqueName}) // duplicate key error
+		suite.Error(err, "Should get duplicate key error")
+
+		// Try another operation - this WILL fail with 25P02
+		_, err = o.Insert(&Foo{Name: fmt.Sprintf("next%d", time.Now().UnixNano())})
+		if err != nil && strings.Contains(err.Error(), "25P02") {
+			gotError25P02 = true
+		}
+		return err
+	})(ctx)
+
+	suite.True(gotError25P02, "Beego's native method SHOULD corrupt the transaction (25P02)")
+}
+
+// TestCustomReadOrCreateDoesNotCorruptTransaction demonstrates that the custom
+// orm.ReadOrCreate handles errors gracefully without corrupting the transaction.
+// This is the FIX for the LDAP login bug.
+//
+// EXPECTED: This test PASSES by proving the transaction is NOT corrupted.
+func (suite *ReadOrCreateTransactionSuite) TestCustomReadOrCreateDoesNotCorruptTransaction() {
+	ctx := NewContext(context.TODO(), orm.NewOrm())
+	recordName := fmt.Sprintf("custom%d", time.Now().UnixNano())
+
+	// Pre-insert a record (simulates concurrent request that won the race)
+	_, err := orm.NewOrm().Insert(&Foo{Name: recordName})
+	suite.Require().NoError(err)
+
+	var transactionHealthy = true
+	err = WithTransaction(func(txCtx context.Context) error {
+		// Custom ReadOrCreate finds existing record (no error, no corruption)
+		foo := &Foo{Name: recordName}
+		created, _, err := ReadOrCreate(txCtx, foo, "Name")
+		if err != nil {
+			return err
+		}
+		suite.False(created, "Should find existing record")
+
+		// Subsequent operations MUST still work
+		foo2 := &Foo{Name: fmt.Sprintf("new%d", time.Now().UnixNano())}
+		created2, _, err := ReadOrCreate(txCtx, foo2, "Name")
+		if err != nil {
+			if strings.Contains(err.Error(), "25P02") {
+				transactionHealthy = false
+			}
+			return err
+		}
+		suite.True(created2, "Should create new record")
+		return nil
+	})(ctx)
+
+	suite.NoError(err)
+	suite.True(transactionHealthy, "Custom ReadOrCreate should NOT corrupt the transaction")
+}
+
+func TestReadOrCreateTransactionSuite(t *testing.T) {
+	suite.Run(t, new(ReadOrCreateTransactionSuite))
+}

--- a/src/lib/orm/test/readorcreate_transaction_test.go
+++ b/src/lib/orm/test/readorcreate_transaction_test.go
@@ -20,48 +20,19 @@ import (
 	"context"
 	"fmt"
 	"strings"
-	"testing"
 	"time"
 
 	"github.com/beego/beego/v2/client/orm"
-	"github.com/stretchr/testify/suite"
 
-	"github.com/goharbor/harbor/src/common/dao"
 	. "github.com/goharbor/harbor/src/lib/orm"
 )
-
-// ReadOrCreateTransactionSuite compares beego's native ReadOrCreate with
-// the custom orm.ReadOrCreate to demonstrate why the custom version is needed.
-// This is a regression test for the LDAP login bug (SQLSTATE 25P02).
-type ReadOrCreateTransactionSuite struct {
-	suite.Suite
-}
-
-func (suite *ReadOrCreateTransactionSuite) SetupSuite() {
-	dao.PrepareTestForPostgresSQL()
-
-	o, err := FromContext(Context())
-	suite.Require().NoError(err)
-
-	_, err = o.Raw(`CREATE TABLE IF NOT EXISTS foo (
-		id SERIAL PRIMARY KEY NOT NULL,
-		name VARCHAR(30),
-		UNIQUE (name)
-	)`).Exec()
-	suite.Require().NoError(err)
-}
-
-func (suite *ReadOrCreateTransactionSuite) TearDownSuite() {
-	o, _ := FromContext(Context())
-	o.Raw(`DROP TABLE IF EXISTS foo`).Exec()
-}
 
 // TestBeegoNativeCorruptsTransaction demonstrates that beego's native method
 // corrupts the transaction when any database error occurs.
 // This is the ROOT CAUSE of the LDAP login bug.
 //
 // EXPECTED: This test PASSES by proving the transaction IS corrupted (25P02).
-func (suite *ReadOrCreateTransactionSuite) TestBeegoNativeCorruptsTransaction() {
+func (suite *OrmSuite) TestBeegoNativeCorruptsTransaction() {
 	ctx := NewContext(context.TODO(), orm.NewOrm())
 	uniqueName := fmt.Sprintf("beego%d", time.Now().UnixNano())
 	var gotError25P02 bool
@@ -92,7 +63,7 @@ func (suite *ReadOrCreateTransactionSuite) TestBeegoNativeCorruptsTransaction() 
 // This is the FIX for the LDAP login bug.
 //
 // EXPECTED: This test PASSES by proving the transaction is NOT corrupted.
-func (suite *ReadOrCreateTransactionSuite) TestCustomReadOrCreateDoesNotCorruptTransaction() {
+func (suite *OrmSuite) TestCustomReadOrCreateDoesNotCorruptTransaction() {
 	ctx := NewContext(context.TODO(), orm.NewOrm())
 	recordName := fmt.Sprintf("custom%d", time.Now().UnixNano())
 
@@ -125,8 +96,4 @@ func (suite *ReadOrCreateTransactionSuite) TestCustomReadOrCreateDoesNotCorruptT
 
 	suite.NoError(err)
 	suite.True(transactionHealthy, "Custom ReadOrCreate should NOT corrupt the transaction")
-}
-
-func TestReadOrCreateTransactionSuite(t *testing.T) {
-	suite.Run(t, new(ReadOrCreateTransactionSuite))
 }

--- a/src/lib/orm/test/readorcreate_transaction_test.go
+++ b/src/lib/orm/test/readorcreate_transaction_test.go
@@ -38,7 +38,6 @@ type ReadOrCreateTransactionSuite struct {
 }
 
 func (suite *ReadOrCreateTransactionSuite) SetupSuite() {
-	RegisterModel(&Foo{})
 	dao.PrepareTestForPostgresSQL()
 
 	o, err := FromContext(Context())

--- a/src/pkg/usergroup/dao/dao.go
+++ b/src/pkg/usergroup/dao/dao.go
@@ -105,6 +105,8 @@ func (d *dao) Query(ctx context.Context, query *q.Query) ([]*model.UserGroup, er
 }
 
 // Get ...
+//
+//nolint:nilnil // A missing user group is represented by a nil result and nil error.
 func (d *dao) Get(ctx context.Context, id int) (*model.UserGroup, error) {
 	userGroupList, err := d.Query(ctx, q.New(q.KeyWords{"ID": id}))
 	if err != nil {
@@ -147,13 +149,11 @@ func (d *dao) UpdateName(ctx context.Context, id int, groupName string) error {
 	return err
 }
 
-// ReadOrCreate read or create user group
+// ReadOrCreate read or create user group.
+// Uses the custom orm.ReadOrCreate which handles errors gracefully
+// within transactions, preventing transaction corruption during LDAP group onboarding.
 func (d *dao) ReadOrCreate(ctx context.Context, g *model.UserGroup, keyAttribute string, combinedKeyAttributes ...string) (bool, int64, error) {
-	o, err := orm.FromContext(ctx)
-	if err != nil {
-		return false, 0, err
-	}
-	return o.ReadOrCreate(g, keyAttribute, combinedKeyAttributes...)
+	return orm.ReadOrCreate(ctx, g, keyAttribute, combinedKeyAttributes...)
 }
 
 func (d *dao) Count(ctx context.Context, query *q.Query) (int64, error) {

--- a/src/pkg/usergroup/model/model.go
+++ b/src/pkg/usergroup/model/model.go
@@ -30,6 +30,11 @@ func (u *UserGroup) TableName() string {
 	return UserGroupTable
 }
 
+// GetID returns the ID of the user group
+func (u *UserGroup) GetID() int64 {
+	return int64(u.ID)
+}
+
 // UserGroupsFromName ...
 func UserGroupsFromName(groupNames []string, groupType int) []UserGroup {
 	groups := make([]UserGroup, 0)


### PR DESCRIPTION
## Summary

Adopts goharbor/harbor#22717 to use the transaction-safe ORM `ReadOrCreate` path for LDAP user-group onboarding, plus supporting ORM DB test cleanup.

## Related Issues

Part of #41

## Type of Change

- [x] Upstream Harbor cherry-pick (`upstream:`)
- [x] Bug fix (`fix:`)
- [x] Tests (`test:`)

## Release Notes

Improves LDAP onboarding reliability by using a transaction-safe user-group `ReadOrCreate` path.

## Testing

- [ ] `go test -tags=db ./lib/orm/test` blocked locally: `POSTGRESQL_HOST` is not set

## Checklist

- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] Commits are signed off (`git commit -s`)
- [x] No new warnings introduced
