### PR TITLE
ci: Add Feature Notes To Release Notes

### DIFF
--- a/.github/scripts/format-commercial-patch.mjs
+++ b/.github/scripts/format-commercial-patch.mjs
@@ -7,10 +7,16 @@ if (!patchPath) {
 }
 
 const lines = readFileSync(patchPath, 'utf8').split(/\r?\n/);
-const subjectIndex = lines.findIndex(line => line.startsWith('Subject: '));
+let subjectIndex = lines.findIndex(line => line.startsWith('Subject: '));
+let includeBody = true;
 
 if (subjectIndex === -1) {
-  process.exit(0);
+  subjectIndex = lines.findIndex(line => line.trim() !== '');
+  includeBody = false;
+
+  if (subjectIndex === -1 || lines[subjectIndex].startsWith('From ')) {
+    process.exit(0);
+  }
 }
 
 const subject = lines[subjectIndex]
@@ -18,13 +24,16 @@ const subject = lines[subjectIndex]
   .replace(/^\[PATCH[^\]]*\]\s*/, '')
   .trim();
 
-let bodyStart = lines.findIndex((line, index) => index > subjectIndex && line === '');
-if (bodyStart === -1) {
-  bodyStart = subjectIndex;
+let bodyStart = subjectIndex;
+if (includeBody) {
+  bodyStart = lines.findIndex((line, index) => index > subjectIndex && line === '');
+  if (bodyStart === -1) {
+    bodyStart = subjectIndex;
+  }
 }
 
-const bodyEnd = lines.findIndex((line, index) => index > bodyStart && line === '---');
-const bodyLines = lines.slice(bodyStart + 1, bodyEnd === -1 ? lines.length : bodyEnd);
+const bodyEnd = includeBody ? lines.findIndex((line, index) => index > bodyStart && line === '---') : -1;
+const bodyLines = includeBody ? lines.slice(bodyStart + 1, bodyEnd === -1 ? lines.length : bodyEnd) : [];
 
 while (bodyLines.length > 0 && bodyLines[0].trim() === '') {
   bodyLines.shift();

--- a/.github/scripts/format-release-notes.mjs
+++ b/.github/scripts/format-release-notes.mjs
@@ -181,6 +181,10 @@ function releaseNotesLines(body) {
   return block;
 }
 
+function isReleasePleaseFooter(line) {
+  return line.trim() === '---' || line.startsWith('This PR was generated with [Release Please]');
+}
+
 for (const line of releaseNotesLines(releaseBody)) {
   if (line.startsWith('## ')) {
     continue;
@@ -214,7 +218,7 @@ for (const line of releaseNotesLines(releaseBody)) {
     continue;
   }
 
-  if (sawSection && line.trim()) {
+  if (sawSection && line.trim() && !isReleasePleaseFooter(line)) {
     trailing.push(line);
   }
 }
@@ -246,13 +250,13 @@ if (trailing.length > 0) {
 
 writeFileSync(outputPath, `${output.join('\n').trim()}\n`);
 
-// New Contributors is emitted as its own top-level `## New Contributors` section
-// by the release workflow, so it is written to a separate file rather than nested
-// under `## What's Changed`.
+// New Contributors is emitted after the release metadata separator by the
+// workflow, so it is written to a separate file rather than nested under
+// `## What's Changed`.
 if (contributorsPath) {
   const newContributors = generatedNotes.match(/## New Contributors[\s\S]*?(?=(?:\r?\n){2}\*\*Full Changelog\*\*|$)/)?.[0];
   writeFileSync(
     contributorsPath,
-    newContributors ? `${newContributors.replace(/^\* /gm, '- ').trim()}\n` : '',
+    newContributors ? `${newContributors.replace(/^## New Contributors$/m, '### New Contributors').replace(/^\* /gm, '- ').trim()}\n` : '',
   );
 }

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -282,16 +282,17 @@ jobs:
               printf '%s\n\n' "${HIGHLIGHTS}"
             fi
             cat "${FORMATTED_BODY}"
+            if [ -f applied-patches.txt ] && [ -s applied-patches.txt ]; then
+              echo ""
+              echo "### Commercial Features"
+              echo ""
+              echo "This release includes the following commercial enhancements:"
+              echo ""
+              cat applied-patches.txt
+            fi
             echo ""
             echo "---"
             echo ""
-            if [ -f applied-patches.txt ] && [ -s applied-patches.txt ]; then
-              echo "## Commercial Features"
-              echo ""
-              echo "This release includes the following commercial enhancements:"
-              cat applied-patches.txt
-              echo ""
-            fi
             echo "## Container Images"
             echo ""
             echo "Multi-arch images (\`linux/amd64\`, \`linux/arm64\`) signed with [cosign](https://github.com/sigstore/cosign)."

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -244,43 +244,7 @@ jobs:
             "${FORMATTED_BODY}" \
             "${CONTRIBUTORS}"
 
-          HIGHLIGHTS=""
-          git fetch --tags --force
-          PREV_TAG=$(git tag --merged HEAD --sort=-creatordate \
-            | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' \
-            | grep -v "^${TAG_NAME}$" \
-            | head -n 1 || true)
-          if [ -n "${PREV_TAG}" ]; then
-            SINCE=$(gh release view "${PREV_TAG}" --json createdAt -q '.createdAt')
-            SINCE_DATE="${SINCE%T*}"
-            HIGHLIGHTS=$(gh pr list \
-              --state merged \
-              --base "${RELEASE_BRANCH}" \
-              --search "merged:>=${SINCE_DATE}" \
-              --json number,title,url,body \
-              --limit 100 \
-              --jq '
-                [.[] | select(.body | test("(?m)^## Release Notes"))] |
-                if length == 0 then ""
-                else
-                  "## Highlights\n\n" +
-                  (map(
-                    "### [#\(.number)](\(.url)) \(.title)\n" +
-                    (.body |
-                      gsub("(?s).*\n## Release Notes\n"; "") |
-                      gsub("(?s)\n## .*"; "") |
-                      gsub("<!--[\\s\\S]*?-->"; "") |
-                      ltrimstr("\n") | rtrimstr("\n")
-                    ) + "\n"
-                  ) | join("\n"))
-                end
-              ')
-          fi
-
           {
-            if [ -n "${HIGHLIGHTS}" ]; then
-              printf '%s\n\n' "${HIGHLIGHTS}"
-            fi
             if [ -f applied-patches.txt ] && [ -s applied-patches.txt ]; then
               while IFS= read -r line; do
                 echo "${line}"

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -228,7 +228,7 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           REGISTRY="${REGISTRY_ADDRESS}/${REGISTRY_PROJECT}"
-          IMAGES="core jobservice registryctl exporter portal registry trivy-adapter"
+          IMAGES=(core jobservice registryctl exporter portal registry trivy-adapter)
           GENERATED_NOTES="$(mktemp)"
           RELEASE_BODY="$(mktemp)"
           FORMATTED_BODY="$(mktemp)"
@@ -269,7 +269,7 @@ jobs:
             echo ""
             echo "| Image | Reference |"
             echo "|-------|-----------|"
-            for image in $IMAGES; do
+            for image in "${IMAGES[@]}"; do
               image_name="harbor-${image}"
               if [ "${image}" = "trivy-adapter" ]; then
                 image_name="trivy-adapter"

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -281,14 +281,20 @@ jobs:
             if [ -n "${HIGHLIGHTS}" ]; then
               printf '%s\n\n' "${HIGHLIGHTS}"
             fi
-            cat "${FORMATTED_BODY}"
             if [ -f applied-patches.txt ] && [ -s applied-patches.txt ]; then
-              echo ""
-              echo "### Commercial Features"
-              echo ""
-              echo "This release includes the following commercial enhancements:"
-              echo ""
-              cat applied-patches.txt
+              while IFS= read -r line; do
+                echo "${line}"
+                if [ "${line}" = "## What's Changed" ]; then
+                  echo ""
+                  echo "### Commercial Features"
+                  echo ""
+                  echo "This release includes the following commercial enhancements:"
+                  echo ""
+                  cat applied-patches.txt
+                fi
+              done < "${FORMATTED_BODY}"
+            else
+              cat "${FORMATTED_BODY}"
             fi
             echo ""
             echo "---"


### PR DESCRIPTION
## Summary

- Keep commercial feature notes under `What's Changed` instead of after the release metadata separator.
- Preserve the existing formatter output for `Subject:` entries while also accepting first-line feature entries.

## Validation

- `node --check .github/scripts/format-commercial-patch.mjs`
- Smoke-tested `format-commercial-patch.mjs` with `Subject:` and first-line inputs.
- `actionlint .github/workflows/release-please.yml`