### PR TITLE
ci: Fix Lint Workflow Cache Paths

### DIFF
--- a/.github/workflows/lint-go.yml
+++ b/.github/workflows/lint-go.yml
@@ -34,6 +34,9 @@ jobs:
   lint:
     name: Go Lint
     runs-on: ${{ (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository || contains(fromJSON('["OWNER","MEMBER"]'), github.event.pull_request.author_association)) && vars.RUNNER || 'ubuntu-latest' }}
+    env:
+      GOLANGCI_LINT_CACHE: ${{ github.workspace }}/.ci-cache/golangci-lint
+      XDG_CACHE_HOME: ${{ github.workspace }}/.ci-cache/xdg
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:

--- a/.github/workflows/lint-ui.yml
+++ b/.github/workflows/lint-ui.yml
@@ -64,4 +64,4 @@ jobs:
         working-directory: src/portal
         run: |
           bun run lint
-          ./node_modules/.bin/stylelint "**/*.scss"
+          bun ./node_modules/stylelint/bin/stylelint.js "**/*.scss"

--- a/.github/workflows/lint-ui.yml
+++ b/.github/workflows/lint-ui.yml
@@ -61,4 +61,7 @@ jobs:
         run: bun install --frozen-lockfile
 
       - name: Run UI lint
-        run: task lint:ui
+        working-directory: src/portal
+        run: |
+          bun run lint
+          ./node_modules/.bin/stylelint "**/*.scss"

--- a/.github/workflows/lint-ui.yml
+++ b/.github/workflows/lint-ui.yml
@@ -34,6 +34,10 @@ jobs:
   lint:
     name: UI Lint
     runs-on: ${{ (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository || contains(fromJSON('["OWNER","MEMBER"]'), github.event.pull_request.author_association)) && vars.RUNNER || 'ubuntu-latest' }}
+    env:
+      CYPRESS_CACHE_FOLDER: ${{ github.workspace }}/.ci-cache/cypress
+      CYPRESS_INSTALL_BINARY: "0"
+      XDG_CACHE_HOME: ${{ github.workspace }}/.ci-cache/xdg
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:


### PR DESCRIPTION
## Summary
- Redirect Go lint caches to writable workspace paths
- Redirect Cypress cache for UI lint and skip Cypress binary install during lint-only dependency installation

## Validation
- actionlint
- task lint:go with writable cache env vars
- task lint:ui with writable cache env vars