### PR TITLE
upstream(retention): Clean Retention Metadata On Policy Deletion

### DIFF
--- a/src/controller/retention/controller.go
+++ b/src/controller/retention/controller.go
@@ -217,12 +217,13 @@ func (r *defaultController) DeleteRetention(ctx context.Context, id int64) error
 		return err
 	}
 
-	if err = r.manager.DeletePolicy(ctx, id); err != nil {
+	// Clean up retention_id before deleting the policy so a retry cannot leave
+	// stale project metadata after a successful policy deletion.
+	if err = r.proMetaMgr.Delete(ctx, p.Scope.Reference, "retention_id"); err != nil {
 		return err
 	}
 
-	// clean up retention_id from project metadata
-	return r.proMetaMgr.Delete(ctx, p.Scope.Reference, "retention_id")
+	return r.manager.DeletePolicy(ctx, id)
 }
 
 // deleteExecs delete executions

--- a/src/controller/retention/controller_test.go
+++ b/src/controller/retention/controller_test.go
@@ -37,6 +37,7 @@ import (
 	"github.com/goharbor/harbor/src/pkg/scheduler"
 	"github.com/goharbor/harbor/src/pkg/task"
 	"github.com/goharbor/harbor/src/testing/pkg/project"
+	testingMetadata "github.com/goharbor/harbor/src/testing/pkg/project/metadata"
 	"github.com/goharbor/harbor/src/testing/pkg/repository"
 	testingTask "github.com/goharbor/harbor/src/testing/pkg/task"
 )
@@ -69,6 +70,7 @@ func (s *ControllerTestSuite) TestPolicy() {
 	retentionLauncher := &fakeLauncher{}
 	execMgr := &testingTask.ExecutionManager{}
 	taskMgr := &testingTask.Manager{}
+	proMetaMgr := &testingMetadata.Manager{}
 	retentionMgr := retention.NewManager()
 	execMgr.On("Create", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(int64(1), nil)
 	execMgr.On("Delete", mock.Anything, mock.Anything).Return(nil)
@@ -96,6 +98,7 @@ func (s *ControllerTestSuite) TestPolicy() {
 	}}, nil)
 	taskMgr.On("Create", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(int64(1), nil)
 	taskMgr.On("Stop", mock.Anything, mock.Anything).Return(nil)
+	proMetaMgr.On("Delete", mock.Anything, mock.Anything, mock.Anything).Return(nil)
 
 	c := defaultController{
 		manager:        retentionMgr,
@@ -105,6 +108,7 @@ func (s *ControllerTestSuite) TestPolicy() {
 		projectManager: projectMgr,
 		repositoryMgr:  repositoryMgr,
 		scheduler:      retentionScheduler,
+		proMetaMgr:     proMetaMgr,
 	}
 
 	p1 := &policy.Metadata{
@@ -196,6 +200,83 @@ func (s *ControllerTestSuite) TestPolicy() {
 	s.Require().NotNil(err)
 	s.Require().True(strings.Contains(err.Error(), "no such Retention policy"))
 	s.Require().Nil(p1)
+}
+
+func (s *ControllerTestSuite) TestDeleteRetentionCleansUpMetadata() {
+	projectMgr := &project.Manager{}
+	repositoryMgr := &repository.Manager{}
+	retentionScheduler := &fakeRetentionScheduler{}
+	retentionLauncher := &fakeLauncher{}
+	execMgr := &testingTask.ExecutionManager{}
+	taskMgr := &testingTask.Manager{}
+	proMetaMgr := &testingMetadata.Manager{}
+	retentionMgr := retention.NewManager()
+
+	execMgr.On("Delete", mock.Anything, mock.Anything).Return(nil)
+	execMgr.On("List", mock.Anything, mock.Anything).Return([]*task.Execution{}, nil)
+	proMetaMgr.On("Delete", mock.Anything, int64(1), "retention_id").Return(nil)
+
+	c := defaultController{
+		manager:        retentionMgr,
+		execMgr:        execMgr,
+		taskMgr:        taskMgr,
+		launcher:       retentionLauncher,
+		projectManager: projectMgr,
+		repositoryMgr:  repositoryMgr,
+		scheduler:      retentionScheduler,
+		proMetaMgr:     proMetaMgr,
+	}
+
+	ctx := orm.Context()
+
+	// create a policy with project reference = 1
+	p1 := &policy.Metadata{
+		Algorithm: "or",
+		Rules: []rule.Metadata{
+			{
+				ID:       1,
+				Priority: 1,
+				Template: "latestPushedK",
+				Parameters: rule.Parameters{
+					"latestPushedK": 10,
+				},
+				TagSelectors: []*rule.Selector{
+					{
+						Kind:       "doublestar",
+						Decoration: "matches",
+						Pattern:    "**",
+					},
+				},
+				ScopeSelectors: map[string][]*rule.Selector{
+					"repository": {
+						{
+							Kind:       "doublestar",
+							Decoration: "matches",
+							Pattern:    "**",
+						},
+					},
+				},
+			},
+		},
+		Trigger: &policy.Trigger{
+			Kind: "",
+		},
+		Scope: &policy.Scope{
+			Level:     "project",
+			Reference: 1,
+		},
+	}
+
+	id, err := c.CreateRetention(ctx, p1)
+	s.Require().NoError(err)
+	s.Require().True(id > 0)
+
+	// delete the retention policy
+	err = c.DeleteRetention(ctx, id)
+	s.Require().NoError(err)
+
+	// verify proMetaMgr.Delete was called with the correct project ID and "retention_id" key
+	proMetaMgr.AssertCalled(s.T(), "Delete", mock.Anything, int64(1), "retention_id")
 }
 
 func (s *ControllerTestSuite) TestExecution() {

--- a/src/server/v2.0/handler/retention.go
+++ b/src/server/v2.0/handler/retention.go
@@ -315,10 +315,6 @@ func (r *retentionAPI) DeleteRetention(ctx context.Context, params operation.Del
 	if err = r.retentionCtl.DeleteRetention(ctx, params.ID); err != nil {
 		return r.SendError(ctx, err)
 	}
-	// delete retention data in project_metadata
-	if err := r.proMetaMgr.Delete(ctx, p.Scope.Reference, "retention_id"); err != nil {
-		return r.SendError(ctx, err)
-	}
 	return operation.NewDeleteRetentionOK()
 }
 


### PR DESCRIPTION
## Summary

Adopts goharbor/harbor#22875 to clean `retention_id` project metadata when deleting retention policies.

## Related Issues

Part of #41

## Type of Change

- [x] Upstream Harbor cherry-pick (`upstream:`)
- [x] Bug fix (`fix:`)

## Release Notes

Deletes stale project retention metadata when retention policies are removed.

## Testing

- [x] `go test ./controller/retention` (no non-DB test files)
- [ ] `go test -tags=db ./controller/retention` blocked locally: `POSTGRESQL_HOST` is not set

## Checklist

- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] Commits are signed off (`git commit -s`)
- [x] No new warnings introduced
