### PR TITLE
fix(security): avoid audit event panic on nil user data

### DIFF
--- a/src/pkg/auditext/event/user/user.go
+++ b/src/pkg/auditext/event/user/user.go
@@ -73,12 +73,17 @@ func (u *userEventResolver) Resolve(ce *commonevent.Metadata, event *notifiereve
 	if ce.RequestMethod != http.MethodPut {
 		return nil
 	}
+	// base resolver leaves Data nil for a PUT that isn't on a specific user (e.g. the /users collection)
+	commonEvent, ok := event.Data.(*model.CommonEvent)
+	if !ok || commonEvent == nil {
+		return nil
+	}
 	// update operation description for update user password and add/remove user as system administrator
-	origin := event.Data.(*model.CommonEvent).OperationDescription
+	origin := commonEvent.OperationDescription
 	if strings.HasSuffix(ce.RequestURL, "/sysadmin") {
-		event.Data.(*model.CommonEvent).OperationDescription = origin + ", add/remove user as system administrator"
+		commonEvent.OperationDescription = origin + ", add/remove user as system administrator"
 	} else if strings.HasSuffix(ce.RequestURL, "/password") {
-		event.Data.(*model.CommonEvent).OperationDescription = origin + ", change user password"
+		commonEvent.OperationDescription = origin + ", change user password"
 	}
 	return nil
 }

--- a/src/pkg/auditext/event/user/user_resolve_test.go
+++ b/src/pkg/auditext/event/user/user_resolve_test.go
@@ -1,3 +1,17 @@
+// Copyright Project Harbor Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package user
 
 import (

--- a/src/pkg/auditext/event/user/user_resolve_test.go
+++ b/src/pkg/auditext/event/user/user_resolve_test.go
@@ -1,0 +1,39 @@
+package user
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/goharbor/harbor/src/common/rbac"
+	"github.com/goharbor/harbor/src/controller/event/metadata/commonevent"
+	"github.com/goharbor/harbor/src/pkg/auditext/event"
+	notifierevent "github.com/goharbor/harbor/src/pkg/notifier/event"
+)
+
+// TestResolvePutUsersCollectionNilData verifies Resolve handles a PUT whose URL
+// does not match a specific user id (the /api/v2.0/users collection). In that
+// case the base resolver returns without populating event.Data, so Resolve must
+// not dereference a nil event.Data.
+func TestResolvePutUsersCollectionNilData(t *testing.T) {
+	r := &userEventResolver{
+		Resolver: event.Resolver{
+			ResourceType:      rbac.ResourceUser.String(),
+			SucceedCodes:      []int{http.StatusCreated, http.StatusOK},
+			ResourceIDPattern: urlPattern,
+		},
+	}
+
+	ce := &commonevent.Metadata{
+		RequestMethod: http.MethodPut,
+		RequestURL:    "/api/v2.0/users", // collection path, no /{id}
+		ResponseCode:  http.StatusMethodNotAllowed,
+	}
+	evt := &notifierevent.Event{}
+
+	assert.NotPanics(t, func() {
+		err := r.Resolve(ce, evt)
+		assert.NoError(t, err)
+	})
+}

--- a/src/pkg/notifier/event/event.go
+++ b/src/pkg/notifier/event/event.go
@@ -16,6 +16,7 @@ package event
 
 import (
 	"context"
+	"runtime"
 
 	"github.com/goharbor/harbor/src/lib/errors"
 	"github.com/goharbor/harbor/src/lib/log"
@@ -100,6 +101,14 @@ func (e *Event) Publish(ctx context.Context) error {
 // The process is done in a separated goroutine
 func BuildAndPublish(ctx context.Context, metadata ...Metadata) {
 	go func() {
+		// a panic in this detached goroutine would otherwise crash the whole process
+		defer func() {
+			if err := recover(); err != nil {
+				buf := make([]byte, 1<<20)
+				size := runtime.Stack(buf, false)
+				log.Errorf("recovered from the panic when building and publishing event: %v; stack: %s", err, buf[0:size])
+			}
+		}()
 		event := &Event{}
 		if err := event.Build(ctx, metadata...); err != nil {
 			log.Errorf("failed to build the event from metadata: %v", err)


### PR DESCRIPTION
## Summary

Cherry-picks the upstream Harbor fix for a harbor-core denial-of-service in audit event handling.

A request such as unauthenticated `PUT /api/v2.0/users` can enter the user audit-event resolver on the `/api/v2.0/users` collection route. Because that URL does not include a concrete user id, the base resolver can leave `event.Data` unset. The user resolver then dereferenced `event.Data.(*model.CommonEvent)` inside the detached audit event publish path, which could panic and terminate `harbor-core`.

This PR keeps the user audit resolver nil-safe and adds a defensive `recover` around `BuildAndPublish` so a panic in the detached event goroutine cannot take down the process.

Upstream PR: https://github.com/goharbor/harbor/pull/23461
Reported PoC: https://gist.github.com/Aloui-Ikram/7d0535399ff8d66be779f6c3701fea7e

## Related Issues

Security report: unauthenticated `PUT /api/v2.0/users` can crash `harbor-core` through the audit-event goroutine.

## Type of Change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` / `fix!:`)
- [ ] Documentation (`docs:`)
- [ ] Refactoring (`refactor:`)
- [ ] CI/CD or build changes (`ci:` / `build:`)
- [x] Upstream Harbor cherry-pick (`upstream:`)
- [ ] Dependencies update (`chore:`)
- [x] Tests (`test:`)

## Release Notes

Fixed a denial-of-service issue where malformed user audit event metadata could panic in a detached audit-event goroutine and crash `harbor-core`.

## Testing

- [x] Unit tests added/updated
- [ ] Manual testing performed

Validation performed:

- `go test ./pkg/auditext/event/user ./pkg/notifier/event -count=1`

Manual end-to-end reproduction was not rerun locally; the reporter's PoC is linked above for security review context.

## Checklist

- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] Commits are signed off (`git commit -s`)
- [x] No new warnings introduced
