### PR TITLE
upstream: chore(deps): bump aws-actions/configure-aws-credentials from 5.1.1 to 6.2.1 (goharbor/harbor#23192)

### DIFF
--- a/upstream-patches/cherry-pick-23192-50facf858.github.patch
+++ b/upstream-patches/cherry-pick-23192-50facf858.github.patch
@@ -1,0 +1,498 @@
+diff --git a/.github/workflows/build-package.yml b/.github/workflows/build-package.yml
+new file mode 100644
+index 000000000..266459099
+--- /dev/null
++++ b/.github/workflows/build-package.yml
+@@ -0,0 +1,260 @@
++name: "Build Package Workflow"
++env:
++  DOCKER_COMPOSE_VERSION: 1.23.0
++
++on:
++  push:
++    branches:
++      - main
++      - release-*
++
++# Serialize runs per branch so concurrent pushes don't race when pushing the
++# shared mutable tags (dev / latest) and the multi-arch manifests. Queue rather
++# than cancel to avoid leaving a half-published set of images.
++concurrency:
++  group: build-package-${{ github.ref }}
++  cancel-in-progress: false
++
++jobs:
++  BUILD_BASE_IMAGE:
++    runs-on: ubuntu-latest
++    permissions:
++      contents: read
++    outputs:
++      build_base: ${{ steps.decide.outputs.build_base || 'false' }}
++    steps:
++      - uses: actions/checkout@v6
++      - uses: jitterbit/get-changed-files@v1
++        id: changed-files
++        continue-on-error: true
++        with:
++          format: space-delimited
++          token: ${{ secrets.GITHUB_TOKEN }}
++      - name: Decide whether to (re)build the base image
++        id: decide
++        if: |
++            steps.changed-files.outcome != 'success' ||
++            contains(steps.changed-files.outputs.modified, 'common/Dockerfile') ||
++            contains(steps.changed-files.outputs.modified, 'Dockerfile.base') ||
++            contains(steps.changed-files.outputs.modified, 'VERSION') ||
++            contains(steps.changed-files.outputs.modified, '.buildbaselog') ||
++            github.ref == 'refs/heads/main'
++        run: echo "build_base=true" >> "$GITHUB_OUTPUT"
++      - name: Set up QEMU
++        if: steps.decide.outputs.build_base == 'true'
++        uses: docker/setup-qemu-action@v3
++        with:
++          # Pin to a known-good binfmt image. The default "tonistiigi/binfmt:latest"
++          # has shipped broken releases that fail arm64 emulation with
++          # 'exec /bin/sh: no such file or directory' during container init.
++          image: tonistiigi/binfmt:qemu-v9.2.2
++          platforms: linux/amd64,linux/arm64
++      - name: Set up Docker Buildx
++        if: steps.decide.outputs.build_base == 'true'
++        uses: docker/setup-buildx-action@v3
++      - name: Build and push goharbor/photon:5.0 multi-arch manifest
++        if: steps.decide.outputs.build_base == 'true'
++        run: |
++          set -x
++          echo "${{ secrets.DOCKER_HUB_PASSWORD }}" | docker login -u "${{ secrets.DOCKER_HUB_USERNAME }}" --password-stdin
++          docker buildx build --platform linux/amd64,linux/arm64 \
++            -f make/photon/common/Dockerfile -t goharbor/photon:5.0 --push .
++          docker logout
++
++  BUILD_PACKAGE:
++    needs: [BUILD_BASE_IMAGE]
++    strategy:
++      fail-fast: false
++      matrix:
++        arch: [amd64, arm64]
++    env:
++        BUILD_PACKAGE: true
++        ARCH: ${{ matrix.arch }}
++        BUILD_BASE: ${{ needs.BUILD_BASE_IMAGE.outputs.build_base }}
++    runs-on: ${{ matrix.arch == 'arm64' && 'ubuntu-24.04-arm' || 'ubuntu-latest' }}
++    steps:
++      - name: Configure AWS credentials
++        uses: aws-actions/configure-aws-credentials@v6.2.1
++        with:
++          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
++          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
++          aws-region: us-east-1
++      - name: Set up Go
++        uses: actions/setup-go@v5
++        with:
++          go-version: 1.26.4
++        id: go
++      - name: Setup Docker
++        uses: docker-practice/actions-setup-docker@master
++        with:
++          docker_version: 20.10
++          docker_channel: stable
++      - uses: actions/checkout@v6
++      - uses: actions/checkout@v6
++        with:
++          path: src/github.com/goharbor/harbor
++      - name: Build Package
++        run: |
++          set -x
++          env
++          df -h
++          harbor_target_bucket=""
++          target_branch="$(echo ${GITHUB_REF#refs/heads/})"
++          harbor_offline_build_bundle=""
++          harbor_online_build_bundle=""
++          harbor_logs_bucket="harbor-ci-logs"
++          harbor_builds_bucket="harbor-builds"
++          harbor_releases_bucket="harbor-releases"
++          harbor_ci_pipeline_store_bucket="harbor-ci-pipeline-store/latest"
++          # the target release version is the version of next release(RC or GA). It needs to be updated on creating new release branch.
++          target_release_version=$(cat ./VERSION)
++          Harbor_Package_Version=$target_release_version-'build.'$GITHUB_RUN_NUMBER
++
++          if [[ $target_branch == "main" ]]; then
++            Harbor_Assets_Version=$Harbor_Package_Version
++            harbor_target_bucket=$harbor_builds_bucket
++          else
++            Harbor_Assets_Version=$target_release_version
++            harbor_target_bucket=$harbor_releases_bucket/$target_branch
++          fi
++
++          if [[ $target_branch == "release-"* ]]; then
++            Harbor_Build_Base_Tag=$target_release_version
++          else
++            Harbor_Build_Base_Tag=dev
++          fi
++
++          build_base_params=" BUILD_BASE=false"
++          cd src/github.com/goharbor/harbor
++          if [ -z "$BUILD_BASE"  ] || [ "$BUILD_BASE" != "true"  ]; then
++            echo "Do not need to build base images!"
++          else
++            # Use the locally built per-arch base, not the remote ":<tag>" manifest,
++            # which is only updated later in CREATE_MANIFEST and may be stale.
++            build_base_params=" BUILD_BASE=true PULL_BASE_FROM_DOCKERHUB=false PUSHBASEIMAGE=true REGISTRYUSER=\"${{ secrets.DOCKER_HUB_USERNAME }}\" REGISTRYPASSWORD=\"${{ secrets.DOCKER_HUB_PASSWORD }}\""
++          fi
++
++          sudo make package_offline ARCH=${ARCH} GOBUILDTAGS="include_oss include_gcs" BASEIMAGETAG=${Harbor_Build_Base_Tag} VERSIONTAG=${Harbor_Assets_Version} PKGVERSIONTAG=${Harbor_Package_Version} TRIVYFLAG=true EXPORTERFLAG=true HTTPPROXY= ${build_base_params}
++          sudo make package_online ARCH=${ARCH} GOBUILDTAGS="include_oss include_gcs" BASEIMAGETAG=${Harbor_Build_Base_Tag} VERSIONTAG=${Harbor_Assets_Version} PKGVERSIONTAG=${Harbor_Package_Version} TRIVYFLAG=true EXPORTERFLAG=true HTTPPROXY= ${build_base_params}
++
++          # fail before publishing if any image was built on a wrong-arch
++          # base (e.g. a stale base pulled from Docker Hub), which produces an
++          # image labeled ${ARCH} but containing binaries of another arch.
++          expected_base_arch=$([ "${ARCH}" = "arm64" ] && echo "aarch64" || echo "x86_64")
++          for img in $(docker images --format '{{.Repository}}:{{.Tag}}' | grep '^goharbor/' | grep -- "${Harbor_Assets_Version}" | grep -v '\-base'); do
++            base_label=$(docker inspect --format '{{index .Config.Labels "name"}}' "$img")
++            if [ -n "$base_label" ] && [[ "$base_label" != *"$expected_base_arch"* ]]; then
++              echo "ERROR: $img is built on a wrong-arch base: '$base_label' (expected *$expected_base_arch*)"
++              exit 1
++            fi
++          done
++
++          harbor_offline_build_bundle=$(basename harbor-offline-installer-*.tgz)
++          harbor_online_build_bundle=$(basename harbor-online-installer-*.tgz)
++          mv "${harbor_offline_build_bundle}" "harbor-offline-installer-${Harbor_Package_Version}-${ARCH}.tgz"
++          mv "${harbor_online_build_bundle}" "harbor-online-installer-${Harbor_Package_Version}-${ARCH}.tgz"
++          harbor_offline_build_bundle="harbor-offline-installer-${Harbor_Package_Version}-${ARCH}.tgz"
++          harbor_online_build_bundle="harbor-online-installer-${Harbor_Package_Version}-${ARCH}.tgz"
++
++          source tests/ci/build_util.sh
++          cp "${harbor_offline_build_bundle}"  "harbor-offline-installer-latest-${ARCH}.tgz"
++          cp "${harbor_online_build_bundle}"   "harbor-online-installer-latest-${ARCH}.tgz"
++          uploader "${harbor_offline_build_bundle}"                    $harbor_target_bucket
++          uploader "${harbor_online_build_bundle}"                     $harbor_target_bucket
++          uploader "harbor-offline-installer-latest-${ARCH}.tgz"      $harbor_target_bucket
++          uploader "harbor-online-installer-latest-${ARCH}.tgz"       $harbor_target_bucket
++          # Backwards compatibility: keep the unsuffixed legacy "latest" name
++          # pointing to amd64 (what it historically was) so existing downstream
++          # consumers that expect harbor-*-installer-latest.tgz don't break.
++          if [ "${ARCH}" = "amd64" ]; then
++            cp "${harbor_offline_build_bundle}"  "harbor-offline-installer-latest.tgz"
++            cp "${harbor_online_build_bundle}"   "harbor-online-installer-latest.tgz"
++            uploader "harbor-offline-installer-latest.tgz"             $harbor_target_bucket
++            uploader "harbor-online-installer-latest.tgz"              $harbor_target_bucket
++          fi
++          echo "BUILD_BUNDLE=${harbor_offline_build_bundle}" >> $GITHUB_ENV
++          echo "harbor_target_bucket=$harbor_target_bucket" >> $GITHUB_ENV
++
++          publishImage $target_branch $Harbor_Assets_Version "${{ secrets.DOCKER_HUB_USERNAME }}" "${{ secrets.DOCKER_HUB_PASSWORD }}" ${ARCH}
++      - name: Save repo list
++        run: |
++          { docker images --format '{{.Repository}}' | grep '^goharbor/' | grep -v '\-base' | grep -v '^goharbor/photon$' | grep -v '^goharbor/spectral$' | grep -v '^goharbor/swagger$' | grep -v '^goharbor/mockery$' || true; } | sort -u > "$GITHUB_WORKSPACE/_repos_${ARCH}.txt"
++          # base images are pushed arch-suffixed by the _build_base make macro
++          # and combined into multi-arch manifests by CREATE_MANIFEST. Derive the
++          # list from the Dockerfile.base directories (the source of truth) so it
++          # stays correct regardless of local image cleanup behavior.
++          if [ "$BUILD_BASE" = "true" ]; then
++            for d in make/photon/*/Dockerfile.base; do
++              component=$(basename "$(dirname "$d")")
++              echo "goharbor/harbor-${component}-base"
++            done | sort -u > "$GITHUB_WORKSPACE/_base_repos_${ARCH}.txt"
++          else
++            : > "$GITHUB_WORKSPACE/_base_repos_${ARCH}.txt"
++          fi
++      - name: Upload repo list
++        uses: actions/upload-artifact@v4
++        with:
++          name: repos-${{ matrix.arch }}
++          path: |
++            ${{ github.workspace }}/_repos_${{ matrix.arch }}.txt
++            ${{ github.workspace }}/_base_repos_${{ matrix.arch }}.txt
++
++  CREATE_MANIFEST:
++    needs: [BUILD_BASE_IMAGE, BUILD_PACKAGE]
++    runs-on: ubuntu-latest
++    permissions:
++      contents: read
++    steps:
++      - uses: actions/checkout@v6
++      - uses: actions/download-artifact@v4
++        with:
++          pattern: repos-*
++          merge-multiple: true
++      - name: Set up Docker Buildx
++        uses: docker/setup-buildx-action@v3
++      - name: Determine image tag
++        id: tag
++        run: |
++          target_branch="$(echo ${GITHUB_REF#refs/heads/})"
++          version=$(cat ./VERSION)
++          if [[ $target_branch == "main" ]]; then
++            echo "image_tag=dev" >> $GITHUB_OUTPUT
++          elif [[ $target_branch == "release-"* ]]; then
++            echo "image_tag=${version}-dev" >> $GITHUB_OUTPUT
++          else
++            echo "image_tag=${version}" >> $GITHUB_OUTPUT
++          fi
++          # base images use BASEIMAGETAG (see Harbor_Build_Base_Tag in BUILD_PACKAGE):
++          # "dev" on main, the release version on release-* branches
++          if [[ $target_branch == "release-"* ]]; then
++            echo "base_tag=${version}" >> $GITHUB_OUTPUT
++          else
++            echo "base_tag=dev" >> $GITHUB_OUTPUT
++          fi
++      - name: Login to Docker Hub
++        run: echo "${{ secrets.DOCKER_HUB_PASSWORD }}" | docker login -u "${{ secrets.DOCKER_HUB_USERNAME }}" --password-stdin
++      - name: Create multi-arch manifests
++        run: |
++          set -euo pipefail
++          image_tag="${{ steps.tag.outputs.image_tag }}"
++          cat _repos_*.txt | sort -u | while IFS= read -r repo; do
++            [ -z "$repo" ] && continue
++            echo "Creating manifest ${repo}:${image_tag}"
++            docker buildx imagetools create -t "${repo}:${image_tag}" \
++              "${repo}:${image_tag}-amd64" \
++              "${repo}:${image_tag}-arm64"
++          done
++          # The harbor-*-base images are only (re)built and pushed (arch-suffixed)
++          # when BUILD_BASE_IMAGE decided to rebuild the base; otherwise the
++          # suffixed tags from this run don't exist and there is nothing to combine.
++          if [ "${{ needs.BUILD_BASE_IMAGE.outputs.build_base }}" = "true" ]; then
++            base_tag="${{ steps.tag.outputs.base_tag }}"
++            cat _base_repos_*.txt | sort -u | while IFS= read -r repo; do
++              [ -z "$repo" ] && continue
++              echo "Creating manifest ${repo}:${base_tag}"
++              docker buildx imagetools create -t "${repo}:${base_tag}" \
++                "${repo}:${base_tag}-amd64" \
++                "${repo}:${base_tag}-arm64"
++            done
++          fi
++          docker logout
+diff --git a/.github/workflows/conformance_test.yml b/.github/workflows/conformance_test.yml
+new file mode 100644
+index 000000000..9e843b85c
+--- /dev/null
++++ b/.github/workflows/conformance_test.yml
+@@ -0,0 +1,67 @@
++name: CONFORMANCE_TEST
++env:
++  DOCKER_COMPOSE_VERSION: 1.23.0
++
++on:
++  repository_dispatch:
++    types:
++      - manual-trigger-conformance
++  schedule:
++    - cron: '0 6 * * *'
++
++jobs:
++  CONFORMANCE_TEST:
++    env:
++      CONFORMANCE_TEST: true
++    runs-on:
++      #- self-hosted
++      - oracle-vm-24cpu-96gb-x86-64
++    steps:
++      - name: Configure AWS credentials
++        uses: aws-actions/configure-aws-credentials@v6.2.1
++        with:
++          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
++          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
++          aws-region: us-east-1
++      - name: Set up Go 1.21
++        uses: actions/setup-go@v5
++        with:
++          go-version: 1.23.2
++        id: go
++      - uses: actions/checkout@v6
++        with:
++          path: src/github.com/goharbor/harbor
++      - name: before_install
++        run: |
++          set -x
++          cd src/github.com/goharbor/harbor
++          pwd
++          env
++          df -h
++          curl -L https://github.com/docker/compose/releases/download/${DOCKER_COMPOSE_VERSION}/docker-compose-`uname -s`-`uname -m` > docker-compose
++          chmod +x docker-compose
++          sudo mv docker-compose /usr/local/bin
++          IP=`hostname -I | awk '{print $1}'`
++          echo '{"insecure-registries" : ["'$IP':5000"]}' | sudo tee /etc/docker/daemon.json
++          echo "IP=$IP" >> $GITHUB_ENV
++          sudo cp ./tests/harbor_ca.crt /usr/local/share/ca-certificates/
++          sudo update-ca-certificates
++          sudo service docker restart
++      - name: install
++        run: |
++          cd src/github.com/goharbor/harbor
++          env
++          df -h
++          bash ./tests/showtime.sh ./tests/ci/api_common_install.sh $IP DB
++      - name: script
++        run: |
++          echo IP: $IP
++          df -h
++          cd src/github.com/goharbor/harbor
++          bash ./tests/showtime.sh ./tests/ci/conformance_test.sh $IP
++          df -h
++      - name: upload test result to gs
++        run: |
++          cd src/github.com/goharbor/harbor
++          aws s3 cp ./distribution-spec/conformance/report.html s3://harbor-conformance-test/report.html
++        if: always()
+diff --git a/.github/workflows/publish_release.yml b/.github/workflows/publish_release.yml
+new file mode 100644
+index 000000000..8afbdeecb
+--- /dev/null
++++ b/.github/workflows/publish_release.yml
+@@ -0,0 +1,153 @@
++name: Publish Release
++
++on:
++  push:
++    tags:
++      - 'v*.*.*'
++
++jobs:
++  release:
++    runs-on: ubuntu-latest
++    permissions:
++      contents: write   # Required for creating GitHub releases and uploading assets
++      id-token: write   # Required for Cosign keyless signing
++      packages: write   # Required for pushing images to ghcr.io
++    steps:
++      - uses: actions/checkout@v6
++      - name: Setup env
++        run: |
++          echo "CUR_TAG=${{ github.ref_name }}" >> $GITHUB_ENV
++          echo "BASE_TAG=$(cat ./VERSION)" >> $GITHUB_ENV
++          release=$(curl -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" -H "Accept: application/vnd.github.v3+json" https://api.github.com/repos/goharbor/harbor/releases/tags/${{ github.ref_name }})
++          echo "BUILD_NO=$(echo $release | jq -r '.body' | jq -r '.buildNo')" >> $GITHUB_ENV
++          echo "PRE_TAG=$(echo $release | jq -r '.body' | jq -r '.preTag')" >> $GITHUB_ENV
++          echo "BRANCH=$(echo $release | jq -r '.target_commitish')" >> $GITHUB_ENV
++          echo "PRERELEASE=$(echo $release | jq -r '.prerelease')" >> $GITHUB_ENV
++      - name: Configure AWS credentials
++        uses: aws-actions/configure-aws-credentials@v6.2.1
++        with:
++          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
++          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
++          aws-region: us-east-1
++      - name: Prepare Assets
++        run: |
++          if [ ! ${{ env.BUILD_NO }} -o ${{ env.BUILD_NO }} = "null" ]
++          then
++              echo "missing required parameter buildNo."
++              exit 1
++          fi
++          echo "buildNo:${{ env.BUILD_NO }}"
++          echo "preTag:${{ env.PRE_TAG }}"
++
++          base=${{ env.BASE_TAG }}
++          cur=${{ env.CUR_TAG }}
++          bucket=${{ secrets.HARBOR_RELEASE_BUILD }}
++          branch=${{ env.BRANCH }}
++          assets_path=$(pwd)/assets
++          mkdir -p "$assets_path"
++
++          for arch in amd64 arm64; do
++            src_offline=harbor-offline-installer-${base}-${{ env.BUILD_NO }}-${arch}.tgz
++            dst_offline=harbor-offline-installer-${cur}-${arch}.tgz
++            dst_online=
++            aws s3 cp s3://${bucket}/${branch}/${src_offline} s3://${bucket}/${branch}/${dst_offline}
++
++            if [ "${{ env.PRERELEASE }}" = "false" ]; then
++              src_online=harbor-online-installer-${base}-${{ env.BUILD_NO }}-${arch}.tgz
++              dst_online=harbor-online-installer-${cur}-${arch}.tgz
++              aws s3 cp s3://${bucket}/${branch}/${src_online} s3://${bucket}/${branch}/${dst_online}
++            fi
++            source tools/release/release_utils.sh && getAssets ${bucket} ${branch} ${dst_offline} ${dst_online} ${{ env.PRERELEASE }} ${assets_path}
++          done
++
++          echo "ASSETS_DIR=$assets_path" >> $GITHUB_ENV
++          echo "MD5SUM_PATH=$assets_path/md5sum" >> $GITHUB_ENV
++      - name: Install Cosign
++        uses: sigstore/cosign-installer@v4.0.0
++      - name: Sign Release Artifacts
++        run: |
++          cur=${{ env.CUR_TAG }}
++          for arch in amd64 arm64; do
++            cosign sign-blob --yes \
++              --bundle=${{ env.ASSETS_DIR }}/harbor-offline-installer-${cur}-${arch}.tgz.sigstore.json \
++              ${{ env.ASSETS_DIR }}/harbor-offline-installer-${cur}-${arch}.tgz
++
++            if [ "${{ env.PRERELEASE }}" = "false" ]; then
++              cosign sign-blob --yes \
++                --bundle=${{ env.ASSETS_DIR }}/harbor-online-installer-${cur}-${arch}.tgz.sigstore.json \
++                ${{ env.ASSETS_DIR }}/harbor-online-installer-${cur}-${arch}.tgz
++            fi
++          done
++      - name: Setup Docker
++        uses: docker-practice/actions-setup-docker@master
++        with:
++          docker_version: 20.10
++          docker_channel: stable
++      - name: Set up Docker Buildx
++        uses: docker/setup-buildx-action@v3
++      - name: Publish Images (amd64 + arm64)
++        run: |
++          set -euo pipefail
++          base=${{ env.BASE_TAG }}
++          cur=${{ env.CUR_TAG }}
++          : > "$GITHUB_WORKSPACE/_images_all.txt"
++
++          for arch in amd64 arm64; do
++            export ARCH="$arch"
++            tar -zxf "${{ env.ASSETS_DIR }}/harbor-offline-installer-${cur}-${arch}.tgz"
++            docker load -i ./harbor/harbor.${base}.tar.gz
++            images="$(docker images --format "{{.Repository}}" --filter=reference="goharbor/*:${base}" | xargs)"
++            echo "$images" | tr ' ' '\n' >> "$GITHUB_WORKSPACE/_images_all.txt"
++            source tools/release/release_utils.sh
++            publishImages "$cur" "$base" "${{ secrets.DOCKER_HUB_USERNAME }}" "${{ secrets.DOCKER_HUB_PASSWORD }}" $images
++            publishPackages "$cur" "$base" "${{ github.actor }}" "${{ secrets.GITHUB_TOKEN }}" $images
++            rm -rf harbor
++          done
++      - name: Create multi-arch manifests
++        run: |
++          set -euo pipefail
++          cur=${{ env.CUR_TAG }}
++          printf '%s\n' "${{ secrets.DOCKER_HUB_PASSWORD }}" | docker login -u "${{ secrets.DOCKER_HUB_USERNAME }}" --password-stdin
++          printf '%s\n' "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u "${{ github.actor }}" --password-stdin
++          sort -u "$GITHUB_WORKSPACE/_images_all.txt" | while IFS= read -r repo; do
++            [ -z "$repo" ] && continue
++            docker buildx imagetools create -t "${repo}:${cur}" \
++              "${repo}:${cur}-amd64" \
++              "${repo}:${cur}-arm64"
++            docker buildx imagetools create -t "ghcr.io/${repo}:${cur}" \
++              "ghcr.io/${repo}:${cur}-amd64" \
++              "ghcr.io/${repo}:${cur}-arm64"
++          done
++          docker logout ghcr.io
++          docker logout
++      - name: Generate release notes
++        run: |
++          release_notes_path=$(pwd)/release-notes.txt
++          source tools/release/release_utils.sh && generateReleaseNotes ${{ env.CUR_TAG }} ${{ env.PRE_TAG }} ${{ secrets.GITHUB_TOKEN }} $release_notes_path
++          echo "RELEASE_NOTES_PATH=$release_notes_path" >> $GITHUB_ENV
++      - name: RC Release
++        uses: softprops/action-gh-release@v2
++        if: ${{ env.PRERELEASE == 'true' }}
++        with:
++          body_path: ${{ env.RELEASE_NOTES_PATH }}
++          files: |
++            ${{ env.ASSETS_DIR }}/harbor-offline-installer-*-amd64.tgz
++            ${{ env.ASSETS_DIR }}/harbor-offline-installer-*-amd64.tgz.sigstore.json
++            ${{ env.ASSETS_DIR }}/harbor-offline-installer-*-arm64.tgz
++            ${{ env.ASSETS_DIR }}/harbor-offline-installer-*-arm64.tgz.sigstore.json
++            ${{ env.MD5SUM_PATH }}
++      - name: GA Release
++        uses: softprops/action-gh-release@v2
++        if: ${{ env.PRERELEASE == 'false' }}
++        with:
++          body_path: ${{ env.RELEASE_NOTES_PATH }}
++          files: |
++            ${{ env.ASSETS_DIR }}/harbor-offline-installer-*-amd64.tgz
++            ${{ env.ASSETS_DIR }}/harbor-offline-installer-*-amd64.tgz.sigstore.json
++            ${{ env.ASSETS_DIR }}/harbor-offline-installer-*-arm64.tgz
++            ${{ env.ASSETS_DIR }}/harbor-offline-installer-*-arm64.tgz.sigstore.json
++            ${{ env.ASSETS_DIR }}/harbor-online-installer-*-amd64.tgz
++            ${{ env.ASSETS_DIR }}/harbor-online-installer-*-amd64.tgz.sigstore.json
++            ${{ env.ASSETS_DIR }}/harbor-online-installer-*-arm64.tgz
++            ${{ env.ASSETS_DIR }}/harbor-online-installer-*-arm64.tgz.sigstore.json
++            ${{ env.MD5SUM_PATH }}


### PR DESCRIPTION
> This cherry-pick had conflicts and was opened as a draft. Conflict markers may be present in the diff and must be resolved before marking ready for review.

## Summary

Cherry-picks upstream Harbor commit `50facf858` from goharbor/harbor#23192.

## Upstream Context

- Upstream PR: goharbor/harbor#23192
- Upstream commit: 50facf858b6bfd17bd4d156ca9fb93c19baca54b
- Upstream title: chore(deps): bump aws-actions/configure-aws-credentials from 5.1.1 to 6.2.1
- Upstream author: @app/dependabot
- Upstream merged by: @chlins
- Upstream approved by: @Vad1mo, @chlins
- Upstream PR URL: https://github.com/goharbor/harbor/pull/23192
- Upstream commit URL: https://github.com/goharbor/harbor/commit/50facf858b6bfd17bd4d156ca9fb93c19baca54b

## Cherry-Pick Status

- Status: conflicted
- Base branch: main
- GitHub folder patch: `upstream-patches/cherry-pick-23192-50facf858.github.patch`
- Workflow run: https://github.com/container-registry/harbor-next/actions/runs/local

## Upstream Description

Bumps [aws-actions/configure-aws-credentials](https://github.com/aws-actions/configure-aws-credentials) from 5.1.1 to 6.2.1.
<details>
<summary>Release notes</summary>
<p><em>Sourced from <a href="https://github.com/aws-actions/configure-aws-credentials/releases">aws-actions/configure-aws-credentials's releases</a>.</em></p>
<blockquote>
<h2>v6.2.1</h2>
<h2><a href="https://github.com/aws-actions/configure-aws-credentials/compare/v6.2.0...v6.2.1">6.2.1</a> (2026-06-26)</h2>
<h3>Bug Fixes</h3>
<ul>
<li>enforce allowed-account-ids on all auth paths (<a href="https://redirect.github.com/aws-actions/configure-aws-credentials/issues/1847">#1847</a>) (<a href="https://github.com/aws-actions/configure-aws-credentials/commit/4d281fbc56a82e63c3fc14f2cc22361f34c97493">4d281fb</a>)</li>
</ul>
<h2>v6.2.0</h2>
<h2><a href="https://github.com/aws-actions/configure-aws-credentials/compare/v6.1.3...v6.2.0">6.2.0</a> (2026-06-01)</h2>
<h3>Features</h3>
<ul>
<li>add additional session tags by default (<a href="https://redirect.github.com/aws-actions/configure-aws-credentials/issues/1775">#1775</a>) (<a href="https://github.com/aws-actions/configure-aws-credentials/commit/e0ba7685077379a14a82d01fefd511490344ebfc">e0ba768</a>)</li>
<li>add more retry logic and better logging (<a href="https://redirect.github.com/aws-actions/configure-aws-credentials/issues/1764">#1764</a>) (<a href="https://github.com/aws-actions/configure-aws-credentials/commit/540d0c13aedb8d55501d220bd2f0b3cdedfe84e8">540d0c1</a>)</li>
<li>add regex validation to role-session-name (<a href="https://redirect.github.com/aws-actions/configure-aws-credentials/issues/1765">#1765</a>) (<a href="https://github.com/aws-actions/configure-aws-credentials/commit/e35449909c6ede5083a48ba4b8bbfaaa1cf09ba1">e354499</a>)</li>
<li>Allow custom session tags to be passed when assuming a role (<a href="https://redirect.github.com/aws-actions/configure-aws-credentials/issues/1759">#1759</a>) (<a href="https://github.com/aws-actions/configure-aws-credentials/commit/61f50f630f383628add73c1eab3f1935ba07da2b">61f50f6</a>)</li>
<li>expose run id in STS client user-agent (<a href="https://redirect.github.com/aws-actions/configure-aws-credentials/issues/1774">#1774</a>) (<a href="https://github.com/aws-actions/configure-aws-credentials/commit/29d1be30273e7ef371d59fccf6ec54572c64ec89">29d1be3</a>)</li>
<li>support custom STS endpoints (<a href="https://redirect.github.com/aws-actions/configure-aws-credentials/issues/1762">#1762</a>) (<a href="https://github.com/aws-actions/configure-aws-credentials/commit/8d52d05d7a4521fa52b39de50cb6114b12e5c332">8d52d05</a>)</li>
</ul>
<h3>Bug Fixes</h3>
<ul>
<li>skip credential check on output-env-credentials: false (<a href="https://redirect.github.com/aws-actions/configure-aws-credentials/issues/1778">#1778</a>) (<a href="https://github.com/aws-actions/configure-aws-credentials/commit/58e7c47adf77846879008deadfeeef8a6969fe6c">58e7c47</a>)</li>
<li>assumeRole failing from session tag size too large (<a href="https://redirect.github.com/aws-actions/configure-aws-credentials/issues/1808">#1808</a>) (<a href="https://github.com/aws-actions/configure-aws-credentials/commit/d6f5dc331b44474b19a52caaf85fa4d637b13c8e">d6f5dc3</a>)</li>
</ul>
<h2>v6.1.3</h2>
<h2><a href="https://github.com/aws-actions/configure-aws-credentials/compare/v6.1.2...v6.1.3">6.1.3</a> (2026-05-27)</h2>
<h3>Bug Fixes</h3>
<ul>
<li>fix: allow kubelet token symlink in <a href="https://redirect.github.com/aws-actions/configure-aws-credentials/pull/1805">aws-actions/configure-aws-credentials#1805</a></li>
</ul>
<h2>v6.1.2</h2>
<h2><a href="https://github.com/aws-actions/configure-aws-credentials/compare/v6.1.1...v6.1.2">6.1.2</a> (2026-05-26)</h2>
<h3>Bug Fixes</h3>
<ul>
<li>additional filesystem checks (<a href="https://redirect.github.com/aws-actions/configure-aws-credentials/issues/1799">#1799</a>) (<a href="https://github.com/aws-actions/configure-aws-credentials/commit/c39f282697aca8a78c522ecf1f7da9899

[Upstream PR body truncated.]

## Review Notes

- Generated by the upstream cherry-pick workflow.
- One upstream commit maps to one Harbor Next PR.
- Changes under `.github/` were written to `upstream-patches/cherry-pick-23192-50facf858.github.patch` because `GITHUB_TOKEN` cannot push workflow file updates.
- Apply the patch with `git apply upstream-patches/cherry-pick-23192-50facf858.github.patch` if those `.github/` changes should be carried forward.
- If this PR is closed without merge, the workflow will not recreate it.

Upstream-Commit: 50facf858b6bfd17bd4d156ca9fb93c19baca54b
Upstream-PR: goharbor/harbor#23192
Cherry-Pick-Status: conflicted
GitHub-Patch-File: upstream-patches/cherry-pick-23192-50facf858.github.patch
