### PR TITLE
ci: Address Vulnerability Review Findings

### DIFF
--- a/.github/workflows/vulnerability-check.yml
+++ b/.github/workflows/vulnerability-check.yml
@@ -7,7 +7,6 @@ on:
 permissions:
   contents: read
   issues: write
-  pull-requests: write
 
 concurrency:
   group: vulnerability-check-${{ github.event.pull_request.number || github.ref }}
@@ -138,8 +137,14 @@ jobs:
           PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
           fixable_count=$(node -e "const fs = require('node:fs'); const summary = JSON.parse(fs.readFileSync('vulnerability-check/summary.json', 'utf8')); console.log(summary.fixableFindingCount || 0);")
-          comment_id=$(gh api "repos/${GITHUB_REPOSITORY}/issues/${PR_NUMBER}/comments" \
-            --jq 'map(select(.body | contains("<!-- harbor-next-vulnerability-check -->")))[0].id // ""')
+          comment_id=$(gh api --paginate --slurp "repos/${GITHUB_REPOSITORY}/issues/${PR_NUMBER}/comments" | node -e '
+          const fs = require("node:fs");
+          const pages = JSON.parse(fs.readFileSync(0, "utf8"));
+          const comments = pages.flat();
+          const comment = comments.find((item) => item.body?.includes("<!-- harbor-next-vulnerability-check -->"));
+          console.log(comment?.id || "");
+          '
+          )
 
           if [ "${fixable_count}" -eq 0 ]; then
             if [ -n "${comment_id}" ]; then
@@ -159,7 +164,7 @@ jobs:
               --field "body=${body}"
           fi
 
-      - uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5
+      - uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5.0.0
         if: always()
         with:
           name: vulnerability-check

--- a/.github/workflows/vulnerability-check.yml
+++ b/.github/workflows/vulnerability-check.yml
@@ -148,7 +148,9 @@ jobs:
 
           if [ "${fixable_count}" -eq 0 ]; then
             if [ -n "${comment_id}" ]; then
-              gh api "repos/${GITHUB_REPOSITORY}/issues/comments/${comment_id}" --method DELETE
+              gh api "repos/${GITHUB_REPOSITORY}/issues/comments/${comment_id}" --method DELETE || {
+                echo "Unable to delete stale vulnerability comment; continuing." >> "${GITHUB_STEP_SUMMARY}"
+              }
             fi
             exit 0
           fi
@@ -157,11 +159,15 @@ jobs:
           if [ -n "${comment_id}" ]; then
             gh api "repos/${GITHUB_REPOSITORY}/issues/comments/${comment_id}" \
               --method PATCH \
-              --field "body=${body}"
+              --field "body=${body}" || {
+                echo "Unable to update vulnerability comment; continuing." >> "${GITHUB_STEP_SUMMARY}"
+              }
           else
             gh api "repos/${GITHUB_REPOSITORY}/issues/${PR_NUMBER}/comments" \
               --method POST \
-              --field "body=${body}"
+              --field "body=${body}" || {
+                echo "Unable to create vulnerability comment; continuing." >> "${GITHUB_STEP_SUMMARY}"
+              }
           fi
 
       - uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5.0.0

--- a/tools/vulnerability-check/render-govulncheck-summary.mjs
+++ b/tools/vulnerability-check/render-govulncheck-summary.mjs
@@ -130,6 +130,22 @@ function traceLabel(trace) {
   return frame.function || frame.package || frame.module || 'N/A';
 }
 
+function appendFindingsTable(lines, findingsToRender, totalFindings, label) {
+  lines.push('| Vulnerability ID | Package | Found In | Fixed In | Description | Example Trace | Details |');
+  lines.push('| :--- | :--- | :--- | :--- | :--- | :--- | :--- |');
+  for (const finding of findingsToRender.slice(0, maxRows)) {
+    lines.push(`| ${markdown(finding.id)} | ${code(finding.packageName)} | ${code(finding.installedVersion)} | ${code(finding.fixedVersion)} | ${markdown(finding.description)} | ${code(finding.trace)} | [View](https://pkg.go.dev/vuln/${encodeURIComponent(finding.id)}) |`);
+  }
+  if (findingsToRender.length > maxRows) {
+    lines.push('');
+    lines.push(`_Showing ${maxRows} of ${findingsToRender.length} ${label}. See workflow artifacts for the full govulncheck JSON report._`);
+  }
+  if (findingsToRender.length !== totalFindings) {
+    lines.push('');
+    lines.push(`_Showing ${findingsToRender.length} of ${totalFindings} total findings._`);
+  }
+}
+
 const reportText = readText(reportPath);
 const parseResult = parseJSONStream(reportText);
 const messages = parseResult.messages;
@@ -155,7 +171,10 @@ for (const message of messages) {
   }
   const osv = osvByID.get(id);
   const trace = Array.isArray(finding.trace) ? finding.trace : [];
-  const moduleFrame = trace.find((frame) => frame.module && frame.module !== 'stdlib') || trace.find((frame) => frame.module) || null;
+  const affectedModules = new Set(
+    (osv?.affected || []).map((affected) => affected?.package?.name).filter(Boolean),
+  );
+  const moduleFrame = trace.find((frame) => frame?.module && affectedModules.has(frame.module)) || trace.find((frame) => frame?.module) || null;
   const packageName = moduleFrame?.module || fallbackModule(osv);
   const installedVersion = moduleFrame?.version || '';
   const key = `${id}\0${packageName}`;
