### PR TITLE
test: Isolate CSRF plaintext HTTP env

### DIFF
--- a/src/server/middleware/csrf/csrf_test.go
+++ b/src/server/middleware/csrf/csrf_test.go
@@ -79,6 +79,7 @@ func TestMiddlewareRejectsPlaintextHTTPOriginByDefault(t *testing.T) {
 		common.ExtEndpoint: "http://localhost:4500",
 	}
 	config.InitWithSettings(conf)
+	t.Setenv(csrfPlaintextHTTPEnv, "false")
 	resetMiddleware()
 	defer func() {
 		config.InitWithSettings(map[string]any{


### PR DESCRIPTION
## Summary
- Fixes #418 by explicitly setting `CSRF_PLAINTEXT_HTTP=false` in the CSRF default rejection test
- Keeps the change test-only; no runtime behavior is changed

## Validation
- `git diff --check next/main...HEAD`
- `go test ./server/middleware/csrf`
- `go test -c -tags db ./server/middleware/csrf`
