### PR TITLE
fix(release): Track Next Development Version On Main

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -49,6 +49,37 @@ jobs:
           config-file: ${{ github.ref_name == 'main' && 'release-please-config.json' || 'release-please-config-maintenance.json' }}
           manifest-file: .release-please-manifest.json
 
+      - name: Check out release PR branch
+        if: ${{ github.ref_name == 'main' && steps.release.outputs.prs_created == 'true' && steps.release.outputs.release_created != 'true' }}
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: ${{ fromJSON(steps.release.outputs.prs)[0].headBranchName }}
+
+      - name: Advance main development version
+        if: ${{ github.ref_name == 'main' && steps.release.outputs.prs_created == 'true' && steps.release.outputs.release_created != 'true' }}
+        run: |
+          release_version=$(node -e "const manifest = require('./.release-please-manifest.json'); const version = manifest['.']; if (!version) { throw new Error('missing root release version'); } console.log(version);")
+          if [[ ! "${release_version}" =~ ^([0-9]+)\.([0-9]+)\.([0-9]+)$ ]]; then
+            echo "::error::Unsupported release version: ${release_version}"
+            exit 1
+          fi
+
+          major="${BASH_REMATCH[1]}"
+          minor="${BASH_REMATCH[2]}"
+          next_version="${major}.$((minor + 1)).0"
+          printf '%s\n' "${next_version}" > VERSION
+
+          if git diff --quiet -- VERSION; then
+            echo "VERSION already targets ${next_version}"
+            exit 0
+          fi
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add VERSION
+          git commit -s -m "chore: target next development version ${next_version}"
+          git push
+
   create-maintenance-branch:
     name: Create Maintenance Branch
     needs: [release-please]
@@ -63,6 +94,7 @@ jobs:
       contents: write
     env:
       TAG_NAME: ${{ needs.release-please.outputs.tag_name }}
+      VERSION: ${{ needs.release-please.outputs.version }}
       MAJOR: ${{ needs.release-please.outputs.major }}
       MINOR: ${{ needs.release-please.outputs.minor }}
     steps:
@@ -80,7 +112,19 @@ jobs:
 
           git fetch --depth=1 origin "refs/tags/${TAG_NAME}:refs/tags/${TAG_NAME}"
           sha=$(git rev-list -n 1 "${TAG_NAME}")
-          git push origin "${sha}:refs/heads/${branch}"
+          git switch --detach "${sha}"
+
+          printf '%s\n' "${VERSION}" > VERSION
+          if git diff --quiet -- VERSION; then
+            git push origin "${sha}:refs/heads/${branch}"
+            exit 0
+          fi
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add VERSION
+          git commit -s -m "chore: initialize ${branch} version"
+          git push origin "HEAD:refs/heads/${branch}"
 
   build:
     name: "${{ matrix.component }} (${{ matrix.platform }})"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,7 +23,7 @@ task dev:up       # Local dev with hot reload
 
 ## Release-please
 
-`feat:` → minor, `fix:` / `upstream:` → patch, `feat!:` / `BREAKING CHANGE:` → major. `ci:`, `build:`, `chore:`, `test:` are hidden from release notes.
+`main` uses `always-bump-minor`; `VERSION` on `main` tracks the next development release while `.release-please-manifest.json` tracks the published release. `release-X.Y` branches use patch-only versioning. `ci:`, `build:`, `chore:`, `test:` are hidden from release notes.
 
 **exclude-paths:** changes touching only `.github/`, `docs/`, or `tests/` don't bump version — use `ci:` for CI-only changes.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -180,11 +180,14 @@ Maintainers should use [RELEASE.md](RELEASE.md) as the release and backport runb
 
 1. A `feat:`, `fix:`, or `upstream:` PR is squash-merged to `main`
 2. Release-please scans commits since the last release
