### PR TITLE
ci: Setup Node For Release Version Update

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -55,6 +55,12 @@ jobs:
         with:
           ref: ${{ fromJSON(steps.release.outputs.prs)[0].headBranchName }}
 
+      - name: Setup Node
+        if: ${{ github.ref_name == 'main' && steps.release.outputs.prs_created == 'true' && steps.release.outputs.release_created != 'true' }}
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: 24
+
       - name: Advance main development version
         if: ${{ github.ref_name == 'main' && steps.release.outputs.prs_created == 'true' && steps.release.outputs.release_created != 'true' }}
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -66,7 +66,6 @@ deploy/compose/config/certs/
 .env
 .env.local
 CLAUDE.md
-AGENTS.md
 tmp/
 bin
 .mcp.json

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,7 +23,7 @@ task dev:up       # Local dev with hot reload
 
 ## GitHub Actions
 
-- When adding a workflow shell command that calls a CLI or interpreter, explicitly install or set up that tool in the same job before using it. Do not assume runner images or JavaScript action runtimes expose tools on `PATH`.
+- Self-hosted runners are intentionally minimal. When adding a workflow shell command that calls a CLI or interpreter, explicitly install or set up that tool in the same job before using it. Do not assume runner images or JavaScript action runtimes expose tools on `PATH`.
 - Pin actions by full commit SHA and keep a version comment, matching the existing workflow style.
 - If a workflow calls `node`, add an explicit `actions/setup-node` step first.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,38 @@
+# Harbor Next Agent Notes
+
+Enhanced fork of [goharbor/harbor](https://github.com/goharbor/harbor). Go backend in `src/`, Angular frontend in `src/portal/`, build automation via Taskfile.
+
+## Commands
+
+```bash
+task build        # Build Go binaries
+task test:quick   # API lint + unit tests
+task test:ci      # Full CI pipeline
+task images       # Build/push Docker images
+task dev:up       # Local dev with hot reload
+```
+
+## PRs
+
+- Branch off `main`, never push direct.
+- Conventional Commits, capitalized subject: `feat: Add Foo`, `fix: Resolve Bar`, `upstream: Cherry-Pick Harbor Fix`.
+- DCO sign-off required: `git commit -s`.
+- Squash and merge only; other merge types break release-please.
+- No `Co-Authored-By` or AI attribution trailers.
+- New features (`feat:`) must add a `## Release Notes` section to the PR description. Its prose is extracted and rendered under `## Highlights` on the GitHub Release.
+
+## GitHub Actions
+
+- When adding a workflow shell command that calls a CLI or interpreter, explicitly install or set up that tool in the same job before using it. Do not assume runner images or JavaScript action runtimes expose tools on `PATH`.
+- Pin actions by full commit SHA and keep a version comment, matching the existing workflow style.
+- If a workflow calls `node`, add an explicit `actions/setup-node` step first.
+
+## Release-Please
+
+`main` uses `always-bump-minor`; `VERSION` on `main` tracks the next development release while `.release-please-manifest.json` tracks the published release. `release-X.Y` branches use patch-only versioning. `ci:`, `build:`, `chore:`, `test:` are hidden from release notes.
+
+**exclude-paths:** changes touching only `.github/`, `docs/`, or `tests/` don't bump version. Use `ci:` for CI-only changes.
+
+## Registry
+
+Default: `8gears.container-registry.com/8gcr/`. Override with `REGISTRY_ADDRESS` / `REGISTRY_PROJECT`. Publishing needs `REGISTRY_USERNAME` / `REGISTRY_PASSWORD` secrets.


### PR DESCRIPTION
## Summary

- Add an explicit `actions/setup-node` step before the Release Please workflow runs `node -e` to update `VERSION`.
- Track `AGENTS.md` in the repo and document that self-hosted runners are minimal, so every workflow CLI/interpreter must be installed or set up before use.

## Root Cause

The Release Please workflow used `node` from a shell step, but the self-hosted runner did not expose `node` on `PATH`. The action runtime can execute JavaScript actions, but workflow shell commands still need explicit tool setup.

## Testing

- `actionlint .github/workflows/release-please.yml`
- `git diff --check`
- `node -e "const fs = require('fs'); const manifest = JSON.parse(fs.readFileSync('.release-please-manifest.json', 'utf8')); const version = manifest['.']; if (!/^([0-9]+)\.([0-9]+)\.([0-9]+)$/.test(version)) process.exit(1);"`

## Release Notes

N/A - CI and agent documentation only.