### PR TITLE
test: Exercise ReadOrCreate Duplicate Key Retry

### DIFF
--- a/src/lib/orm/test/readorcreate_transaction_test.go
+++ b/src/lib/orm/test/readorcreate_transaction_test.go
@@ -18,21 +18,23 @@ package test
 
 import (
 	"context"
+	"errors"
 	"fmt"
-	"strings"
 	"time"
 
 	"github.com/beego/beego/v2/client/orm"
+	"github.com/jackc/pgx/v5/pgconn"
 
 	. "github.com/goharbor/harbor/src/lib/orm"
 )
 
-// TestBeegoNativeCorruptsTransaction demonstrates that beego's native method
-// corrupts the transaction when any database error occurs.
-// This is the ROOT CAUSE of the LDAP login bug.
+const postgresTransactionAbortedCode = "25P02"
+
+// TestDuplicateKeyErrorAbortsTransactionWithoutSavepoint demonstrates that an
+// unisolated duplicate-key error aborts a PostgreSQL transaction.
 //
-// EXPECTED: This test PASSES by proving the transaction IS corrupted (25P02).
-func (suite *OrmSuite) TestBeegoNativeCorruptsTransaction() {
+// EXPECTED: This test passes by proving the transaction is aborted (25P02).
+func (suite *OrmSuite) TestDuplicateKeyErrorAbortsTransactionWithoutSavepoint() {
 	ctx := NewContext(context.TODO(), orm.NewOrm())
 	uniqueName := fmt.Sprintf("beego%d", time.Now().UnixNano())
 	var gotError25P02 bool
@@ -49,51 +51,137 @@ func (suite *OrmSuite) TestBeegoNativeCorruptsTransaction() {
 
 		// Try another operation - this WILL fail with 25P02
 		_, err = o.Insert(&Foo{Name: fmt.Sprintf("next%d", time.Now().UnixNano())})
-		if err != nil && strings.Contains(err.Error(), "25P02") {
+		if isPostgresErrorCode(err, postgresTransactionAbortedCode) {
 			gotError25P02 = true
 		}
 		return err
 	})(ctx)
 
-	suite.True(gotError25P02, "Beego's native method SHOULD corrupt the transaction (25P02)")
+	suite.True(gotError25P02, "duplicate-key error should abort the transaction (25P02) when not isolated")
 }
 
-// TestCustomReadOrCreateDoesNotCorruptTransaction demonstrates that the custom
-// orm.ReadOrCreate handles errors gracefully without corrupting the transaction.
-// This is the FIX for the LDAP login bug.
+// TestCustomReadOrCreateDoesNotAbortTransactionOnDuplicateKey demonstrates that
+// the custom orm.ReadOrCreate isolates duplicate-key errors and retries the read.
 //
 // EXPECTED: This test PASSES by proving the transaction is NOT corrupted.
-func (suite *OrmSuite) TestCustomReadOrCreateDoesNotCorruptTransaction() {
-	ctx := NewContext(context.TODO(), orm.NewOrm())
+func (suite *OrmSuite) TestCustomReadOrCreateDoesNotAbortTransactionOnDuplicateKey() {
 	recordName := fmt.Sprintf("custom%d", time.Now().UnixNano())
-
-	// Pre-insert a record (simulates concurrent request that won the race)
-	_, err := orm.NewOrm().Insert(&Foo{Name: recordName})
-	suite.Require().NoError(err)
-
-	var transactionHealthy = true
-	err = WithTransaction(func(txCtx context.Context) error {
-		// Custom ReadOrCreate finds existing record (no error, no corruption)
-		foo := &Foo{Name: recordName}
-		created, _, err := ReadOrCreate(txCtx, foo, "Name")
-		if err != nil {
-			return err
+	releaseFirstTransaction := make(chan struct{})
+	firstReady := make(chan error, 1)
+	firstDone := make(chan error, 1)
+	secondPID := make(chan backendPIDResult, 1)
+	secondDone := make(chan error, 1)
+	released := false
+	defer func() {
+		if !released {
+			close(releaseFirstTransaction)
 		}
-		suite.False(created, "Should find existing record")
+	}()
 
-		// Subsequent operations MUST still work
-		foo2 := &Foo{Name: fmt.Sprintf("new%d", time.Now().UnixNano())}
-		created2, _, err := ReadOrCreate(txCtx, foo2, "Name")
-		if err != nil {
-			if strings.Contains(err.Error(), "25P02") {
-				transactionHealthy = false
+	go func() {
+		ctx := NewContext(context.TODO(), orm.NewOrm())
+		firstDone <- WithTransaction(func(txCtx context.Context) error {
+			foo := &Foo{Name: recordName}
+			created, _, err := ReadOrCreate(txCtx, foo, "Name")
+			if err != nil {
+				firstReady <- fmt.Errorf("first ReadOrCreate: %w", err)
+				return err
 			}
-			return err
-		}
-		suite.True(created2, "Should create new record")
-		return nil
-	})(ctx)
+			if !created {
+				firstReady <- fmt.Errorf("first ReadOrCreate should create %q", recordName)
+				return nil
+			}
 
-	suite.NoError(err)
-	suite.True(transactionHealthy, "Custom ReadOrCreate should NOT corrupt the transaction")
+			firstReady <- nil
+			<-releaseFirstTransaction
+			return nil
+		})(ctx)
+	}()
+
+	suite.Require().NoError(<-firstReady)
+
+	go func() {
+		ctx := NewContext(context.TODO(), orm.NewOrm())
+		secondDone <- WithTransaction(func(txCtx context.Context) error {
+			pid, err := postgresBackendPID(txCtx)
+			if err != nil {
+				secondPID <- backendPIDResult{err: err}
+				return err
+			}
+			secondPID <- backendPIDResult{pid: pid}
+
+			foo := &Foo{Name: recordName}
+			created, _, err := ReadOrCreate(txCtx, foo, "Name")
+			if err != nil {
+				return fmt.Errorf("racing ReadOrCreate: %w", err)
+			}
+			if created {
+				return fmt.Errorf("racing ReadOrCreate should find %q after duplicate-key retry", recordName)
+			}
+
+			foo2 := &Foo{Name: fmt.Sprintf("new%d", time.Now().UnixNano())}
+			created, _, err = ReadOrCreate(txCtx, foo2, "Name")
+			if err != nil {
+				if isPostgresErrorCode(err, postgresTransactionAbortedCode) {
+					return fmt.Errorf("transaction was aborted after duplicate-key retry: %w", err)
+				}
+				return fmt.Errorf("subsequent ReadOrCreate: %w", err)
+			}
+			if !created {
+				return fmt.Errorf("subsequent ReadOrCreate should create %q", foo2.Name)
+			}
+
+			return nil
+		})(ctx)
+	}()
+
+	pidResult := <-secondPID
+	suite.Require().NoError(pidResult.err)
+	suite.Require().Eventually(func() bool {
+		waiting, err := postgresBackendWaitingOnLock(pidResult.pid)
+		return err == nil && waiting
+	}, 5*time.Second, 50*time.Millisecond, "second transaction should block on the first transaction's unique-key insert")
+
+	close(releaseFirstTransaction)
+	released = true
+	suite.Require().NoError(<-firstDone)
+	suite.NoError(<-secondDone)
+}
+
+type backendPIDResult struct {
+	pid int
+	err error
+}
+
+func postgresBackendPID(ctx context.Context) (int, error) {
+	o, err := FromContext(ctx)
+	if err != nil {
+		return 0, err
+	}
+
+	var pid int
+	if err := o.Raw("SELECT pg_backend_pid()").QueryRow(&pid); err != nil {
+		return 0, err
+	}
+	return pid, nil
+}
+
+func postgresBackendWaitingOnLock(pid int) (bool, error) {
+	o, err := FromContext(Context())
+	if err != nil {
+		return false, err
+	}
+
+	var waiting bool
+	err = o.Raw(`SELECT EXISTS (
+		SELECT 1
+		FROM pg_stat_activity
+		WHERE pid = ? AND wait_event_type = 'Lock'
+	)`, pid).QueryRow(&waiting)
+	return waiting, err
+}
+
+func isPostgresErrorCode(err error, code string) bool {
+	var pgErr *pgconn.PgError
+	return errors.As(err, &pgErr) && pgErr.Code == code
 }


### PR DESCRIPTION
## Summary

Follow-up to #323 for the Copilot review feedback on `readorcreate_transaction_test.go`.

This updates the regression tests to:

- Stop attributing a plain duplicate-key transaction abort to beego `ReadOrCreate`.
- Rename/reword the PostgreSQL transaction-abort test to match what it actually verifies.
- Replace brittle `strings.Contains(err.Error(), "25P02")` checks with structured `*pgconn.PgError` SQLSTATE checks.
- Exercise the custom `orm.ReadOrCreate` duplicate-key retry path with two concurrent transactions, then verify the outer transaction remains usable.

The model registration/table lifecycle comments from Copilot were already handled by #323 moving the tests into `OrmSuite` and registering `Foo` in package init.

## Related Issues

Follow-up to #323.

## Type of Change

- [x] Tests (`test:`)

## Release Notes


## Testing

- [x] `go test -tags=db ./lib/orm/test -run '^$'`
- [x] `go test ./lib/orm`
- [x] `git diff --check next/main...HEAD`

Full DB-tagged execution requires PostgreSQL test env (`POSTGRESQL_HOST`).

## Checklist

- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] Commits are signed off (`git commit -s`)
- [x] No new warnings introduced
