### PR TITLE
feat(ci): Add Zizmor Workflow Audit

### DIFF
--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -1,0 +1,38 @@
+name: GitHub Actions Security Analysis
+
+on:
+  pull_request:
+    branches: ["**"]
+    paths:
+      - ".github/workflows/**"
+      - ".github/actions/**"
+      - ".github/dependabot.yml"
+  push:
+    branches: [main]
+    paths:
+      - ".github/workflows/**"
+      - ".github/actions/**"
+      - ".github/dependabot.yml"
+
+permissions: {}
+
+jobs:
+  zizmor:
+    name: Run zizmor
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - name: Run zizmor
+        uses: zizmorcore/zizmor-action@192e21d79ab29983730a13d1382995c2307fbcaa # v0.5.7
+        with:
+          inputs: .
+          online-audits: true
+          persona: regular


### PR DESCRIPTION
## Summary

- Add a dedicated `zizmor` workflow for GitHub Actions security analysis.
- Run it on PRs across all target branches when CI definitions change.
- Also run it on `main` pushes for baseline monitoring.
- Use least-privilege workflow permissions and SHA-pinned actions.

Closes #361

## Testing

- `actionlint .github/workflows/zizmor.yml`
- `.opencode/tmp/zizmor-1.26.1/zizmor --offline .github/workflows/zizmor.yml`
- `.opencode/tmp/zizmor-1.26.1/zizmor --offline --min-severity=medium .` surfaced existing baseline findings in other workflows/Dependabot config; this PR leaves those untouched.
