### PR TITLE
upstream: Fix/api completeness (goharbor/harbor#23476)

### DIFF
--- a/.spectral.yaml
+++ b/.spectral.yaml
@@ -32,3 +32,19 @@ rules:
     then:
       field: parameters
       function: requireRequestId
+
+  operation-description:
+    description: Every operation must have a description field.
+    given: $.paths[*][*]
+    severity: error
+    then:
+      field: description
+      function: truthy
+
+  operation-summary-required:
+    description: Every operation must have a summary field.
+    given: $.paths[*][*]
+    severity: error
+    then:
+      field: summary
+      function: truthy

--- a/api/v2.0/swagger.yaml
+++ b/api/v2.0/swagger.yaml
@@ -222,7 +222,7 @@ paths:
         '403':
           description: User does not have permission of admin role.
         '500':
-          description: Unexpected internal errors.
+          $ref: '#/responses/500'
   /configurations:
     get:
       summary: Get system configurations.
@@ -262,12 +262,16 @@ paths:
       responses:
         '200':
           description: Modify system configurations successfully.
+        '400':
+          $ref: '#/responses/400'
         '401':
-          description: User need to log in first.
+          $ref: '#/responses/401'
         '403':
-          description: User does not have permission of admin role.
+          $ref: '#/responses/403'
+        '422':
+          $ref: '#/responses/422'
         '500':
-          description: Unexpected internal errors.
+          $ref: '#/responses/500'
   /projects:
     get:
       summary: List projects
@@ -316,8 +320,12 @@ paths:
             Link:
               description: Link refers to the previous page and next page
               type: string
+        '400':
+          $ref: '#/responses/400'
         '401':
           $ref: '#/responses/401'
+        '422':
+          $ref: '#/responses/422'
         '500':
           $ref: '#/responses/500'
     head:
@@ -365,7 +373,13 @@ paths:
         '401':
           $ref: '#/responses/401'
         '409':
-          $ref: '#/responses/409'
+          description: Project name already exists.
+          headers:
+            X-Request-Id:
+              description: The ID of the corresponding request for the response
+              type: string
+          schema:
+            $ref: '#/definitions/Errors'
         '500':
           $ref: '#/responses/500'
   '/projects/{project_name_or_id}':
@@ -386,6 +400,16 @@ paths:
             $ref: '#/definitions/Project'
         '401':
           $ref: '#/responses/401'
+        '403':
+          $ref: '#/responses/403'
+        '404':
+          description: Project not found. No project exists with the specified name or ID.
+          headers:
+            X-Request-Id:
+              description: The ID of the corresponding request for the response
+              type: string
+          schema:
+            $ref: '#/definitions/Errors'
         '500':
           $ref: '#/responses/500'
     put:
@@ -435,9 +459,21 @@ paths:
         '403':
           $ref: '#/responses/403'
         '404':
-          $ref: '#/responses/404'
+          description: Project not found. No project exists with the specified name or ID.
+          headers:
+            X-Request-Id:
+              description: The ID of the corresponding request for the response
+              type: string
+          schema:
+            $ref: '#/definitions/Errors'
         '412':
-          $ref: '#/responses/412'
+          description: Project cannot be deleted. The project still contains repositories or has pending tasks.
+          headers:
+            X-Request-Id:
+              description: The ID of the corresponding request for the response
+              type: string
+          schema:
+            $ref: '#/definitions/Errors'
         '500':
           $ref: '#/responses/500'
   /projects/{project_name_or_id}/_deletable:
@@ -630,6 +666,7 @@ paths:
           $ref: '#/responses/500'
     delete:
       summary: Delete project member
+      description: Remove the specified project member from the project.
       operationId: deleteProjectMember
       tags:
         - member
@@ -652,6 +689,8 @@ paths:
           $ref: '#/responses/401'
         '403':
           $ref: '#/responses/403'
+        '404':
+          $ref: '#/responses/404'
         '500':
           $ref: '#/responses/500'
   '/projects/{project_name_or_id}/metadatas/':
@@ -879,6 +918,8 @@ paths:
           $ref: '#/responses/403'
         '404':
           $ref: '#/responses/404'
+        '422':
+          $ref: '#/responses/422'
         '500':
           $ref: '#/responses/500'
   /projects/{project_name}/repositories/{repository_name}:
@@ -904,7 +945,13 @@ paths:
         '403':
           $ref: '#/responses/403'
         '404':
-          $ref: '#/responses/404'
+          description: Repository not found. No repository with the specified name exists in this project.
+          headers:
+            X-Request-Id:
+              description: The ID of the corresponding request for the response
+              type: string
+          schema:
+            $ref: '#/definitions/Errors'
         '500':
           $ref: '#/responses/500'
     put:
@@ -956,7 +1003,21 @@ paths:
         '403':
           $ref: '#/responses/403'
         '404':
-          $ref: '#/responses/404'
+          description: Repository not found. No repository with the specified name exists in this project.
+          headers:
+            X-Request-Id:
+              description: The ID of the corresponding request for the response
+              type: string
+          schema:
+            $ref: '#/definitions/Errors'
+        '412':
+          description: Precondition failed. The repository contains images protected by an immutable tag rule and cannot be deleted.
+          headers:
+            X-Request-Id:
+              description: The ID of the corresponding request for the response
+              type: string
+          schema:
+            $ref: '#/definitions/Errors'
         '500':
           $ref: '#/responses/500'
   /projects/{project_name}/repositories/{repository_name}/artifacts:
@@ -1032,7 +1093,15 @@ paths:
         '403':
           $ref: '#/responses/403'
         '404':
-          $ref: '#/responses/404'
+          description: Repository or project not found.
+          headers:
+            X-Request-Id:
+              description: The ID of the corresponding request for the response
+              type: string
+          schema:
+            $ref: '#/definitions/Errors'
+        '422':
+          $ref: '#/responses/422'
         '500':
           $ref: '#/responses/500'
     post:
@@ -1060,7 +1129,13 @@ paths:
         '403':
           $ref: '#/responses/403'
         '404':
-          $ref: '#/responses/404'
+          description: Source artifact or target repository not found.
+          headers:
+            X-Request-Id:
+              description: The ID of the corresponding request for the response
+              type: string
+          schema:
+            $ref: '#/definitions/Errors'
         '405':
           $ref: '#/responses/405'
         '500':
@@ -1135,7 +1210,13 @@ paths:
         '403':
           $ref: '#/responses/403'
         '404':
-          $ref: '#/responses/404'
+          description: Artifact not found. No artifact exists for the given reference in this project and repository.
+          headers:
+            X-Request-Id:
+              description: The ID of the corresponding request for the response
+              type: string
+          schema:
+            $ref: '#/definitions/Errors'
         '500':
           $ref: '#/responses/500'
     delete:
@@ -1157,7 +1238,13 @@ paths:
         '403':
           $ref: '#/responses/403'
         '404':
-          $ref: '#/responses/404'
+          description: Artifact not found. No artifact with the specified reference exists in this repository.
+          headers:
+            X-Request-Id:
+              description: The ID of the corresponding request for the response
+              type: string
+          schema:
+            $ref: '#/definitions/Errors'
         '500':
           $ref: '#/responses/500'
   /projects/{project_name}/repositories/{repository_name}/artifacts/{reference}/scan:
@@ -1187,9 +1274,21 @@ paths:
         '403':
           $ref: '#/responses/403'
         '404':
-          $ref: '#/responses/404'
+          description: Artifact not found. No artifact with the specified reference exists in this repository.
+          headers:
+            X-Request-Id:
+              description: The ID of the corresponding request for the response
+              type: string
+          schema:
+            $ref: '#/definitions/Errors'
         '422':
-          $ref: '#/responses/422'
+          description: The artifact does not support scanning (for example, it is an image index with no directly scannable layers).
+          headers:
+            X-Request-Id:
+              description: The ID of the corresponding request for the response
+              type: string
+          schema:
+            $ref: '#/definitions/Errors'
         '500':
           $ref: '#/responses/500'
   /projects/{project_name}/repositories/{repository_name}/artifacts/{reference}/scan/stop:
@@ -1287,11 +1386,23 @@ paths:
         '403':
           $ref: '#/responses/403'
         '404':
-          $ref: '#/responses/404'
+          description: The artifact specified by the reference does not exist.
+          headers:
+            X-Request-Id:
+              description: The ID of the corresponding request for the response
+              type: string
+          schema:
+            $ref: '#/definitions/Errors'
         '405':
           $ref: '#/responses/405'
         '409':
-          $ref: '#/responses/409'
+          description: A tag with this name already exists on the artifact.
+          headers:
+            X-Request-Id:
+              description: The ID of the corresponding request for the response
+              type: string
+          schema:
+            $ref: '#/definitions/Errors'
         '500':
           $ref: '#/responses/500'
     get:
@@ -1337,6 +1448,8 @@ paths:
           $ref: '#/responses/403'
         '404':
           $ref: '#/responses/404'
+        '422':
+          $ref: '#/responses/422'
         '500':
           $ref: '#/responses/500'
   /projects/{project_name}/repositories/{repository_name}/artifacts/{reference}/tags/{tag_name}:
@@ -1360,7 +1473,13 @@ paths:
         '403':
           $ref: '#/responses/403'
         '404':
-          $ref: '#/responses/404'
+          description: Tag not found. The specified tag does not exist on this artifact.
+          headers:
+            X-Request-Id:
+              description: The ID of the corresponding request for the response
+              type: string
+          schema:
+            $ref: '#/definitions/Errors'
         '500':
           $ref: '#/responses/500'
   /projects/{project_name}/repositories/{repository_name}/artifacts/{reference}/accessories:
@@ -1625,6 +1744,8 @@ paths:
           $ref: '#/responses/403'
         '404':
           $ref: '#/responses/404'
+        '422':
+          $ref: '#/responses/422'
         '500':
           $ref: '#/responses/500'
   '/projects/{project_name_or_id}/scanner':
@@ -1805,6 +1926,10 @@ paths:
               $ref: '#/definitions/AuditLogEventType'
         '401':
           $ref: '#/responses/401'
+        '403':
+          $ref: '#/responses/403'
+        '500':
+          $ref: '#/responses/500'
   /projects/{project_name}/logs:
     get:
       summary: Get recent logs of the projects (deprecated)
@@ -2511,6 +2636,7 @@ paths:
   '/projects/{project_name_or_id}/immutabletagrules/{immutable_rule_id}':
     put:
       summary: Update the immutable tag rule or enable or disable the rule
+      description: Update or toggle the specified immutable tag rule within the project. Returns 404 if the project or rule is not found.
       tags:
         - immutable
       operationId: UpdateImmuRule
@@ -2533,10 +2659,13 @@ paths:
           $ref: '#/responses/401'
         '403':
           $ref: '#/responses/403'
+        '404':
+          $ref: '#/responses/404'
         '500':
           $ref: '#/responses/500'
     delete:
       summary: Delete the immutable tag rule.
+      description: Delete the specified immutable tag rule from the project. Returns 404 if the project or rule is not found.
       tags:
         - immutable
       operationId: DeleteImmuRule
@@ -2554,6 +2683,8 @@ paths:
           $ref: '#/responses/401'
         '403':
           $ref: '#/responses/403'
+        '404':
+          $ref: '#/responses/404'
         '500':
           $ref: '#/responses/500'
   '/projects/{project_name_or_id}/webhook/policies':
@@ -4192,6 +4323,8 @@ paths:
           $ref: '#/responses/401'
         '403':
           $ref: '#/responses/403'
+        '500':
+          $ref: '#/responses/500'
   /system/gc:
     get:
       summary: Get gc results.
@@ -4860,6 +4993,7 @@ paths:
   /schedules:
     get:
       operationId: listSchedules
+      summary: List schedules
       description: List schedules
       tags:
         - schedule
@@ -4882,6 +5016,8 @@ paths:
             Link:
               description: Link to previous page and next page
               type: string
+        '400':
+          $ref: '#/responses/400'
         '401':
           $ref: '#/responses/401'
         '403':
@@ -4893,6 +5029,7 @@ paths:
   /schedules/{job_type}/paused:
     get:
       operationId: getSchedulePaused
+      summary: Get scheduler paused status
       description: Get scheduler paused status
       tags:
         - schedule
@@ -4908,6 +5045,8 @@ paths:
           description: Get scheduler status successfully.
           schema:
             $ref: '#/definitions/SchedulerStatus'
+        '400':
+          $ref: '#/responses/400'
         '401':
           $ref: '#/responses/401'
         '403':
@@ -4946,6 +5085,10 @@ paths:
           description: Get Retention Metadatas successfully.
           schema:
             $ref: '#/definitions/RetentionMetadata'
+        '401':
+          $ref: '#/responses/401'
+        '500':
+          $ref: '#/responses/500'
 
   /retentions:
     post:
@@ -5521,6 +5664,7 @@ paths:
   /users:
     get:
       summary: List users
+      description: List users registered in Harbor. Requires system admin privileges.
       tags:
         - user
       operationId: listUsers
@@ -5572,14 +5716,27 @@ paths:
         '401':
           $ref: '#/responses/401'
         '403':
-          description: When the  self registration is disabled, non-admin does not have permission to create user.  When self registration is enabled, this API can only be called from UI portal, calling it via script will get a 403 error.
+          description: When self-registration is disabled, only admins can create users. When self-registration is enabled, user creation via API is not permitted (UI only).
+          headers:
+            X-Request-Id:
+              description: The ID of the corresponding request for the response
+              type: string
+          schema:
+            $ref: '#/definitions/Errors'
         '409':
-          $ref: '#/responses/409'
+          description: Username already exists. A user with the same username already exists in Harbor.
+          headers:
+            X-Request-Id:
+              description: The ID of the corresponding request for the response
+              type: string
+          schema:
+            $ref: '#/definitions/Errors'
         '500':
           $ref: '#/responses/500'
   /users/current:
     get:
       summary: Get current user info.
+      description: Get the profile of the currently authenticated user. Returns 412 if the caller is authenticated via a non-local context such as a robot account.
       tags:
         - user
       operationId: getCurrentUserInfo
@@ -5592,6 +5749,8 @@ paths:
             $ref: '#/definitions/UserResp'
         '401':
           $ref: '#/responses/401'
+        '412':
+          $ref: '#/responses/412'
         '500':
           $ref: '#/responses/500'
   /users/search:
@@ -5632,6 +5791,7 @@ paths:
   '/users/{user_id}':
     get:
       summary: Get a user's profile.
+      description: Get profile information for the specified user. System admins can access any user; regular users can only access their own profile.
       parameters:
         - $ref: '#/parameters/requestId'
         - name: user_id
@@ -5657,6 +5817,7 @@ paths:
           $ref: '#/responses/500'
     put:
       summary: Update user's profile.
+      description: Update profile fields (email, realname, comment) of a user. Regular users can only update their own profile.
       parameters:
         - $ref: '#/parameters/requestId'
         - name: user_id
@@ -5677,6 +5838,8 @@ paths:
       responses:
         '200':
           $ref: '#/responses/200'
+        '400':
+          $ref: '#/responses/400'
         '401':
           $ref: '#/responses/401'
         '403':
@@ -5708,12 +5871,19 @@ paths:
         '403':
           $ref: '#/responses/403'
         '404':
-          $ref: '#/responses/404'
+          description: User not found. No user exists with the specified ID.
+          headers:
+            X-Request-Id:
+              description: The ID of the corresponding request for the response
+              type: string
+          schema:
+            $ref: '#/definitions/Errors'
         '500':
           $ref: '#/responses/500'
   /users/{user_id}/sysadmin:
     put:
       summary: Update a registered user to change to be an administrator of Harbor.
+      description: Promote or demote a registered user to/from Harbor system administrator. Requires system admin privileges.
       tags:
        - user
       operationId: setUserSysAdmin
@@ -5740,7 +5910,7 @@ paths:
         '404':
           $ref: '#/responses/404'
         '500':
-          description: Unexpected internal errors.
+          $ref: '#/responses/500'
   '/users/{user_id}/password':
     put:
       summary: Change the password on a user that already exists.
@@ -5776,6 +5946,7 @@ paths:
   /users/current/permissions:
     get:
       summary: Get current user permissions.
+      description: Get the RBAC permission list for the currently authenticated user, optionally filtered by scope.
       tags:
         - user
       operationId: getCurrentUserPermissions
@@ -5801,9 +5972,9 @@ paths:
             items:
               $ref: '#/definitions/Permission'
         '401':
-          description: User need to log in first.
+          $ref: '#/responses/401'
         '500':
-          description: Internal errors.
+          $ref: '#/responses/500'
   '/users/{user_id}/cli_secret':
     put:
       summary: Set CLI secret for a user.
@@ -6439,7 +6610,7 @@ responses:
         description: The ID of the corresponding request for the response
         type: string
   '400':
-    description: Bad request
+    description: Bad request. The request body or query parameters are invalid. Inspect the `errors` array in the response body for details.
     headers:
       X-Request-Id:
         description: The ID of the corresponding request for the response
@@ -6447,7 +6618,7 @@ responses:
     schema:
       $ref: '#/definitions/Errors'
   '401':
-    description: Unauthorized
+    description: Unauthorized. Authentication is required to access this resource.
     headers:
       X-Request-Id:
         description: The ID of the corresponding request for the response
@@ -6455,7 +6626,7 @@ responses:
     schema:
       $ref: '#/definitions/Errors'
   '403':
-    description: Forbidden
+    description: Forbidden. The caller does not have sufficient permission to perform the requested operation.
     headers:
       X-Request-Id:
         description: The ID of the corresponding request for the response
@@ -6463,7 +6634,7 @@ responses:
     schema:
       $ref: '#/definitions/Errors'
   '404':
-    description: Not found
+    description: Not found. The requested resource does not exist.
     headers:
       X-Request-Id:
         description: The ID of the corresponding request for the response
@@ -6471,7 +6642,7 @@ responses:
     schema:
       $ref: '#/definitions/Errors'
   '405':
-    description: Method not allowed
+    description: Method not allowed.
     headers:
       X-Request-Id:
         description: The ID of the corresponding request for the response
@@ -6479,7 +6650,7 @@ responses:
     schema:
       $ref: '#/definitions/Errors'
   '409':
-    description: Conflict
+    description: Conflict. The resource already exists or the current state prevents the operation.
     headers:
       X-Request-Id:
         description: The ID of the corresponding request for the response
@@ -6487,7 +6658,7 @@ responses:
     schema:
       $ref: '#/definitions/Errors'
   '412':
-    description: Precondition failed
+    description: Precondition failed. A dependency or policy check failed; inspect the `errors` array for the constraint that was violated.
     headers:
       X-Request-Id:
         description: The ID of the corresponding request for the response
@@ -6495,7 +6666,7 @@ responses:
     schema:
       $ref: '#/definitions/Errors'
   '415':
-    description: Unsupported MediaType
+    description: Unsupported media type.
     headers:
       X-Request-Id:
         description: The ID of the corresponding request for the response
@@ -6503,7 +6674,7 @@ responses:
     schema:
       $ref: '#/definitions/Errors'
   '422':
-    description: Unsupported Type
+    description: Unprocessable entity. The request was well-formed but could not be processed (for example, due to validation errors). Inspect the `errors` array in the response body for details.
     headers:
       X-Request-Id:
         description: The ID of the corresponding request for the response
@@ -6511,7 +6682,7 @@ responses:
     schema:
       $ref: '#/definitions/Errors'
   '500':
-    description: Internal server error
+    description: Internal server error. Inspect the `errors` array in the response body for details.
     headers:
       X-Request-Id:
         description: The ID of the corresponding request for the response
@@ -6527,6 +6698,7 @@ definitions:
         type: array
         items:
           $ref: '#/definitions/Error'
+          x-nullable: false
   Error:
     description: a model for all the error response coming from harbor
     type: object
@@ -6537,6 +6709,9 @@ definitions:
       message:
         type: string
         description: The error message
+    example:
+      code: NOT_FOUND
+      message: artifact library/hello-world:latest not found
   Search:
     type: object
     properties:


### PR DESCRIPTION
## Summary

Cherry-picks upstream Harbor commit `abc41cc9e` from goharbor/harbor#23476.

## Upstream Context

- Upstream PR: goharbor/harbor#23476
- Upstream commit: abc41cc9ebcba43fb6ee6b9a68b1fcaac650e9ec
- Upstream title: Fix/api completeness
- Upstream author: @qcserestipy
- Upstream merged by: @Vad1mo
- Upstream approved by: @Vad1mo, @bupd
- Upstream PR URL: https://github.com/goharbor/harbor/pull/23476
- Upstream commit URL: https://github.com/goharbor/harbor/commit/abc41cc9ebcba43fb6ee6b9a68b1fcaac650e9ec

## Cherry-Pick Status

- Status: clean
- Base branch: main
- Workflow run: https://github.com/container-registry/harbor-next/actions/runs/local

## Upstream Description

Thank you for contributing to Harbor!

# Comprehensive Summary of your change

The `api/v2.0/swagger.yaml` spec is missing response codes that Harbor's handlers already
return. Any go-swagger-generated client (including `goharbor/go-client` and therefore
`harbor-cli`) treats an undocumented status code as a fatal error with this opaque message:

```
response status code does not match any response statuses defined for this endpoint
in the swagger spec (status NNN): {}
```

This completely hides the actual Harbor error body. This PR adds the missing response
codes (traced directly to handler code), removes a small number of codes the handlers
never return, improves inline response descriptions, and adds Spectral lint rules to
prevent the same omissions from recurring.

**Response codes added:**

| Endpoint | Added |
|----------|-------|
| `DELETE /projects/{name}/repositories/{repo}` | 412 (immutable tag rule) |
| `PUT /system/configurations` | 400, 422 |
| `GET /projects` (`listProjects`) | 400, 422 |
| `GET /repositories` (`listRepositories`) | 422 |
| `GET /artifacts` (`listArtifacts`) | 422 |
| `GET /tags` (`listTags`) | 422 |
| `GET /artifacts` project-level (`listArtifactsOfProject`) | 422 |
| `GET /users/current` | 412 |
| `DELETE /projects/{id}/members/{mid}` | 404 |
| `PUT /projects/{id}/immutabletagrules/{rid}` | 404 |
| `DELETE /projects/{id}/immutabletagrules/{rid}` | 404 |
| `GET /audit-log/eventtypes` | 403, 500 |
| `GET /schedules` | 400 |
| `GET /schedules/{id}/paused` | 400 |
| `PUT /users/{id}` (`updateUserProfile`) | 400 |
| `GET /retentions/metadatas` | 401, 500 |
| `POST /system/oidc/ping` | 500 |
| `GET /projects/{id}` | 403, 404 |


**Additional improvements:**
- Inline 404/409/412 descriptions replaced with context-specific wording
- Global shared response descriptions (400, 401, 403, 404, 409, 412, 422, 500) made more actionable
- `description` fields added to operations that only had `summary`
- `example` added to the `Error` definition; `x-nullable: false` on `errors` array items
- `.spectral.yaml`: added `operation-description` and `operation-summary-required` rules (severity: error)

# Issue being fixed
Fixes #23475

Related harbor-cli issues resolved downstream once `goharbor/go-client` is regenerated:
[harbor-cli#419](https://github.com/goharbor/harbor-cli/issues/419),
[harbor-cli#557](https://github.com/goharbor/harbor-cli/issues/557),
[harbor-cli#341](https://github.com/goharbor/harbor-cli/issues/341),
[harbor-cli#941](https://github.com/goharbor/harbor-cli/issues/941),
[harbor-cli#808](https://github.com/goharbor/harbor-cli/issues/808)

Please indicate you've done the following:
- [x] Well Written Title and Summary of the PR
- [x] Label the PR as needed. `release-note/docs`
- [x] Accepted the DCO. Commits without the DCO will delay acceptance.
- [ ] Made sure tests are passing and test coverage is added if needed.
- [x] Considered the docs impact and opened a new docs issue or PR with docs changes if needed in [website repository](https://github.com/goharbor/website).

## Review Notes

- Generated by the upstream cherry-pick workflow.
- One upstream commit maps to one Harbor Next PR.
- If this PR is closed without merge, the workflow will not recreate it.

Upstream-Commit: abc41cc9ebcba43fb6ee6b9a68b1fcaac650e9ec
Upstream-PR: goharbor/harbor#23476
Cherry-Pick-Status: clean
