### PR TITLE
upstream: chore(deps): bump sigstore/cosign-installer from 4.0.0 to 4.1.2 (goharbor/harbor#23193)

### DIFF
--- a/upstream-patches/cherry-pick-23193-d730cb495.github.patch
+++ b/upstream-patches/cherry-pick-23193-d730cb495.github.patch
@@ -1,0 +1,159 @@
+diff --git a/.github/workflows/publish_release.yml b/.github/workflows/publish_release.yml
+new file mode 100644
+index 000000000..75c8da353
+--- /dev/null
++++ b/.github/workflows/publish_release.yml
+@@ -0,0 +1,153 @@
++name: Publish Release
++
++on:
++  push:
++    tags:
++      - 'v*.*.*'
++
++jobs:
++  release:
++    runs-on: ubuntu-latest
++    permissions:
++      contents: write   # Required for creating GitHub releases and uploading assets
++      id-token: write   # Required for Cosign keyless signing
++      packages: write   # Required for pushing images to ghcr.io
++    steps:
++      - uses: actions/checkout@v6
++      - name: Setup env
++        run: |
++          echo "CUR_TAG=${{ github.ref_name }}" >> $GITHUB_ENV
++          echo "BASE_TAG=$(cat ./VERSION)" >> $GITHUB_ENV
++          release=$(curl -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" -H "Accept: application/vnd.github.v3+json" https://api.github.com/repos/goharbor/harbor/releases/tags/${{ github.ref_name }})
++          echo "BUILD_NO=$(echo $release | jq -r '.body' | jq -r '.buildNo')" >> $GITHUB_ENV
++          echo "PRE_TAG=$(echo $release | jq -r '.body' | jq -r '.preTag')" >> $GITHUB_ENV
++          echo "BRANCH=$(echo $release | jq -r '.target_commitish')" >> $GITHUB_ENV
++          echo "PRERELEASE=$(echo $release | jq -r '.prerelease')" >> $GITHUB_ENV
++      - name: Configure AWS credentials
++        uses: aws-actions/configure-aws-credentials@v6.2.1
++        with:
++          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
++          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
++          aws-region: us-east-1
++      - name: Prepare Assets
++        run: |
++          if [ ! ${{ env.BUILD_NO }} -o ${{ env.BUILD_NO }} = "null" ]
++          then
++              echo "missing required parameter buildNo."
++              exit 1
++          fi
++          echo "buildNo:${{ env.BUILD_NO }}"
++          echo "preTag:${{ env.PRE_TAG }}"
++
++          base=${{ env.BASE_TAG }}
++          cur=${{ env.CUR_TAG }}
++          bucket=${{ secrets.HARBOR_RELEASE_BUILD }}
++          branch=${{ env.BRANCH }}
++          assets_path=$(pwd)/assets
++          mkdir -p "$assets_path"
++
++          for arch in amd64 arm64; do
++            src_offline=harbor-offline-installer-${base}-${{ env.BUILD_NO }}-${arch}.tgz
++            dst_offline=harbor-offline-installer-${cur}-${arch}.tgz
++            dst_online=
++            aws s3 cp s3://${bucket}/${branch}/${src_offline} s3://${bucket}/${branch}/${dst_offline}
++
++            if [ "${{ env.PRERELEASE }}" = "false" ]; then
++              src_online=harbor-online-installer-${base}-${{ env.BUILD_NO }}-${arch}.tgz
++              dst_online=harbor-online-installer-${cur}-${arch}.tgz
++              aws s3 cp s3://${bucket}/${branch}/${src_online} s3://${bucket}/${branch}/${dst_online}
++            fi
++            source tools/release/release_utils.sh && getAssets ${bucket} ${branch} ${dst_offline} ${dst_online} ${{ env.PRERELEASE }} ${assets_path}
++          done
++
++          echo "ASSETS_DIR=$assets_path" >> $GITHUB_ENV
++          echo "MD5SUM_PATH=$assets_path/md5sum" >> $GITHUB_ENV
++      - name: Install Cosign
++        uses: sigstore/cosign-installer@v4.1.2
++      - name: Sign Release Artifacts
++        run: |
++          cur=${{ env.CUR_TAG }}
++          for arch in amd64 arm64; do
++            cosign sign-blob --yes \
++              --bundle=${{ env.ASSETS_DIR }}/harbor-offline-installer-${cur}-${arch}.tgz.sigstore.json \
++              ${{ env.ASSETS_DIR }}/harbor-offline-installer-${cur}-${arch}.tgz
++
++            if [ "${{ env.PRERELEASE }}" = "false" ]; then
++              cosign sign-blob --yes \
++                --bundle=${{ env.ASSETS_DIR }}/harbor-online-installer-${cur}-${arch}.tgz.sigstore.json \
++                ${{ env.ASSETS_DIR }}/harbor-online-installer-${cur}-${arch}.tgz
++            fi
++          done
++      - name: Setup Docker
++        uses: docker-practice/actions-setup-docker@master
++        with:
++          docker_version: 20.10
++          docker_channel: stable
++      - name: Set up Docker Buildx
++        uses: docker/setup-buildx-action@v3
++      - name: Publish Images (amd64 + arm64)
++        run: |
++          set -euo pipefail
++          base=${{ env.BASE_TAG }}
++          cur=${{ env.CUR_TAG }}
++          : > "$GITHUB_WORKSPACE/_images_all.txt"
++
++          for arch in amd64 arm64; do
++            export ARCH="$arch"
++            tar -zxf "${{ env.ASSETS_DIR }}/harbor-offline-installer-${cur}-${arch}.tgz"
++            docker load -i ./harbor/harbor.${base}.tar.gz
++            images="$(docker images --format "{{.Repository}}" --filter=reference="goharbor/*:${base}" | xargs)"
++            echo "$images" | tr ' ' '\n' >> "$GITHUB_WORKSPACE/_images_all.txt"
++            source tools/release/release_utils.sh
++            publishImages "$cur" "$base" "${{ secrets.DOCKER_HUB_USERNAME }}" "${{ secrets.DOCKER_HUB_PASSWORD }}" $images
++            publishPackages "$cur" "$base" "${{ github.actor }}" "${{ secrets.GITHUB_TOKEN }}" $images
++            rm -rf harbor
++          done
++      - name: Create multi-arch manifests
++        run: |
++          set -euo pipefail
++          cur=${{ env.CUR_TAG }}
++          printf '%s\n' "${{ secrets.DOCKER_HUB_PASSWORD }}" | docker login -u "${{ secrets.DOCKER_HUB_USERNAME }}" --password-stdin
++          printf '%s\n' "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u "${{ github.actor }}" --password-stdin
++          sort -u "$GITHUB_WORKSPACE/_images_all.txt" | while IFS= read -r repo; do
++            [ -z "$repo" ] && continue
++            docker buildx imagetools create -t "${repo}:${cur}" \
++              "${repo}:${cur}-amd64" \
++              "${repo}:${cur}-arm64"
++            docker buildx imagetools create -t "ghcr.io/${repo}:${cur}" \
++              "ghcr.io/${repo}:${cur}-amd64" \
++              "ghcr.io/${repo}:${cur}-arm64"
++          done
++          docker logout ghcr.io
++          docker logout
++      - name: Generate release notes
++        run: |
++          release_notes_path=$(pwd)/release-notes.txt
++          source tools/release/release_utils.sh && generateReleaseNotes ${{ env.CUR_TAG }} ${{ env.PRE_TAG }} ${{ secrets.GITHUB_TOKEN }} $release_notes_path
++          echo "RELEASE_NOTES_PATH=$release_notes_path" >> $GITHUB_ENV
++      - name: RC Release
++        uses: softprops/action-gh-release@v2
++        if: ${{ env.PRERELEASE == 'true' }}
++        with:
++          body_path: ${{ env.RELEASE_NOTES_PATH }}
++          files: |
++            ${{ env.ASSETS_DIR }}/harbor-offline-installer-*-amd64.tgz
++            ${{ env.ASSETS_DIR }}/harbor-offline-installer-*-amd64.tgz.sigstore.json
++            ${{ env.ASSETS_DIR }}/harbor-offline-installer-*-arm64.tgz
++            ${{ env.ASSETS_DIR }}/harbor-offline-installer-*-arm64.tgz.sigstore.json
++            ${{ env.MD5SUM_PATH }}
++      - name: GA Release
++        uses: softprops/action-gh-release@v2
++        if: ${{ env.PRERELEASE == 'false' }}
++        with:
++          body_path: ${{ env.RELEASE_NOTES_PATH }}
++          files: |
++            ${{ env.ASSETS_DIR }}/harbor-offline-installer-*-amd64.tgz
++            ${{ env.ASSETS_DIR }}/harbor-offline-installer-*-amd64.tgz.sigstore.json
++            ${{ env.ASSETS_DIR }}/harbor-offline-installer-*-arm64.tgz
++            ${{ env.ASSETS_DIR }}/harbor-offline-installer-*-arm64.tgz.sigstore.json
++            ${{ env.ASSETS_DIR }}/harbor-online-installer-*-amd64.tgz
++            ${{ env.ASSETS_DIR }}/harbor-online-installer-*-amd64.tgz.sigstore.json
++            ${{ env.ASSETS_DIR }}/harbor-online-installer-*-arm64.tgz
++            ${{ env.ASSETS_DIR }}/harbor-online-installer-*-arm64.tgz.sigstore.json
++            ${{ env.MD5SUM_PATH }}


### PR DESCRIPTION
> This cherry-pick had conflicts and was opened as a draft. Conflict markers may be present in the diff and must be resolved before marking ready for review.

## Summary

Cherry-picks upstream Harbor commit `d730cb495` from goharbor/harbor#23193.

## Upstream Context

- Upstream PR: goharbor/harbor#23193
- Upstream commit: d730cb495c6be516485e64b7cd7a25ecac51035c
- Upstream title: chore(deps): bump sigstore/cosign-installer from 4.0.0 to 4.1.2
- Upstream author: @app/dependabot
- Upstream merged by: @chlins
- Upstream approved by: @Vad1mo, @chlins
- Upstream PR URL: https://github.com/goharbor/harbor/pull/23193
- Upstream commit URL: https://github.com/goharbor/harbor/commit/d730cb495c6be516485e64b7cd7a25ecac51035c

## Cherry-Pick Status

- Status: conflicted
- Base branch: main
- GitHub folder patch: `upstream-patches/cherry-pick-23193-d730cb495.github.patch`
- Workflow run: https://github.com/container-registry/harbor-next/actions/runs/local

## Upstream Description

Bumps [sigstore/cosign-installer](https://github.com/sigstore/cosign-installer) from 4.0.0 to 4.1.2.
<details>
<summary>Release notes</summary>
<p><em>Sourced from <a href="https://github.com/sigstore/cosign-installer/releases">sigstore/cosign-installer's releases</a>.</em></p>
<blockquote>
<h2>v4.1.2</h2>
<h2>What's Changed</h2>
<ul>
<li>Bump cosign to 3.0.6 in <a href="https://redirect.github.com/sigstore/cosign-installer/pull/232">sigstore/cosign-installer#232</a></li>
</ul>
<h2>v4.1.1</h2>
<h2>What's Changed</h2>
<ul>
<li>chore: update default cosign-release to v3.0.5 in <a href="https://redirect.github.com/sigstore/cosign-installer/pull/223">sigstore/cosign-installer#223</a></li>
</ul>
<p><strong>Full Changelog</strong>: <a href="https://github.com/sigstore/cosign-installer/compare/v4.1.0...v4.1.1">https://github.com/sigstore/cosign-installer/compare/v4.1.0...v4.1.1</a></p>
<h2>v4.1.0</h2>
<h2>What's Changed</h2>
<p>We recommend updating as soon as possible as this includes bug fixes for Cosign. We also recommend removing <code>with: cosign-release</code> and strongly discourage using <code>cosign-release</code> unless you have a specific reason to use an older version of Cosign.</p>
<ul>
<li>Bump cosign to 3.0.5 in <a href="https://redirect.github.com/sigstore/cosign-installer/pull/220">sigstore/cosign-installer#220</a></li>
<li>fix: add retry to curl downloads for transient network failures in <a href="https://redirect.github.com/sigstore/cosign-installer/pull/210">sigstore/cosign-installer#210</a></li>
</ul>
<p><strong>Full Changelog</strong>: <a href="https://github.com/sigstore/cosign-installer/compare/v4.0.0...v4.1.0">https://github.com/sigstore/cosign-installer/compare/v4.0.0...v4.1.0</a></p>
</blockquote>
</details>
<details>
<summary>Commits</summary>
<ul>
<li><a href="https://github.com/sigstore/cosign-installer/commit/6f9f17788090df1f26f669e9d70d6ae9567deba6"><code>6f9f177</code></a> Bump cosign to 3.0.6 (<a href="https://redirect.github.com/sigstore/cosign-installer/issues/232">#232</a>)</li>
<li><a href="https://github.com/sigstore/cosign-installer/commit/b5e753ae2d39589c7b38850b463739151fc67f07"><code>b5e753a</code></a> Bump actions/github-script from 8.0.0 to 9.0.0 (<a href="https://redirect.github.com/sigstore/cosign-installer/issues/230">#230</a>)</li>
<li><a href="https://github.com/sigstore/cosign-installer/commit/115e4ce455e573aa6e9ba51e8d040ddd5c1378af"><code>115e4ce</code></a> Bump actions/setup-go from 6.3.0 to 6.4.0 (<a href="https://redirect.github.com/sigstore/cosign-installer/issues/226">#226</a>)</li>
<li><a href="https://github.com/sigstore/cosign-installer/commit/cad07c2e89fa2edd6e2d7bab4c1aa38e53f76003"><code>cad07c2</code></a> chore: update default cosign-release to v3.0.5 (<a href="https://redirect.github.com/sigstore/cosign-installer/issues/223">#223</a>)</li>
<li><a href="https://github.com/sigstore/cosign-installer/commit/ba7bc0a3fef59531c69a25acd34668d6d3fe6f22"><code>ba7bc0a</code></a> fix: add retry to curl downloads for transient network failures (<a href="https://redirect.github.com/sigstore/cosign-installer/issues/210">#210</a>)</li>
<li><a href="https://github.com/sigstore/cosign-installer/commit/5a292e1504fdf08d68831aa1d265e92aee5701f9"><code>5a292e1</code></a> Bump cosign to 3.0.5 (<a href="https://redirect.github.com/sigstore/cosign-installer/issues/220">#220</a>)</li>
<li><a href="https://github.com/sigstore/cosign-installer/commit/351ea76151ae2dbbf52374c9dd639f4981de944f"><code>351ea76</code></a> Bump actions/checkout from 6.0.1 to 6.0.2 (<a href="https://redirect.github.com/sigstore/cosign-installer/issues/217">#217</a>)</li>
<li><a href="https://github.com/sigstore/cosign-installer/commit/c17565ff322a3403de48978f18d9ee0cfa7c2cd5"><code>c17565f</code></a> test with go 1.26 too (<a href="https://redirect.github.com/sigstore/cosign-installer/issues/221">#221</a>)</li>
<li><a href="https://github.com/sigstore/cosign-installer/commit/a6fdd19182ff7fb86ae39a9329ba29eb602cbabb"><c

[Upstream PR body truncated.]

## Review Notes

- Generated by the upstream cherry-pick workflow.
- One upstream commit maps to one Harbor Next PR.
- Changes under `.github/` were written to `upstream-patches/cherry-pick-23193-d730cb495.github.patch` because `GITHUB_TOKEN` cannot push workflow file updates.
- Apply the patch with `git apply upstream-patches/cherry-pick-23193-d730cb495.github.patch` if those `.github/` changes should be carried forward.
- If this PR is closed without merge, the workflow will not recreate it.

Upstream-Commit: d730cb495c6be516485e64b7cd7a25ecac51035c
Upstream-PR: goharbor/harbor#23193
Cherry-Pick-Status: conflicted
GitHub-Patch-File: upstream-patches/cherry-pick-23193-d730cb495.github.patch