-3. It opens a `chore: release X.Y.Z` PR that updates `VERSION` and `CHANGELOG.md`
-4. Maintainer reviews and merges the release PR (squash merge)
-5. GitHub Release is created automatically
-6. Docker images are built, signed, and pushed
-7. If the release is a new minor `.0` release, a `release-X.Y` maintenance branch is created automatically from the release tag
+3. It opens a `chore: release X.Y.0` PR that updates `.release-please-manifest.json` and `CHANGELOG.md`
+4. The release workflow advances `VERSION` on that PR branch to the following minor development target
+5. Maintainer reviews and merges the release PR (squash merge)
+6. GitHub Release is created automatically from the manifest version
+7. Docker images are built, signed, and pushed with the release-please output version
+8. A `release-X.Y` maintenance branch is created automatically and its `VERSION` is reset to `X.Y.0`
+
+On `main`, `VERSION` is the next development target, not the last published release. For example, after publishing `v2.16.0`, `main` immediately moves to `VERSION` `2.17.0`. `.release-please-manifest.json` remains the authoritative release-please record of published versions.
 
 ### Maintenance Branches
 
@@ -196,13 +199,14 @@ For eligible merged PRs on `main`, a maintainer can comment `/backport vX.Y` on 
 
 ### Version Bump Rules
 
