### PR TITLE
ci: Address CVE follow-up review comments

### DIFF
--- a/.github/actions/setup-task/action.yml
+++ b/.github/actions/setup-task/action.yml
@@ -14,7 +14,7 @@ runs:
       shell: bash
       env:
         TASK_VERSION: ${{ inputs.version }}
-      run: |
+      run: | # zizmor: ignore[github-env] Adds only this action's checksum-verified Task install directory to PATH.
         set -euo pipefail
 
         version="${TASK_VERSION}"
@@ -39,12 +39,8 @@ runs:
         curl -fsSL "https://github.com/go-task/task/releases/download/v${version}/task_checksums.txt" -o "${tool_dir}/task_checksums.txt"
         (cd "${tool_dir}" && grep "  ${archive}$" task_checksums.txt | sha256sum -c -)
         tar -xzf "${tool_dir}/${archive}" -C "${tool_dir}" task
-
-        if [ -w /usr/local/bin ]; then
-          install -m 0755 "${tool_dir}/task" /usr/local/bin/task
-        else
-          sudo install -m 0755 "${tool_dir}/task" /usr/local/bin/task
-        fi
+        install -m 0755 "${tool_dir}/task" "${tool_dir}/bin/task"
+        echo "${tool_dir}/bin" >> "${GITHUB_PATH}"
 
     - name: Verify Task
       shell: bash

--- a/dockerfile/portal.dockerfile
+++ b/dockerfile/portal.dockerfile
@@ -1,8 +1,6 @@
 # Dockerfile for Harbor Portal (Angular Frontend) on Nginx
 
 ARG BUN_VERSION=MISSING-BUILD-ARG
-ARG GO_VERSION=MISSING-BUILD-ARG
-ARG LPROBE_VERSION=MISSING-BUILD-ARG
 ARG NGINX_VERSION=MISSING-BUILD-ARG
 
 #
@@ -22,21 +20,9 @@ COPY LICENSE ./dist/LICENSE
 WORKDIR /harbor/src/portal/app-swagger-ui
 RUN bun install --ignore-scripts && bun run build
 
-#
-FROM --platform=$BUILDPLATFORM golang:${GO_VERSION}-alpine AS lprobe
-ARG LPROBE_VERSION
-ARG TARGETARCH
-ARG TARGETOS
-RUN apk add --no-cache git && \
-    git clone --branch v${LPROBE_VERSION} --depth 1 https://github.com/fivexl/lprobe.git /src/lprobe && \
-    cd /src/lprobe && \
-    go mod edit -require github.com/go-jose/go-jose/v4@v4.1.4 && \
-    go mod edit -require golang.org/x/net@v0.55.0 && \
-    go mod tidy -e && \
-    CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build -trimpath -o /lprobe .
-
 FROM 8gears.container-registry.com/dhi.io/nginx:${NGINX_VERSION}-debian13
-COPY --from=lprobe /lprobe /lprobe
+ARG TARGETARCH
+COPY bin/linux-${TARGETARCH}/lprobe /lprobe
 COPY --from=builder /harbor/src/portal/dist /usr/share/nginx/html
 COPY --from=builder /harbor/src/portal/app-swagger-ui/dist /usr/share/nginx/html
 COPY config/portal/nginx.conf /etc/nginx/nginx.conf

--- a/taskfile/image.yml
+++ b/taskfile/image.yml
@@ -175,7 +175,7 @@ tasks:
         vars:
           IMAGE_NAME: harbor-portal
           DOCKERFILE: portal.dockerfile
-          BUILD_ARGS: '--build-arg BUN_VERSION={{.BUN_VERSION}} --build-arg GO_VERSION={{.GO_VERSION}} --build-arg LPROBE_VERSION={{.LPROBE_VERSION}} --build-arg NGINX_VERSION={{.NGINX_VERSION}}'
+          BUILD_ARGS: '--build-arg BUN_VERSION={{.BUN_VERSION}} --build-arg NGINX_VERSION={{.NGINX_VERSION}}'
 
   registry:
     desc: "Build Distribution Registry image (compiles binary, then builds container)"


### PR DESCRIPTION
## Summary
- make portal consume the prebuilt lprobe helper artifact instead of rebuilding it during docker build
- keep setup-task non-privileged by installing to the runner temp tool path and exporting it via GITHUB_PATH
- document the intentional GITHUB_PATH write for zizmor

## Related Issues
- Follow-up to #374

## Testing
- actionlint .github/workflows/*.yml
- git diff --check
- rm -f bin/linux-amd64/lprobe && task image:portal PUSH=false
- go version -m bin/linux-amd64/registry | rg "github.com/distribution/distribution/v3"

## Release Notes
N/A: CI/image-build follow-up only.