### PR TITLE
upstream: chore(deps-dev): bump pygments from 2.19.2 to 2.20.0 in /make/photon/prepare (goharbor/harbor#23053)

### DIFF
--- a/make/photon/prepare/Pipfile.lock
+++ b/make/photon/prepare/Pipfile.lock
@@ -1,0 +1,140 @@
+{
+    "_meta": {
+        "hash": {
+            "sha256": "d3a89b8575c29b9f822b892ffd31fd4a997effb1ebf3e3ed061a41e2d04b4490"
+        },
+        "pipfile-spec": 6,
+        "requires": {
+            "python_version": "3.13"
+        },
+        "sources": [
+            {
+                "name": "pypi",
+                "url": "https://pypi.org/simple",
+                "verify_ssl": true
+            }
+        ]
+    },
+    "default": {
+        "click": {
+            "hashes": [
+                "sha256:27c491cc05d968d271d5a1db13e3b5a184636d9d930f148c50b038f0d0646202",
+                "sha256:61a3265b914e850b85317d0b3109c7f8cd35a670f963866005d6ef1d5175a12b"
+            ],
+            "index": "pypi",
+            "markers": "python_version >= '3.10'",
+            "version": "==8.2.1"
+        },
+        "packaging": {
+            "hashes": [
+                "sha256:29572ef2b1f17581046b3a2227d5c611fb25ec70ca1ba8554b24b0e69331a484",
+                "sha256:d443872c98d677bf60f6a1f2f8c1cb748e8fe762d2bf9d3148b5599295b0fc4f"
+            ],
+            "index": "pypi",
+            "markers": "python_version >= '3.8'",
+            "version": "==25.0"
+        }
+    },
+    "develop": {
+        "astroid": {
+            "hashes": [
+                "sha256:104fb9cb9b27ea95e847a94c003be03a9e039334a8ebca5ee27dafaf5c5711eb",
+                "sha256:c332157953060c6deb9caa57303ae0d20b0fbdb2e59b4a4f2a6ba49d0a7961ce"
+            ],
+            "markers": "python_full_version >= '3.9.0'",
+            "version": "==3.3.10"
+        },
+        "dill": {
+            "hashes": [
+                "sha256:0633f1d2df477324f53a895b02c901fb961bdbf65a17122586ea7019292cbcf0",
+                "sha256:44f54bf6412c2c8464c14e8243eb163690a9800dbe2c367330883b19c7561049"
+            ],
+            "markers": "python_version >= '3.8'",
+            "version": "==0.4.0"
+        },
+        "iniconfig": {
+            "hashes": [
+                "sha256:3abbd2e30b36733fee78f9c7f7308f2d0050e88f0087fd25c2645f63c773e1c7",
+                "sha256:9deba5723312380e77435581c6bf4935c94cbfab9b1ed33ef8d238ea168eb760"
+            ],
+            "markers": "python_version >= '3.8'",
+            "version": "==2.1.0"
+        },
+        "isort": {
+            "hashes": [
+                "sha256:1cb5df28dfbc742e490c5e41bad6da41b805b0a8be7bc93cd0fb2a8a890ac450",
+                "sha256:2dc5d7f65c9678d94c88dfc29161a320eec67328bc97aad576874cb4be1e9615"
+            ],
+            "markers": "python_full_version >= '3.9.0'",
+            "version": "==6.0.1"
+        },
+        "mccabe": {
+            "hashes": [
+                "sha256:348e0240c33b60bbdf4e523192ef919f28cb2c3d7d5c7794f74009290f236325",
+                "sha256:6c2d30ab6be0e4a46919781807b4f0d834ebdd6c6e3dca0bda5a15f863427b6e"
+            ],
+            "markers": "python_version >= '3.6'",
+            "version": "==0.7.0"
+        },
+        "packaging": {
+            "hashes": [
+                "sha256:29572ef2b1f17581046b3a2227d5c611fb25ec70ca1ba8554b24b0e69331a484",
+                "sha256:d443872c98d677bf60f6a1f2f8c1cb748e8fe762d2bf9d3148b5599295b0fc4f"
+            ],
+            "index": "pypi",
+            "markers": "python_version >= '3.8'",
+            "version": "==25.0"
+        },
+        "platformdirs": {
+            "hashes": [
+                "sha256:3d512d96e16bcb959a814c9f348431070822a6496326a4be0911c40b5a74c2bc",
+                "sha256:ff7059bb7eb1179e2685604f4aaf157cfd9535242bd23742eadc3c13542139b4"
+            ],
+            "markers": "python_version >= '3.9'",
+            "version": "==4.3.8"
+        },
+        "pluggy": {
+            "hashes": [
+                "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3",
+                "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746"
+            ],
+            "markers": "python_version >= '3.9'",
+            "version": "==1.6.0"
+        },
+        "pygments": {
+            "hashes": [
+                "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f",
+                "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176"
+            ],
+            "index": "pypi",
+            "markers": "python_version >= '3.9'",
+            "version": "==2.20.0"
+        },
+        "pylint": {
+            "hashes": [
+                "sha256:2b11de8bde49f9c5059452e0c310c079c746a0a8eeaa789e5aa966ecc23e4559",
+                "sha256:43860aafefce92fca4cf6b61fe199cdc5ae54ea28f9bf4cd49de267b5195803d"
+            ],
+            "index": "pypi",
+            "markers": "python_full_version >= '3.9.0'",
+            "version": "==3.3.7"
+        },
+        "pytest": {
+            "hashes": [
+                "sha256:539c70ba6fcead8e78eebbf1115e8b589e7565830d7d006a8723f19ac8a0afb7",
+                "sha256:7c67fd69174877359ed9371ec3af8a3d2b04741818c51e5e99cc1742251fa93c"
+            ],
+            "index": "pypi",
+            "markers": "python_version >= '3.9'",
+            "version": "==8.4.1"
+        },
+        "tomlkit": {
+            "hashes": [
+                "sha256:430cf247ee57df2b94ee3fbe588e71d362a941ebb545dec29b53961d61add2a1",
+                "sha256:c89c649d79ee40629a9fda55f8ace8c6a1b42deb912b2a8fd8d942ddadb606b0"
+            ],
+            "markers": "python_version >= '3.8'",
+            "version": "==0.13.3"
+        }
+    }
+}


### PR DESCRIPTION
> This cherry-pick had conflicts and was opened as a draft. Conflict markers may be present in the diff and must be resolved before marking ready for review.

## Summary

Cherry-picks upstream Harbor commit `4a09f715e` from goharbor/harbor#23053.

## Upstream Context

- Upstream PR: goharbor/harbor#23053
- Upstream commit: 4a09f715e11179903073ae4184a20f46852488f7
- Upstream title: chore(deps-dev): bump pygments from 2.19.2 to 2.20.0 in /make/photon/prepare
- Upstream author: @app/dependabot
- Upstream merged by: @chlins
- Upstream approved by: @Vad1mo, @chlins
- Upstream PR URL: https://github.com/goharbor/harbor/pull/23053
- Upstream commit URL: https://github.com/goharbor/harbor/commit/4a09f715e11179903073ae4184a20f46852488f7

## Cherry-Pick Status

- Status: conflicted
- Base branch: main
- Workflow run: https://github.com/container-registry/harbor-next/actions/runs/local

## Upstream Description

Bumps [pygments](https://github.com/pygments/pygments) from 2.19.2 to 2.20.0.
<details>
<summary>Release notes</summary>
<p><em>Sourced from <a href="https://github.com/pygments/pygments/releases">pygments's releases</a>.</em></p>
<blockquote>
<h2>2.20.0</h2>
<ul>
<li>
<p>New lexers:</p>
<ul>
<li>Rell (<a href="https://redirect.github.com/pygments/pygments/issues/2914">#2914</a>)</li>
</ul>
</li>
<li>
<p>Updated lexers:</p>
<ul>
<li>archetype: Fix catastrophic backtracking in GUID and ID patterns (<a href="https://redirect.github.com/pygments/pygments/issues/3064">#3064</a>)</li>
<li>ASN.1: Recognize minus sign and fix range operator (<a href="https://redirect.github.com/pygments/pygments/issues/3014">#3014</a>, <a href="https://redirect.github.com/pygments/pygments/issues/3060">#3060</a>)</li>
<li>C++: Add C++26 keywords (<a href="https://redirect.github.com/pygments/pygments/issues/2955">#2955</a>), add integer literal suffixes (<a href="https://redirect.github.com/pygments/pygments/issues/2966">#2966</a>)</li>
<li>ComponentPascal: Fix <code>analyse_text</code> (<a href="https://redirect.github.com/pygments/pygments/issues/3028">#3028</a>, <a href="https://redirect.github.com/pygments/pygments/issues/3032">#3032</a>)</li>
<li>Coq renamed to Rocq (<a href="https://redirect.github.com/pygments/pygments/issues/2883">#2883</a>, <a href="https://redirect.github.com/pygments/pygments/issues/2908">#2908</a>)</li>
<li>Cython: Various improvements (<a href="https://redirect.github.com/pygments/pygments/issues/2932">#2932</a>, <a href="https://redirect.github.com/pygments/pygments/issues/2933">#2933</a>)</li>
<li>Debian control: Improve architecture parsing (<a href="https://redirect.github.com/pygments/pygments/issues/3052">#3052</a>)</li>
<li>Devicetree: Add support for overlay/fragments (<a href="https://redirect.github.com/pygments/pygments/issues/3021">#3021</a>), add bytestring support (<a href="https://redirect.github.com/pygments/pygments/issues/3022">#3022</a>), fix catastrophic backtracking (<a href="https://redirect.github.com/pygments/pygments/issues/3057">#3057</a>)</li>
<li>Fennel: Various improvements (<a href="https://redirect.github.com/pygments/pygments/issues/2911">#2911</a>)</li>
<li>Haskell: Handle escape sequences in character literals (<a href="https://redirect.github.com/pygments/pygments/issues/3069">#3069</a>, <a href="https://redirect.github.com/pygments/pygments/issues/1795">#1795</a>)</li>
<li>Java: Add module keywords (<a href="https://redirect.github.com/pygments/pygments/issues/2955">#2955</a>)</li>
<li>Lean4: Add operators <code>]'</code>, <code>]?</code>, <code>]!</code>  (<a href="https://redirect.github.com/pygments/pygments/issues/2946">#2946</a>)</li>
<li>LESS: Support single-line comments (<a href="https://redirect.github.com/pygments/pygments/issues/3005">#3005</a>)</li>
<li>LilyPond: Update to 2.25.29 (<a href="https://redirect.github.com/pygments/pygments/issues/2974">#2974</a>)</li>
<li>LLVM: Support C-style comments (<a href="https://redirect.github.com/pygments/pygments/issues/3023">#3023</a>, <a href="https://redirect.github.com/pygments/pygments/issues/2978">#2978</a>)</li>
<li>Lua(u): Fix catastrophic backtracking (<a href="https://redirect.github.com/pygments/pygments/issues/3047">#3047</a>)</li>
<li>Macaulay2: Update to 1.25.05 (<a href="https://redirect.github.com/pygments/pygments/issues/2893">#2893</a>), 1.25.11 (<a href="https://redirect.github.com/pygments/pygments/issues/2988">#2988</a>)</li>
<li>Mathematica: Various improvements (<a href="https://redirect.github.com/pygments/pygments/issues/2957">#2957</a>)</li>
<li>meson: Add additional operators (<a href="https://redirect.github.com/pygments/pygments/issues/2919">#2919</a>)</li>
<li>MySQL: Update keywords (<a href="https://redirect.github.com/pygments/pygments/issues/2970">#2970</a>)</li>
<li>org-Mode: Support both schedule and deadline (<a href="https://redirect.github.com/pygments/pygments/issues/2899">#2899</a>)</li>
<li>PH

[Upstream PR body truncated.]

## Review Notes

- Generated by the upstream cherry-pick workflow.
- One upstream commit maps to one Harbor Next PR.
- If this PR is closed without merge, the workflow will not recreate it.

Upstream-Commit: 4a09f715e11179903073ae4184a20f46852488f7
Upstream-PR: goharbor/harbor#23053
Cherry-Pick-Status: conflicted
