### PR TITLE
chore(ci): Remove word 'cherry-pick' from upstream sync pr title

### DIFF
--- a/.github/scripts/upstream-cherry-pick.sh
+++ b/.github/scripts/upstream-cherry-pick.sh
@@ -300,9 +300,9 @@ cherry_pick_commit() {
   upstream_subject="${pr_title:-${upstream_subject}}"
 
   if [ -n "${pr_number}" ]; then
-    pr_title_final="upstream: Cherry-Pick ${upstream_subject} (${UPSTREAM_REPO}#${pr_number})"
+    pr_title_final="upstream: ${upstream_subject} (${UPSTREAM_REPO}#${pr_number})"
   else
-    pr_title_final="upstream: Cherry-Pick ${upstream_subject}"
+    pr_title_final="upstream: ${upstream_subject}"
   fi
 
   echo "candidate: ${sha} ${upstream_subject}"


### PR DESCRIPTION
## Summary

<!-- Brief description of what this PR does -->
Optimize the pr title for merging in those prs. 

## Related Issues

<!-- Fixes #123 -->

## Type of Change

- [ ] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` / `fix!:`)
- [ ] Documentation (`docs:`)
- [ ] Refactoring (`refactor:`)
- [x] CI/CD or build changes (`ci:` / `build:`)
- [ ] Upstream Harbor cherry-pick (`upstream:`)
- [ ] Dependencies update (`chore:`)
- [ ] Tests (`test:`)

## Release Notes

<!--
Optional. Fill in for user-facing changes (new features, breaking changes, deprecations).
Leave blank for ci:/chore:/refactor:/docs:/test: PRs.
-->

## Testing

- [ ] Unit tests added/updated
- [ ] Manual testing performed

## Checklist

- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] Commits are signed off (`git commit -s`)
- [x] No new warnings introduced
