### PR TITLE
ci: Make Zero CVE Report Only

### DIFF
--- a/.github/workflows/zero-cve.yml
+++ b/.github/workflows/zero-cve.yml
@@ -307,10 +307,15 @@ jobs:
           path: ${{ env.ZERO_CVE_REPORT_DIR }}/
           if-no-files-found: warn
 
-      - name: Summarize zero-CVE findings
+      - name: Summarize zero-CVE status
         run: |
           node <<'NODE'
           const { readFileSync } = require('node:fs');
           const summary = JSON.parse(readFileSync('zero-cve-reports/summary.json', 'utf8'));
-          console.log(`Zero-CVE report completed: ${summary.remainingFindingCount} remaining findings, ${summary.scannerErrorCount} scanner errors.`);
+          const message = `Zero-CVE report: ${summary.findingCount} total findings, ${summary.fixedFindingCount} remediated, ${summary.remainingFindingCount} remaining, ${summary.scannerErrorCount} scanner errors.`;
+          console.log(message);
+          if (process.env.GITHUB_STEP_SUMMARY) {
+            const { appendFileSync } = require('node:fs');
+            appendFileSync(process.env.GITHUB_STEP_SUMMARY, `## Zero CVE Report\n\n${message}\n\n`);
+          }
           NODE

--- a/.github/workflows/zero-cve.yml
+++ b/.github/workflows/zero-cve.yml
@@ -311,7 +311,9 @@ jobs:
         run: |
           node <<'NODE'
           const { readFileSync } = require('node:fs');
-          const summary = JSON.parse(readFileSync('zero-cve-reports/summary.json', 'utf8'));
+          const { join } = require('node:path');
+          const reportDir = process.env.ZERO_CVE_REPORT_DIR || 'zero-cve-reports';
+          const summary = JSON.parse(readFileSync(join(reportDir, 'summary.json'), 'utf8'));
           const message = `Zero-CVE report: ${summary.findingCount} total findings, ${summary.fixedFindingCount} remediated, ${summary.remainingFindingCount} remaining, ${summary.scannerErrorCount} scanner errors.`;
           console.log(message);
           if (process.env.GITHUB_STEP_SUMMARY) {


### PR DESCRIPTION
## Summary

- replace the final Zero CVE failing gate with a non-failing status summary
- keep scans, remediation attempts, rolling PR updates, tracking issue updates, and report artifacts intact
- ensure remaining vulnerabilities and scanner-error counts are reported without failing the workflow

## Why

The latest main run completed scanning and updated the tracking issue, but failed only because the final gate exited non-zero for remaining vulnerabilities:

https://github.com/container-registry/harbor-next/actions/runs/28199140717/job/83533765703

Zero CVE should operate as reporting/tracking automation: it should list findings, update the issue/PR/report artifacts, and not fail simply because vulnerabilities are present.

## Related Issues

- Follow-up to #371

## Type of Change

- [x] CI workflow fix
- [x] Security scanning reporting change
- [ ] User-facing feature

## Release Notes

N/A. CI-only change.

## Testing

- actionlint .github/workflows/zero-cve.yml
- git diff --check