### PR TITLE
ci: Restore PR write for backport suggestions

### DIFF
--- a/.github/workflows/backport-suggestion.yml
+++ b/.github/workflows/backport-suggestion.yml
@@ -8,6 +8,7 @@ on:
 permissions:
   contents: read
   issues: write
+  pull-requests: write
 
 jobs:
   suggest:


### PR DESCRIPTION
## Summary

Restore `pull-requests: write` for the Backport Suggestion workflow so `github-script` can create or update PR conversation comments again. The recent failures showed the workflow token receiving 403 responses from the issue comment API even though the job stayed green.

## Testing

- `actionlint .github/workflows/backport-suggestion.yml`