@@ -173,7 +192,7 @@ for (const message of messages) {
 
 const findings = [...findingsByKey.values()].sort((a, b) => `${a.id}${a.packageName}`.localeCompare(`${b.id}${b.packageName}`));
 const fixableFindings = findings.filter((finding) => finding.fixedVersion);
-const scannerError = parseResult.errors.length > 0 || (exitCode !== 0 && findings.length === 0 && stderr.trim() !== '');
+const scannerError = parseResult.errors.length > 0 || Number.isNaN(exitCode) || (exitCode !== 0 && findings.length === 0);
 const renderedFindings = commentMode ? fixableFindings : findings;
 const lines = [marker, '<h2>🔒 Vulnerability Check Results</h2>', ''];
 
@@ -182,6 +201,12 @@ if (scannerError) {
   lines.push('');
   const details = parseResult.errors.length > 0 ? `Malformed govulncheck JSON: ${parseResult.errors.join('; ')}` : stderr;
   lines.push(code(shortText(details, 500)));
+  if (renderedFindings.length > 0) {
+    lines.push('');
+    lines.push(`⚠️ **Parsed vulnerability findings before scanner failure:** ${renderedFindings.length} of ${findings.length} found`);
+    lines.push('');
+    appendFindingsTable(lines, renderedFindings, findings.length, commentMode ? 'fixable vulnerabilities' : 'vulnerabilities');
+  }
 } else if (renderedFindings.length === 0) {
   if (commentMode && findings.length > 0) {
     lines.push(`ℹ️ No fixable vulnerabilities found. govulncheck reported ${findings.length} vulnerabilities without fixed versions.`);
@@ -191,29 +216,13 @@ if (scannerError) {
 } else if (commentMode) {
   lines.push(`⚠️ **Fixable vulnerabilities detected:** ${renderedFindings.length} of ${findings.length} found`);
   lines.push('');
-  lines.push('| Vulnerability ID | Package | Found In | Fixed In | Description | Example Trace | Details |');
-  lines.push('| :--- | :--- | :--- | :--- | :--- | :--- | :--- |');
-  for (const finding of renderedFindings.slice(0, maxRows)) {
-    lines.push(`| ${markdown(finding.id)} | ${code(finding.packageName)} | ${code(finding.installedVersion)} | ${code(finding.fixedVersion)} | ${markdown(finding.description)} | ${code(finding.trace)} | [View](https://pkg.go.dev/vuln/${encodeURIComponent(finding.id)}) |`);
-  }
-  if (renderedFindings.length > maxRows) {
-    lines.push('');
-    lines.push(`_Showing ${maxRows} of ${renderedFindings.length} fixable vulnerabilities. See workflow artifacts for the full govulncheck JSON report._`);
-  }
+  appendFindingsTable(lines, renderedFindings, findings.length, 'fixable vulnerabilities');
 } else if (findings.length === 0) {
   lines.push('✅ No vulnerabilities found.');
 } else {
   lines.push(`⚠️ **Vulnerabilities detected:** ${findings.length} found`);
   lines.push('');
-  lines.push('| Vulnerability ID | Package | Found In | Fixed In | Description | Example Trace | Details |');
-  lines.push('| :--- | :--- | :--- | :--- | :--- | :--- | :--- |');
-  for (const finding of findings.slice(0, maxRows)) {
-    lines.push(`| ${markdown(finding.id)} | ${code(finding.packageName)} | ${code(finding.installedVersion)} | ${code(finding.fixedVersion)} | ${markdown(finding.description)} | ${code(finding.trace)} | [View](https://pkg.go.dev/vuln/${encodeURIComponent(finding.id)}) |`);
-  }
-  if (findings.length > maxRows) {
-    lines.push('');
-    lines.push(`_Showing ${maxRows} of ${findings.length} vulnerabilities. See workflow artifacts for the full govulncheck JSON report._`);
-  }
+  appendFindingsTable(lines, findings, findings.length, 'vulnerabilities');
 }
 
 lines.push('');


### PR DESCRIPTION
## Summary

- reduce the PR vulnerability workflow token scope by dropping unused pull request write permission
- paginate vulnerability-check comment lookup so existing marker comments are found beyond the first page
- normalize the upload-artifact pinned action version comment
- attribute govulncheck findings to the affected OSV package before falling back to trace order
- fail closed when govulncheck exits non-zero without findings while preserving parsed findings for malformed partial output

## Related Issues

- Follow-up to #368
- Documents Zero CVE readiness in #372

## Type of Change

- [x] CI workflow fix
- [x] Security scanning hardening
- [ ] User-facing feature

## Release Notes

N/A. CI-only change.

## Testing

- actionlint .github/workflows/zero-cve.yml .github/workflows/vulnerability-check.yml
- git diff --check next/main..HEAD
- verified paginated GitHub comment lookup finds the existing vulnerability-check marker comment
- renderer smoke test: stdlib attribution remains on stdlib
- renderer smoke test: malformed partial JSON sets scannerError and preserves parsed findings
- renderer smoke test: non-zero empty scan fails closed