### PR TITLE
feat(ci): Publish Latest Images From Main

### DIFF
--- a/.github/workflows/main-images.yml
+++ b/.github/workflows/main-images.yml
@@ -1,0 +1,46 @@
+name: Main Images
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: main-images-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  version:
+    name: Read Version
+    runs-on: ${{ vars.RUNNER || 'ubuntu-latest' }}
+    outputs:
+      version: ${{ steps.version.outputs.version }}
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: ${{ github.sha }}
+
+      - name: Read VERSION
+        id: version
+        run: |
+          version=$(tr -d '\n' < VERSION)
+          echo "version=${version}" >> "$GITHUB_OUTPUT"
+
+  publish-images:
+    name: Publish Latest Images
+    needs: [version]
+    permissions:
+      contents: read
+      id-token: write
+    uses: ./.github/workflows/publish-images.yml
+    with:
+      checkout_ref: ${{ github.sha }}
+      image_tag: latest
+      version: ${{ needs.version.outputs.version }}
+      artifact_prefix: main-latest
+      registry_address: ${{ vars.REGISTRY_ADDRESS || '8gears.container-registry.com' }}
+      registry_project: ${{ vars.REGISTRY_PROJECT || '8gcr' }}
+    secrets: inherit

--- a/.github/workflows/publish-images.yml
+++ b/.github/workflows/publish-images.yml
@@ -1,0 +1,271 @@
+name: Publish Images
+
+on:
+  workflow_call:
+    inputs:
+      checkout_ref:
+        required: true
+        type: string
+      image_tag:
+        required: true
+        type: string
+      version:
+        required: true
+        type: string
+      artifact_prefix:
+        required: true
+        type: string
+      registry_address:
+        required: false
+        type: string
+        default: 8gears.container-registry.com
+      registry_project:
+        required: false
+        type: string
+        default: 8gcr
+    secrets:
+      REGISTRY_PASSWORD:
+        required: true
+      SYNC_APP_PRIVATE_KEY:
+        required: true
+
+env:
+  # arduino/setup-task still declares node20; opt in to the
+  # 2026-06-16 node24 default early.
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
+jobs:
+  build:
+    name: "${{ matrix.component }} (${{ matrix.platform }})"
+    strategy:
+      fail-fast: false
+      matrix:
+        component: [core, jobservice, registryctl, exporter, portal, registry, trivy-adapter]
+        platform:
+          - linux/amd64
+          - linux/arm64
+    runs-on: ${{ vars.RUNNER || 'ubuntu-latest' }}
+    permissions:
+      contents: read
+    env:
+      REGISTRY_ADDRESS: ${{ inputs.registry_address }}
+      REGISTRY_PROJECT: ${{ inputs.registry_project }}
+      VERSION: ${{ inputs.version }}
+    steps:
+      - name: Prepare
+        id: prepare
+        run: |
+          platform=${{ matrix.platform }}
+          echo "PLATFORM_PAIR=${platform//\//-}" >> "$GITHUB_ENV"
+          if [ "${{ matrix.component }}" = "trivy-adapter" ]; then
+            echo "image_name=trivy-adapter" >> "$GITHUB_OUTPUT"
+          else
+            echo "image_name=harbor-${{ matrix.component }}" >> "$GITHUB_OUTPUT"
+          fi
+          if [ -n "$BUILDX_HOST" ]; then
+            echo "BUILDX_HOST=$BUILDX_HOST" >> "$GITHUB_ENV"
+          fi
+
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: ${{ inputs.checkout_ref }}
+
+      - name: Install Task
+        uses: arduino/setup-task@b91d5d2c96a56797b48ac1e0e89220bf64044611 # v2.0.0
+        with:
+          version: 3.x
+          repo-token: ${{ github.token }}
+
+      - name: Install StGit
+        run: |
+          if command -v stg >/dev/null 2>&1; then
+            stg --version
+            exit 0
+          fi
+
+          if command -v apt-get >/dev/null 2>&1; then
+            if command -v sudo >/dev/null 2>&1; then
+              sudo apt-get update
+              sudo apt-get install -y stgit
+            else
+              apt-get update
+              apt-get install -y stgit
+            fi
+          elif command -v brew >/dev/null 2>&1; then
+            brew install stgit
+          else
+            echo "::error::StGit is required but no supported package manager was found."
+            exit 1
+          fi
+
+          stg --version
+
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          app-id: ${{ vars.SYNC_APP_ID }}
+          private-key: ${{ secrets.SYNC_APP_PRIVATE_KEY }}
+          owner: container-registry
+          repositories: 8gcr
+
+      - name: Apply commercial patches
+        env:
+          PATCHES_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: task --taskfile taskfile/release-ready.yml apply-commercial-patches
+
+      - name: Load versions
+        run: grep -E '^[A-Z_]+=' versions.env >> "$GITHUB_ENV"
+
+      - name: Setup Go
+        if: ${{ contains(fromJSON('["core","jobservice","registryctl","exporter","registry","trivy-adapter"]'), matrix.component) }}
+        uses: ./.github/actions/setup-go-cached
+        with:
+          go-version-file: src/go.mod
+          go-sum-path: src/go.sum
+
+      - name: Generate API code
+        if: ${{ contains(fromJSON('["core","jobservice","registryctl","exporter","registry","trivy-adapter"]'), matrix.component) }}
+        run: task build:gen-apis
+
+      - name: Compile Go binary
+        if: ${{ contains(fromJSON('["core","jobservice","registryctl","exporter","registry","trivy-adapter"]'), matrix.component) }}
+        run: task build:binary:${{ matrix.component }}:${{ env.PLATFORM_PAIR }} GIT_COMMIT="${GITHUB_SHA:0:8}"
+
+      - uses: docker/setup-qemu-action@06116385d9baf250c9f4dcb4858b16962ea869c3 # v4.1.0
+        if: env.BUILDX_HOST == ''
+
+      - uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
+        with:
+          driver: ${{ env.BUILDX_HOST && 'remote' || '' }}
+          endpoint: ${{ env.BUILDX_HOST }}
+
+      - name: Log in to registry
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
+        with:
+          registry: ${{ env.REGISTRY_ADDRESS }}
+          username: ${{ vars.REGISTRY_USERNAME }}
+          password: ${{ secrets.REGISTRY_PASSWORD }}
+
+      - name: Build and push by digest
+        id: build
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
+        with:
+          context: .
+          file: dockerfile/${{ matrix.component }}.dockerfile
+          platforms: ${{ matrix.platform }}
+          build-args: |
+            ALPINE_VERSION=${{ env.ALPINE_VERSION }}
+            LPROBE_VERSION=${{ env.LPROBE_VERSION }}
+            NGINX_VERSION=${{ env.NGINX_VERSION }}
+            BUN_VERSION=${{ env.BUN_VERSION }}
+            GO_VERSION=${{ env.GO_VERSION }}
+            DISTRIBUTION_VERSION=${{ env.DISTRIBUTION_VERSION }}
+            TRIVY_VERSION=${{ env.TRIVY_VERSION }}
+            TRIVY_BASE_IMAGE_VERSION=${{ env.TRIVY_BASE_IMAGE_VERSION }}
+            HARBOR_SCANNER_TRIVY_VERSION=${{ env.HARBOR_SCANNER_TRIVY_VERSION }}
+          tags: ${{ env.REGISTRY_ADDRESS }}/${{ env.REGISTRY_PROJECT }}/${{ steps.prepare.outputs.image_name }}
+          outputs: type=image,push-by-digest=true,name-canonical=true,push=true
+
+      - name: Export digest
+        run: |
+          mkdir -p "${{ runner.temp }}/digests"
+          digest="${{ steps.build.outputs.digest }}"
+          touch "${{ runner.temp }}/digests/${digest#sha256:}"
+
+      - name: Upload digest
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: ${{ inputs.artifact_prefix }}-digest-${{ matrix.component }}-${{ env.PLATFORM_PAIR }}
+          path: ${{ runner.temp }}/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  merge:
+    name: "Merge ${{ matrix.component }}"
+    needs: [build]
+    strategy:
+      matrix:
+        component: [core, jobservice, registryctl, exporter, portal, registry, trivy-adapter]
+    runs-on: ${{ vars.RUNNER || 'ubuntu-latest' }}
+    permissions:
+      contents: read
+    env:
+      REGISTRY_ADDRESS: ${{ inputs.registry_address }}
+      REGISTRY_PROJECT: ${{ inputs.registry_project }}
+      IMAGE_TAG: ${{ inputs.image_tag }}
+    steps:
+      - name: Prepare BuildKit
+        id: prepare
+        run: |
+          if [ "${{ matrix.component }}" = "trivy-adapter" ]; then
+            echo "image_name=trivy-adapter" >> "$GITHUB_OUTPUT"
+          else
+            echo "image_name=harbor-${{ matrix.component }}" >> "$GITHUB_OUTPUT"
+          fi
+          if [ -n "$BUILDX_HOST" ]; then
+            echo "BUILDX_HOST=$BUILDX_HOST" >> "$GITHUB_ENV"
+          fi
+
+      - name: Download digests
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          path: ${{ runner.temp }}/digests
+          pattern: ${{ inputs.artifact_prefix }}-digest-${{ matrix.component }}-*
+          merge-multiple: true
+
+      - name: Log in to registry
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
+        with:
+          registry: ${{ env.REGISTRY_ADDRESS }}
+          username: ${{ vars.REGISTRY_USERNAME }}
+          password: ${{ secrets.REGISTRY_PASSWORD }}
+
+      - uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
+        with:
+          driver: ${{ env.BUILDX_HOST && 'remote' || '' }}
+          endpoint: ${{ env.BUILDX_HOST }}
+
+      - name: Create manifest list and push
+        working-directory: ${{ runner.temp }}/digests
+        env:
+          IMAGE: ${{ env.REGISTRY_ADDRESS }}/${{ env.REGISTRY_PROJECT }}/${{ steps.prepare.outputs.image_name }}
+        run: |
+          # shellcheck disable=SC2046
+          docker buildx imagetools create \
+            -t "${IMAGE}:${IMAGE_TAG}" \
+            $(printf "${IMAGE}@sha256:%s " *)
+
+  sign:
+    name: Sign images
+    needs: [merge]
+    runs-on: ${{ vars.RUNNER || 'ubuntu-latest' }}
+    permissions:
+      contents: read
+      id-token: write
+    env:
+      REGISTRY_ADDRESS: ${{ inputs.registry_address }}
+      REGISTRY_PROJECT: ${{ inputs.registry_project }}
+      IMAGE_TAG: ${{ inputs.image_tag }}
+    steps:
+      - name: Install cosign
+        uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
+
+      - name: Log in to registry
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
+        with:
+          registry: ${{ env.REGISTRY_ADDRESS }}
+          username: ${{ vars.REGISTRY_USERNAME }}
+          password: ${{ secrets.REGISTRY_PASSWORD }}
+
+      - name: Sign images
+        run: |
+          for image in core jobservice registryctl exporter portal registry trivy-adapter; do
+            image_name="harbor-${image}"
+            if [ "${image}" = "trivy-adapter" ]; then
+              image_name="trivy-adapter"
+            fi
+
+            cosign sign --yes \
+              "${REGISTRY_ADDRESS}/${REGISTRY_PROJECT}/${image_name}:${IMAGE_TAG}"
+          done

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -82,218 +82,30 @@ jobs:
           sha=$(git rev-list -n 1 "${TAG_NAME}")
           git push origin "${sha}:refs/heads/${branch}"
 
