### PR TITLE
ci: Install Envsubst Before Cosign

### DIFF
--- a/.github/workflows/publish-images.yml
+++ b/.github/workflows/publish-images.yml
@@ -248,6 +248,9 @@ jobs:
       REGISTRY_PROJECT: ${{ inputs.registry_project }}
       IMAGE_TAG: ${{ inputs.image_tag }}
     steps:
+      - name: Install envsubst
+        run: command -v envsubst || (sudo apt-get update && sudo apt-get install -y gettext-base)
+
       - name: Install cosign
         uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
 


### PR DESCRIPTION
## Summary
- install gettext-base before running cosign-installer in the reusable publish-images workflow
- covers both latest image publishing and versioned release image publishing because both call publish-images.yml

## Testing
- actionlint .github/workflows/publish-images.yml