### PR TITLE
upstream: chore(deps): bump aquasecurity/trivy-action from 0.35.0 to 0.36.0 (goharbor/harbor#23191)

### DIFF
--- a/.github/workflows/nightly-trivy-scan.yml
+++ b/.github/workflows/nightly-trivy-scan.yml
@@ -1,0 +1,42 @@
+name: Trivy Nightly Scan
+on:
+  schedule:
+    - cron: '0 2 * * *' # run at 2 AM UTC
+
+
+jobs:
+  nightly-scan:
+    name: Trivy Scan nightly
+    strategy:
+      fail-fast: false
+      matrix:
+        # maintain the tags of harbor that need to be actively security scanned on a nightly basis,
+        # it is the image tags that need to be scanned in the dockerhub goharbor, for example: goharbor/harbor-core:dev, dev is the tag.
+        tags: [dev]
+        # list of images that need to be scanned
+        images: [harbor-core, harbor-db, harbor-exporter, harbor-jobservice, harbor-log, harbor-portal, harbor-registryctl, prepare, registry-photon, nginx-photon, valkey-photon, trivy-adapter-photon]
+    permissions:
+      security-events: write  # for github/codeql-action/upload-sarif to upload SARIF results
+
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+      - name: Run Trivy vulnerability scanner
+        # tag 0.35.0, get the commit hash from https://github.com/aquasecurity/trivy-action.git
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25
+        with:
+          image-ref: 'docker.io/goharbor/${{ matrix.images }}:${{ matrix.tags }}'
+          severity: 'CRITICAL,HIGH'
+          format: 'template'
+          template: '@/contrib/sarif.tpl'
+          output: 'trivy-results.sarif'
+        env:
+          # Use AWS' ECR mirror for the trivy-db image, as GitHub's Container
+          # Registry is returning a TOOMANYREQUESTS error.
+          # Ref: https://github.com/aquasecurity/trivy-action/issues/389
+          TRIVY_DB_REPOSITORY: 'public.ecr.aws/aquasecurity/trivy-db:2'
+      - name: Upload Trivy scan results to GitHub Security tab
+        uses: github/codeql-action/upload-sarif@v4
+        with:
+          sarif_file: 'trivy-results.sarif'


### PR DESCRIPTION
> This cherry-pick had workflow-file changes that were applied locally after rebasing the branch.

## Summary

Cherry-picks upstream Harbor commit `0c4a183e1` from goharbor/harbor#23191.

## Upstream Context

- Upstream PR: goharbor/harbor#23191
- Upstream commit: 0c4a183e189b0ee3e7b8b55bba42758288a21c55
- Upstream title: chore(deps): bump aquasecurity/trivy-action from 0.35.0 to 0.36.0
- Upstream author: @app/dependabot
- Upstream merged by: @chlins
- Upstream approved by: @Vad1mo, @chlins
- Upstream PR URL: https://github.com/goharbor/harbor/pull/23191
- Upstream commit URL: https://github.com/goharbor/harbor/commit/0c4a183e189b0ee3e7b8b55bba42758288a21c55

## Cherry-Pick Status

- Status: resolved
- Base branch: main
- Workflow run: https://github.com/container-registry/harbor-next/actions/runs/local

## Upstream Description

Bumps [aquasecurity/trivy-action](https://github.com/aquasecurity/trivy-action) from 0.35.0 to 0.36.0.
<details>
<summary>Release notes</summary>
<p><em>Sourced from <a href="https://github.com/aquasecurity/trivy-action/releases">aquasecurity/trivy-action's releases</a>.</em></p>
<blockquote>
<h2>v0.36.0</h2>
<h2>What's Changed</h2>
<ul>
<li>chore(ci): update bump-trivy workflow by <a href="https://github.com/DmitriyLewen"><code>@​DmitriyLewen</code></a> in <a href="https://redirect.github.com/aquasecurity/trivy-action/pull/546">aquasecurity/trivy-action#546</a></li>
<li>ci: use action.yaml as single source of truth for Trivy version by <a href="https://github.com/nikpivkin"><code>@​nikpivkin</code></a> in <a href="https://redirect.github.com/aquasecurity/trivy-action/pull/552">aquasecurity/trivy-action#552</a></li>
<li>ci: replace peter-evans/create-pull-request with gh CLI by <a href="https://github.com/nikpivkin"><code>@​nikpivkin</code></a> in <a href="https://redirect.github.com/aquasecurity/trivy-action/pull/550">aquasecurity/trivy-action#550</a></li>
<li>test: use pinned digests for trivy-db, trivy-java-db and trivy-checks by <a href="https://github.com/nikpivkin"><code>@​nikpivkin</code></a> in <a href="https://redirect.github.com/aquasecurity/trivy-action/pull/555">aquasecurity/trivy-action#555</a></li>
<li>ci: add dependabot config by <a href="https://github.com/nikpivkin"><code>@​nikpivkin</code></a> in <a href="https://redirect.github.com/aquasecurity/trivy-action/pull/556">aquasecurity/trivy-action#556</a></li>
<li>chore: add zizmor config by <a href="https://github.com/nikpivkin"><code>@​nikpivkin</code></a> in <a href="https://redirect.github.com/aquasecurity/trivy-action/pull/557">aquasecurity/trivy-action#557</a></li>
<li>chore(deps): bump the actions group with 5 updates by <a href="https://github.com/dependabot"><code>@​dependabot</code></a>[bot] in <a href="https://redirect.github.com/aquasecurity/trivy-action/pull/558">aquasecurity/trivy-action#558</a></li>
<li>fix: use portable shebang in entrypoint.sh by <a href="https://github.com/Hayao0819"><code>@​Hayao0819</code></a> in <a href="https://redirect.github.com/aquasecurity/trivy-action/pull/545">aquasecurity/trivy-action#545</a></li>
<li>Fix typo in GOOGLE_APPLICATION_CREDENTIALS env var name by <a href="https://github.com/patrik-csak"><code>@​patrik-csak</code></a> in <a href="https://redirect.github.com/aquasecurity/trivy-action/pull/547">aquasecurity/trivy-action#547</a></li>
<li>Upgrade Trivy action version from 0.33.1 to 0.35.0 fixes <a href="https://redirect.github.com/aquasecurity/trivy-action/issues/549">#549</a> by <a href="https://github.com/Aditya09-cse"><code>@​Aditya09-cse</code></a> in <a href="https://redirect.github.com/aquasecurity/trivy-action/pull/548">aquasecurity/trivy-action#548</a></li>
<li>chore: use GitHub Actions as git commit author in bump-trivy workflow by <a href="https://github.com/nikpivkin"><code>@​nikpivkin</code></a> in <a href="https://redirect.github.com/aquasecurity/trivy-action/pull/561">aquasecurity/trivy-action#561</a></li>
<li>chore(deps): Update trivy to v0.70.0 by <a href="https://github.com/Argon-DevOps-Mgt"><code>@​Argon-DevOps-Mgt</code></a> in <a href="https://redirect.github.com/aquasecurity/trivy-action/pull/559">aquasecurity/trivy-action#559</a></li>
<li>chore: update action version to v0.36.0 in examples by <a href="https://github.com/nikpivkin"><code>@​nikpivkin</code></a> in <a href="https://redirect.github.com/aquasecurity/trivy-action/pull/563">aquasecurity/trivy-action#563</a></li>
</ul>
<h2>New Contributors</h2>
<ul>
<li><a href="https://github.com/dependabot"><code>@​dependabot</code></a>[bot] made their first contribution in <a href="https://redirect.github.com/aquasecurity/trivy-action/pull/558">aquasecurity/trivy-action#558</a></li>
<li><a href="https://github.com/Hayao0819"><code>@​Hayao0819</code></a> made their first contribution in <a href="https://redirect.github.com/aquasecurity/trivy-ac

[Upstream PR body truncated.]

## Review Notes

- Generated by the upstream cherry-pick workflow.
- One upstream commit maps to one Harbor Next PR.
- If this PR is closed without merge, the workflow will not recreate it.

Upstream-Commit: 0c4a183e189b0ee3e7b8b55bba42758288a21c55
Upstream-PR: goharbor/harbor#23191
Cherry-Pick-Status: resolved