-  build:
-    name: "${{ matrix.component }} (${{ matrix.platform }})"
+  publish-images:
+    name: Publish Release Images
     needs: [release-please]
     if: ${{ needs.release-please.outputs.release_created == 'true' }}
-    strategy:
-      fail-fast: false
-      matrix:
-        component: [core, jobservice, registryctl, exporter, portal, registry, trivy-adapter]
-        platform:
-          - linux/amd64
-          - linux/arm64
-    runs-on: ${{ vars.RUNNER || 'ubuntu-latest' }}
     permissions:
       contents: read
-    env:
-      REGISTRY_ADDRESS: ${{ vars.REGISTRY_ADDRESS || '8gears.container-registry.com' }}
-      REGISTRY_PROJECT: ${{ vars.REGISTRY_PROJECT || '8gcr' }}
-      VERSION: ${{ needs.release-please.outputs.version }}
-    steps:
-      - name: Prepare
-        id: prepare
-        run: |
-          platform=${{ matrix.platform }}
-          echo "PLATFORM_PAIR=${platform//\//-}" >> "$GITHUB_ENV"
-          if [ "${{ matrix.component }}" = "trivy-adapter" ]; then
-            echo "image_name=trivy-adapter" >> "$GITHUB_OUTPUT"
-          else
-            echo "image_name=harbor-${{ matrix.component }}" >> "$GITHUB_OUTPUT"
-          fi
-          if [ -n "$BUILDX_HOST" ]; then
-            echo "BUILDX_HOST=$BUILDX_HOST" >> "$GITHUB_ENV"
-          fi
+      id-token: write
+    uses: ./.github/workflows/publish-images.yml
+    with:
+      checkout_ref: ${{ needs.release-please.outputs.tag_name }}
+      image_tag: ${{ needs.release-please.outputs.tag_name }}
+      version: ${{ needs.release-please.outputs.version }}
+      artifact_prefix: release-${{ needs.release-please.outputs.tag_name }}
+      registry_address: ${{ vars.REGISTRY_ADDRESS || '8gears.container-registry.com' }}
+      registry_project: ${{ vars.REGISTRY_PROJECT || '8gcr' }}
+    secrets: inherit
 
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-        with:
-          ref: ${{ needs.release-please.outputs.tag_name }}
-
-      - name: Install Task
-        uses: arduino/setup-task@b91d5d2c96a56797b48ac1e0e89220bf64044611 # v2.0.0
-        with:
-          version: 3.x
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Install StGit
-        run: |
-          if command -v stg >/dev/null 2>&1; then
-            stg --version
-            exit 0
-          fi
-
-          if command -v apt-get >/dev/null 2>&1; then
-            if command -v sudo >/dev/null 2>&1; then
-              sudo apt-get update
-              sudo apt-get install -y stgit
-            else
-              apt-get update
-              apt-get install -y stgit
-            fi
-          elif command -v brew >/dev/null 2>&1; then
-            brew install stgit
-          else
-            echo "::error::StGit is required but no supported package manager was found."
-            exit 1
-          fi
-
-          stg --version
-
-      - name: Generate GitHub App token
-        id: app-token
-        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
-        with:
-          app-id: ${{ vars.SYNC_APP_ID }}
-          private-key: ${{ secrets.SYNC_APP_PRIVATE_KEY }}
-          owner: container-registry
-          repositories: 8gcr
-
-      - name: Apply commercial patches
-        env:
-          PATCHES_TOKEN: ${{ steps.app-token.outputs.token }}
-        run: task --taskfile taskfile/release-ready.yml apply-commercial-patches
-
-      - name: Load versions
-        run: grep -E '^[A-Z_]+=' versions.env >> "$GITHUB_ENV"
-
-      - name: Setup Go
-        if: ${{ contains(fromJSON('["core","jobservice","registryctl","exporter","registry","trivy-adapter"]'), matrix.component) }}
-        uses: ./.github/actions/setup-go-cached
-        with:
-          go-version-file: src/go.mod
-          go-sum-path: src/go.sum
-
-      - name: Generate API code
-        if: ${{ contains(fromJSON('["core","jobservice","registryctl","exporter","registry","trivy-adapter"]'), matrix.component) }}
-        run: task build:gen-apis
-
-      - name: Compile Go binary
-        if: ${{ contains(fromJSON('["core","jobservice","registryctl","exporter","registry","trivy-adapter"]'), matrix.component) }}
-        run: task build:binary:${{ matrix.component }}:${{ env.PLATFORM_PAIR }} GIT_COMMIT="${GITHUB_SHA:0:8}"
-
-      - uses: docker/setup-qemu-action@06116385d9baf250c9f4dcb4858b16962ea869c3 # v4.1.0
-        if: env.BUILDX_HOST == ''
-
-      - uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
-        with:
-          driver: ${{ env.BUILDX_HOST && 'remote' || '' }}
-          endpoint: ${{ env.BUILDX_HOST }}
-
-      - name: Log in to registry
-        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
-        with:
-          registry: ${{ env.REGISTRY_ADDRESS }}
-          username: ${{ vars.REGISTRY_USERNAME }}
-          password: ${{ secrets.REGISTRY_PASSWORD }}
-
-      - name: Build and push by digest
-        id: build
-        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
-        with:
-          context: .
-          file: dockerfile/${{ matrix.component }}.dockerfile
-          platforms: ${{ matrix.platform }}
-          build-args: |
-            ALPINE_VERSION=${{ env.ALPINE_VERSION }}
-            LPROBE_VERSION=${{ env.LPROBE_VERSION }}
-            NGINX_VERSION=${{ env.NGINX_VERSION }}
-            BUN_VERSION=${{ env.BUN_VERSION }}
-            GO_VERSION=${{ env.GO_VERSION }}
-            DISTRIBUTION_VERSION=${{ env.DISTRIBUTION_VERSION }}
-            TRIVY_VERSION=${{ env.TRIVY_VERSION }}
-            TRIVY_BASE_IMAGE_VERSION=${{ env.TRIVY_BASE_IMAGE_VERSION }}
-            HARBOR_SCANNER_TRIVY_VERSION=${{ env.HARBOR_SCANNER_TRIVY_VERSION }}
-          tags: ${{ env.REGISTRY_ADDRESS }}/${{ env.REGISTRY_PROJECT }}/${{ steps.prepare.outputs.image_name }}
-          outputs: type=image,push-by-digest=true,name-canonical=true,push=true
-
-      - name: Export digest
-        run: |
-          mkdir -p "${{ runner.temp }}/digests"
-          digest="${{ steps.build.outputs.digest }}"
-          touch "${{ runner.temp }}/digests/${digest#sha256:}"
-
-      - name: Upload digest
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        with:
-          name: digest-${{ matrix.component }}-${{ env.PLATFORM_PAIR }}
-          path: ${{ runner.temp }}/digests/*
-          if-no-files-found: error
-          retention-days: 1
-
-  merge:
-    name: "Merge ${{ matrix.component }}"
-    needs: [release-please, build]
-    strategy:
-      matrix:
-        component: [core, jobservice, registryctl, exporter, portal, registry, trivy-adapter]
-    runs-on: ${{ vars.RUNNER || 'ubuntu-latest' }}
-    permissions:
-      contents: read
-    env:
-      REGISTRY_ADDRESS: ${{ vars.REGISTRY_ADDRESS || '8gears.container-registry.com' }}
-      REGISTRY_PROJECT: ${{ vars.REGISTRY_PROJECT || '8gcr' }}
-      VERSION: ${{ needs.release-please.outputs.version }}
-      TAG_NAME: ${{ needs.release-please.outputs.tag_name }}
-      RELEASE_BRANCH: ${{ github.ref_name }}
-    steps:
-      - name: Prepare BuildKit
-        id: prepare
-        run: |
-          if [ "${{ matrix.component }}" = "trivy-adapter" ]; then
-            echo "image_name=trivy-adapter" >> "$GITHUB_OUTPUT"
-          else
-            echo "image_name=harbor-${{ matrix.component }}" >> "$GITHUB_OUTPUT"
-          fi
-          if [ -n "$BUILDX_HOST" ]; then
-            echo "BUILDX_HOST=$BUILDX_HOST" >> "$GITHUB_ENV"
-          fi
-
-      - name: Download digests
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
-        with:
-          path: ${{ runner.temp }}/digests
-          pattern: digest-${{ matrix.component }}-*
-          merge-multiple: true
-
-      - name: Log in to registry
-        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
-        with:
-          registry: ${{ env.REGISTRY_ADDRESS }}
-          username: ${{ vars.REGISTRY_USERNAME }}
-          password: ${{ secrets.REGISTRY_PASSWORD }}
-
-      - uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
-        with:
-          driver: ${{ env.BUILDX_HOST && 'remote' || '' }}
-          endpoint: ${{ env.BUILDX_HOST }}
-
-      - name: Create manifest list and push
-        working-directory: ${{ runner.temp }}/digests
-        env:
-          IMAGE: ${{ env.REGISTRY_ADDRESS }}/${{ env.REGISTRY_PROJECT }}/${{ steps.prepare.outputs.image_name }}
-        run: |
-          # shellcheck disable=SC2046
-          docker buildx imagetools create \
-            -t "${IMAGE}:${TAG_NAME}" \
-            $(printf "${IMAGE}@sha256:%s " *)
-
-  sign:
-    name: Sign and Release
-    needs: [release-please, merge]
+  update-release-notes:
+    name: Update Release Notes
+    needs: [release-please, publish-images]
+    if: ${{ needs.release-please.outputs.release_created == 'true' }}
     runs-on: ${{ vars.RUNNER || 'ubuntu-latest' }}
     permissions:
       contents: write
-      id-token: write
     env:
       REGISTRY_ADDRESS: ${{ vars.REGISTRY_ADDRESS || '8gears.container-registry.com' }}
       REGISTRY_PROJECT: ${{ vars.REGISTRY_PROJECT || '8gcr' }}
@@ -312,28 +124,6 @@ jobs:
         uses: actions4gh/setup-gh@44a12005484c53be5bf51bebe8c985b4be8ba8de # v1.0.2
         with:
           gh-version: latest
-
-      - name: Install cosign
-        uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
-
-      - name: Log in to registry
-        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
-        with:
-          registry: ${{ env.REGISTRY_ADDRESS }}
-          username: ${{ vars.REGISTRY_USERNAME }}
-          password: ${{ secrets.REGISTRY_PASSWORD }}
-
-      - name: Sign images
-        run: |
-          for image in core jobservice registryctl exporter portal registry trivy-adapter; do
-            image_name="harbor-${image}"
-            if [ "${image}" = "trivy-adapter" ]; then
-              image_name="trivy-adapter"
-            fi
-
-            cosign sign --yes \
-              "${REGISTRY_ADDRESS}/${REGISTRY_PROJECT}/${image_name}:${TAG_NAME}"
-          done
 
       - name: Generate GitHub App token
         id: app-token
@@ -448,7 +238,7 @@ jobs:
             echo "**Verify an image signature:**"
             echo "\`\`\`sh"
             echo "cosign verify \\"
-            echo "  --certificate-identity \"https://github.com/${{ github.repository }}/.github/workflows/release-please.yml@refs/heads/${RELEASE_BRANCH}\" \\"
+            echo "  --certificate-identity \"https://github.com/${{ github.repository }}/.github/workflows/publish-images.yml@refs/heads/${RELEASE_BRANCH}\" \\"
             echo "  --certificate-oidc-issuer \"https://token.actions.githubusercontent.com\" \\"
             echo "  ${REGISTRY}/harbor-core:${TAG_NAME}"
             echo "\`\`\`"


### PR DESCRIPTION
## Summary
- Add a reusable patched multi-arch image publishing workflow.
- Add a main-branch workflow that publishes signed `:latest` images using the repository `VERSION` value.
- Update release publishing to use the shared image publishing workflow while keeping release-note updates release-only.

## Testing
- `actionlint`
- `git diff --check`

Closes #357