-| Commit type | Version bump | Example |
-|-------------|-------------|---------|
-| `fix:` | Patch | `2.16.0` -> `2.16.1` |
-| `upstream:` | Patch | `2.16.0` -> `2.16.1` |
-| `feat:` | Minor | `2.16.0` -> `2.17.0` |
-| `feat!:` / `BREAKING CHANGE:` | Major | `2.16.0` -> `3.0.0` |
-| `ci:` / `chore:` / `docs:` / `test:` / `build:` | No release | - |
+| Commit type | `main` bump | `release-X.Y` bump | Example |
+|-------------|-------------|--------------------|---------|
+| `fix:` | Minor | Patch | `main`: `2.16.0` -> `2.17.0`; `release-2.16`: `2.16.0` -> `2.16.1` |
+| `upstream:` | Minor | Patch | `main`: `2.16.0` -> `2.17.0`; `release-2.16`: `2.16.0` -> `2.16.1` |
+| `perf:` | Minor | Patch | `main`: `2.16.0` -> `2.17.0`; `release-2.16`: `2.16.0` -> `2.16.1` |
+| `feat:` | Minor | Patch | `main`: `2.16.0` -> `2.17.0`; `release-2.16`: `2.16.0` -> `2.16.1` |
+| `feat!:` / `BREAKING CHANGE:` | Minor | Patch | `main`: `2.16.0` -> `2.17.0`; `release-2.16`: `2.16.0` -> `2.16.1` |
+| `ci:` / `chore:` / `docs:` / `test:` / `build:` | No release | No release | - |
 
 ### What Triggers a Release PR
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ It serves as the foundation for [8gcr](https://container-registry.com/8gcr) (8ge
 We're developing Harbor Next as a [community proposal](https://github.com/goharbor/community/pull/272) with the goal of advancing Harbor and the container registry ecosystem.
 
 - Harbor Next and CNCF Harbor cross-pollinate: Harbor Next cherry-picks features and fixes from Harbor, and upstream Harbor adopts features and concepts proven in Harbor Next.
-- Harbor Next follows the same release versioning and cadence as Harbor.
+- Harbor Next follows Harbor's release cadence. The `main` branch always targets the next development release in `VERSION`; published release state is tracked by release-please.
 - Harbor Next is a drop-in replacement for Harbor.
 
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -12,6 +12,10 @@ Release state is defined by:
 - `VERSION`
 - `CHANGELOG.md`
 
+`main` intentionally tracks the next development release in `VERSION`. For example, while `main` is preparing `2.16.0`, `VERSION` is `2.16.0` even though the last published release may still be `2.15.0`. The authoritative release-please state for the last published version is `.release-please-manifest.json`.
+
+On `main`, release-please uses the Go strategy and does not own `VERSION`; the workflow advances `VERSION` on the generated release PR branch. On `release-X.Y`, release-please uses the simple strategy and updates `VERSION` to the patch release version.
+
 ## Repository Flow
 
 ```mermaid
@@ -47,17 +51,17 @@ Rules:
 
 ```mermaid
 flowchart LR
-  a["harbor-next/main\nv2.15.0"]
+  a["harbor-next/main\nVERSION 2.16.0\nmanifest 2.15.0"]
   b["harbor-next/main\nfeat: new capability"]
   c["harbor-next/main\nfix: bug fix"]
-  d["harbor-next/main\nchore: release 2.16.0"]
+  d["release PR\nchore: release 2.16.0\nVERSION 2.17.0"]
   e["tag\nv2.16.0"]
-  f["harbor-next/release-2.16\ncreated from v2.16.0"]
+  f["harbor-next/release-2.16\nVERSION reset to 2.16.0"]
   g["harbor-next/main\nfix: later main fix"]
-  h["backport PR\n/backport v2.15"]
-  i["harbor-next/release-2.15\nfix: later main fix"]
-  j["harbor-next/release-2.15\nchore: release 2.15.1"]
-  k["tag\nv2.15.1"]
+  h["backport PR\n/backport v2.16"]
+  i["harbor-next/release-2.16\nfix: later main fix"]
+  j["harbor-next/release-2.16\nchore: release 2.16.1"]
+  k["tag\nv2.16.1"]
 
   a --> b --> c --> d --> e --> f
   d --> g --> h --> i --> j --> k
@@ -80,10 +84,12 @@ sequenceDiagram
   Actions->>RP: Run release-please for github.ref_name
   alt github.ref_name == main
     RP->>RP: Use release-please-config.json
+    RP->>GitHub: Open or update chore: release X.Y.0 PR
+    Actions->>GitHub: Advance VERSION on release PR branch to X.(Y+1).0
   else github.ref_name == release-X.Y
     RP->>RP: Use release-please-config-maintenance.json
+    RP->>GitHub: Open or update chore: release X.Y.Z PR
   end
-  RP->>GitHub: Open or update chore: release X.Y.Z PR
   Maintainer->>GitHub: Squash-merge release PR
   GitHub->>Actions: Push starts Release Please workflow again
   RP->>GitHub: Create vX.Y.Z tag and GitHub Release
@@ -101,10 +107,10 @@ sequenceDiagram
 
 | Branch | Config | Release behavior |
 |--------|--------|------------------|
-| `main` | `release-please-config.json` | Normal semver bumps |
+| `main` | `release-please-config.json` | Always bumps to the next minor release |
 | `release-X.Y` | `release-please-config-maintenance.json` | Patch-only releases |
 
-`main` releases can create major, minor, or patch versions. A new `.0` release from `main` automatically creates `release-X.Y` from the release tag.
+`main` uses `versioning: always-bump-minor`. All release-worthy commits on `main` are collected into the next minor release. A new `.0` release from `main` automatically creates `release-X.Y` from the release tag, then resets `VERSION` on that maintenance branch to the released `X.Y.0` value.
 
 `release-X.Y` uses `versioning: always-bump-patch`. Any release-worthy commit on a maintenance branch produces the next patch version.
 
@@ -112,12 +118,12 @@ sequenceDiagram
 
 | Commit type | `main` bump | `release-X.Y` bump | Notes section |
 |-------------|-------------|--------------------|---------------|
-| `fix:` | Patch | Patch | Bug Fixes |
-| `upstream:` | Patch | Patch | Upstream |
-| `perf:` | Patch | Patch | Performance Improvements |
+| `fix:` | Minor | Patch | Bug Fixes |
+| `upstream:` | Minor | Patch | Upstream |
+| `perf:` | Minor | Patch | Performance Improvements |
 | `feat:` | Minor | Patch | Features |
-| `feat!:` or `BREAKING CHANGE:` | Major | Patch | Breaking changes |
-| `revert:` | Patch when reverting releasable change | Patch when reverting releasable change | Reverts |
+| `feat!:` or `BREAKING CHANGE:` | Minor | Patch | Breaking changes |
+| `revert:` | Minor when reverting releasable change | Patch when reverting releasable change | Reverts |
 | `ci:`, `chore:`, `build:`, `test:` | No release | No release | Hidden |
 
 Release-please ignores changes that only touch:
@@ -131,16 +137,17 @@ Use `ci:` for workflow-only changes.
 ## Main Release Flow
 
 1. Squash-merge PRs to `main` with valid conventional titles.
-2. Release-please opens or updates `chore: release X.Y.Z`.
-3. Review `VERSION`, `.release-please-manifest.json`, and `CHANGELOG.md`.
-4. Squash-merge the release PR.
-5. Release-please creates the `vX.Y.Z` tag and GitHub Release.
-6. The release workflow checks out the Harbor Next release source.
-7. The workflow applies 8gcr patches at release runtime.
-8. The workflow builds and pushes multi-arch images.
-9. The workflow signs images with cosign.
-10. The workflow rewrites the GitHub Release notes.
-11. If the version is `vX.Y.0`, the workflow creates `release-X.Y`.
+2. Release-please opens or updates `chore: release X.Y.0`.
+3. The workflow advances `VERSION` on that release PR branch to `X.(Y+1).0` so `main` moves straight into the next development cycle after the release PR merges.
+4. Review `.release-please-manifest.json` and `CHANGELOG.md` for the released `X.Y.0` version, and review `VERSION` for the next development target.
+5. Squash-merge the release PR.
+6. Release-please creates the `vX.Y.0` tag and GitHub Release from the manifest version, not from `VERSION`.
+7. The release workflow checks out the Harbor Next release source.
+8. The workflow applies 8gcr patches at release runtime.
+9. The workflow builds and pushes multi-arch images with the release-please output version.
+10. The workflow signs images with cosign.
+11. The workflow rewrites the GitHub Release notes.
+12. The workflow creates `release-X.Y` and resets `VERSION` on that maintenance branch to `X.Y.0`.
 
 ## Maintenance Release Flow
 
@@ -237,10 +244,11 @@ Before merging a release-please PR:
 
 1. Target branch is correct.
 2. Version bump is correct for the branch.
-3. `VERSION`, `.release-please-manifest.json`, and `CHANGELOG.md` are correct.
-4. Merge method is **Squash and merge**.
-5. `Release Please` workflow completes.
-6. GitHub Release notes include images and cosign verification.
+3. On `main`, `.release-please-manifest.json` and `CHANGELOG.md` match the release being published, while `VERSION` points at the following minor development target.
+4. On `release-X.Y`, `VERSION`, `.release-please-manifest.json`, and `CHANGELOG.md` all match the patch release being published.
+5. Merge method is **Squash and merge**.
+6. `Release Please` workflow completes.
+7. GitHub Release notes include images and cosign verification.
 
 Before merging a backport PR:
 

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,10 +1,11 @@
 {
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
   "bootstrap-sha": "123fb099df0cc04c99bdb92f01a6da552fafd0fd",
-  "pull-request-header": "This PR prepares the next release based on conventional commits.",
+  "pull-request-header": "This PR prepares the next release based on conventional commits. On main, .release-please-manifest.json tracks the release version and VERSION is advanced to the following minor development target before the PR is merged.",
   "pull-request-title-pattern": "chore: release ${version}",
-  "release-type": "simple",
+  "release-type": "go",
   "versioning": "always-bump-minor",
+  "always-update": true,
   "include-v-in-tag": true,
   "exclude-paths": [".github", "docs", "tests"],
   "changelog-sections": [
@@ -21,8 +22,6 @@
     {"type": "build",    "section": "Build System",   "hidden": true}
   ],
   "packages": {
-    ".": {
-      "version-file": "VERSION"
-    }
+    ".": {}
   }
 }


### PR DESCRIPTION
## Summary

- Make release-please on `main` treat `.release-please-manifest.json` as the published release state while the workflow advances `VERSION` to the next minor development target.
- Keep release builds on the release-please output version so `v2.16.0` builds as `2.16.0` even when `main` moves to `VERSION` `2.17.0`.
- Document the new main-vs-maintenance release version behavior.

## Testing

- `node -e "const fs = require('fs'); for (const f of ['release-please-config.json', 'release-please-config-maintenance.json', '.release-please-manifest.json']) JSON.parse(fs.readFileSync(f, 'utf8'));"`
- `git diff --check`
- `actionlint .github/workflows/release-please.yml`
- Version math sanity check: `2.16.0` -> `2.17.0`

## Release Notes

N/A - release workflow and documentation only.