### PR TITLE
upstream: chore(deps): bump actions/download-artifact from 4 to 8 (goharbor/harbor#23495)

### DIFF
--- a/upstream-patches/cherry-pick-23495-838349e91.github.patch
+++ b/upstream-patches/cherry-pick-23495-838349e91.github.patch
@@ -1,0 +1,266 @@
+diff --git a/.github/workflows/build-package.yml b/.github/workflows/build-package.yml
+new file mode 100644
+index 000000000..105bb7fb3
+--- /dev/null
++++ b/.github/workflows/build-package.yml
+@@ -0,0 +1,260 @@
++name: "Build Package Workflow"
++env:
++  DOCKER_COMPOSE_VERSION: 1.23.0
++
++on:
++  push:
++    branches:
++      - main
++      - release-*
++
++# Serialize runs per branch so concurrent pushes don't race when pushing the
++# shared mutable tags (dev / latest) and the multi-arch manifests. Queue rather
++# than cancel to avoid leaving a half-published set of images.
++concurrency:
++  group: build-package-${{ github.ref }}
++  cancel-in-progress: false
++
++jobs:
++  BUILD_BASE_IMAGE:
++    runs-on: ubuntu-latest
++    permissions:
++      contents: read
++    outputs:
++      build_base: ${{ steps.decide.outputs.build_base || 'false' }}
++    steps:
++      - uses: actions/checkout@v6
++      - uses: jitterbit/get-changed-files@v1
++        id: changed-files
++        continue-on-error: true
++        with:
++          format: space-delimited
++          token: ${{ secrets.GITHUB_TOKEN }}
++      - name: Decide whether to (re)build the base image
++        id: decide
++        if: |
++            steps.changed-files.outcome != 'success' ||
++            contains(steps.changed-files.outputs.modified, 'common/Dockerfile') ||
++            contains(steps.changed-files.outputs.modified, 'Dockerfile.base') ||
++            contains(steps.changed-files.outputs.modified, 'VERSION') ||
++            contains(steps.changed-files.outputs.modified, '.buildbaselog') ||
++            github.ref == 'refs/heads/main'
++        run: echo "build_base=true" >> "$GITHUB_OUTPUT"
++      - name: Set up QEMU
++        if: steps.decide.outputs.build_base == 'true'
++        uses: docker/setup-qemu-action@v3
++        with:
++          # Pin to a known-good binfmt image. The default "tonistiigi/binfmt:latest"
++          # has shipped broken releases that fail arm64 emulation with
++          # 'exec /bin/sh: no such file or directory' during container init.
++          image: tonistiigi/binfmt:qemu-v9.2.2
++          platforms: linux/amd64,linux/arm64
++      - name: Set up Docker Buildx
++        if: steps.decide.outputs.build_base == 'true'
++        uses: docker/setup-buildx-action@v3
++      - name: Build and push goharbor/photon:5.0 multi-arch manifest
++        if: steps.decide.outputs.build_base == 'true'
++        run: |
++          set -x
++          echo "${{ secrets.DOCKER_HUB_PASSWORD }}" | docker login -u "${{ secrets.DOCKER_HUB_USERNAME }}" --password-stdin
++          docker buildx build --platform linux/amd64,linux/arm64 \
++            -f make/photon/common/Dockerfile -t goharbor/photon:5.0 --push .
++          docker logout
++
++  BUILD_PACKAGE:
++    needs: [BUILD_BASE_IMAGE]
++    strategy:
++      fail-fast: false
++      matrix:
++        arch: [amd64, arm64]
++    env:
++        BUILD_PACKAGE: true
++        ARCH: ${{ matrix.arch }}
++        BUILD_BASE: ${{ needs.BUILD_BASE_IMAGE.outputs.build_base }}
++    runs-on: ${{ matrix.arch == 'arm64' && 'ubuntu-24.04-arm' || 'ubuntu-latest' }}
++    steps:
++      - name: Configure AWS credentials
++        uses: aws-actions/configure-aws-credentials@v6.2.1
++        with:
++          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
++          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
++          aws-region: us-east-1
++      - name: Set up Go
++        uses: actions/setup-go@v5
++        with:
++          go-version: 1.26.4
++        id: go
++      - name: Setup Docker
++        uses: docker-practice/actions-setup-docker@master
++        with:
++          docker_version: 20.10
++          docker_channel: stable
++      - uses: actions/checkout@v6
++      - uses: actions/checkout@v6
++        with:
++          path: src/github.com/goharbor/harbor
++      - name: Build Package
++        run: |
++          set -x
++          env
++          df -h
++          harbor_target_bucket=""
++          target_branch="$(echo ${GITHUB_REF#refs/heads/})"
++          harbor_offline_build_bundle=""
++          harbor_online_build_bundle=""
++          harbor_logs_bucket="harbor-ci-logs"
++          harbor_builds_bucket="harbor-builds"
++          harbor_releases_bucket="harbor-releases"
++          harbor_ci_pipeline_store_bucket="harbor-ci-pipeline-store/latest"
++          # the target release version is the version of next release(RC or GA). It needs to be updated on creating new release branch.
++          target_release_version=$(cat ./VERSION)
++          Harbor_Package_Version=$target_release_version-'build.'$GITHUB_RUN_NUMBER
++
++          if [[ $target_branch == "main" ]]; then
++            Harbor_Assets_Version=$Harbor_Package_Version
++            harbor_target_bucket=$harbor_builds_bucket
++          else
++            Harbor_Assets_Version=$target_release_version
++            harbor_target_bucket=$harbor_releases_bucket/$target_branch
++          fi
++
++          if [[ $target_branch == "release-"* ]]; then
++            Harbor_Build_Base_Tag=$target_release_version
++          else
++            Harbor_Build_Base_Tag=dev
++          fi
++
++          build_base_params=" BUILD_BASE=false"
++          cd src/github.com/goharbor/harbor
++          if [ -z "$BUILD_BASE"  ] || [ "$BUILD_BASE" != "true"  ]; then
++            echo "Do not need to build base images!"
++          else
++            # Use the locally built per-arch base, not the remote ":<tag>" manifest,
++            # which is only updated later in CREATE_MANIFEST and may be stale.
++            build_base_params=" BUILD_BASE=true PULL_BASE_FROM_DOCKERHUB=false PUSHBASEIMAGE=true REGISTRYUSER=\"${{ secrets.DOCKER_HUB_USERNAME }}\" REGISTRYPASSWORD=\"${{ secrets.DOCKER_HUB_PASSWORD }}\""
++          fi
++
++          sudo make package_offline ARCH=${ARCH} GOBUILDTAGS="include_oss include_gcs" BASEIMAGETAG=${Harbor_Build_Base_Tag} VERSIONTAG=${Harbor_Assets_Version} PKGVERSIONTAG=${Harbor_Package_Version} TRIVYFLAG=true EXPORTERFLAG=true HTTPPROXY= ${build_base_params}
++          sudo make package_online ARCH=${ARCH} GOBUILDTAGS="include_oss include_gcs" BASEIMAGETAG=${Harbor_Build_Base_Tag} VERSIONTAG=${Harbor_Assets_Version} PKGVERSIONTAG=${Harbor_Package_Version} TRIVYFLAG=true EXPORTERFLAG=true HTTPPROXY= ${build_base_params}
++
++          # fail before publishing if any image was built on a wrong-arch
++          # base (e.g. a stale base pulled from Docker Hub), which produces an
++          # image labeled ${ARCH} but containing binaries of another arch.
++          expected_base_arch=$([ "${ARCH}" = "arm64" ] && echo "aarch64" || echo "x86_64")
++          for img in $(docker images --format '{{.Repository}}:{{.Tag}}' | grep '^goharbor/' | grep -- "${Harbor_Assets_Version}" | grep -v '\-base'); do
++            base_label=$(docker inspect --format '{{index .Config.Labels "name"}}' "$img")
++            if [ -n "$base_label" ] && [[ "$base_label" != *"$expected_base_arch"* ]]; then
++              echo "ERROR: $img is built on a wrong-arch base: '$base_label' (expected *$expected_base_arch*)"
++              exit 1
++            fi
++          done
++
++          harbor_offline_build_bundle=$(basename harbor-offline-installer-*.tgz)
++          harbor_online_build_bundle=$(basename harbor-online-installer-*.tgz)
++          mv "${harbor_offline_build_bundle}" "harbor-offline-installer-${Harbor_Package_Version}-${ARCH}.tgz"
++          mv "${harbor_online_build_bundle}" "harbor-online-installer-${Harbor_Package_Version}-${ARCH}.tgz"
++          harbor_offline_build_bundle="harbor-offline-installer-${Harbor_Package_Version}-${ARCH}.tgz"
++          harbor_online_build_bundle="harbor-online-installer-${Harbor_Package_Version}-${ARCH}.tgz"
++
++          source tests/ci/build_util.sh
++          cp "${harbor_offline_build_bundle}"  "harbor-offline-installer-latest-${ARCH}.tgz"
++          cp "${harbor_online_build_bundle}"   "harbor-online-installer-latest-${ARCH}.tgz"
++          uploader "${harbor_offline_build_bundle}"                    $harbor_target_bucket
++          uploader "${harbor_online_build_bundle}"                     $harbor_target_bucket
++          uploader "harbor-offline-installer-latest-${ARCH}.tgz"      $harbor_target_bucket
++          uploader "harbor-online-installer-latest-${ARCH}.tgz"       $harbor_target_bucket
++          # Backwards compatibility: keep the unsuffixed legacy "latest" name
++          # pointing to amd64 (what it historically was) so existing downstream
++          # consumers that expect harbor-*-installer-latest.tgz don't break.
++          if [ "${ARCH}" = "amd64" ]; then
++            cp "${harbor_offline_build_bundle}"  "harbor-offline-installer-latest.tgz"
++            cp "${harbor_online_build_bundle}"   "harbor-online-installer-latest.tgz"
++            uploader "harbor-offline-installer-latest.tgz"             $harbor_target_bucket
++            uploader "harbor-online-installer-latest.tgz"              $harbor_target_bucket
++          fi
++          echo "BUILD_BUNDLE=${harbor_offline_build_bundle}" >> $GITHUB_ENV
++          echo "harbor_target_bucket=$harbor_target_bucket" >> $GITHUB_ENV
++
++          publishImage $target_branch $Harbor_Assets_Version "${{ secrets.DOCKER_HUB_USERNAME }}" "${{ secrets.DOCKER_HUB_PASSWORD }}" ${ARCH}
++      - name: Save repo list
++        run: |
++          { docker images --format '{{.Repository}}' | grep '^goharbor/' | grep -v '\-base' | grep -v '^goharbor/photon$' | grep -v '^goharbor/spectral$' | grep -v '^goharbor/swagger$' | grep -v '^goharbor/mockery$' || true; } | sort -u > "$GITHUB_WORKSPACE/_repos_${ARCH}.txt"
++          # base images are pushed arch-suffixed by the _build_base make macro
++          # and combined into multi-arch manifests by CREATE_MANIFEST. Derive the
++          # list from the Dockerfile.base directories (the source of truth) so it
++          # stays correct regardless of local image cleanup behavior.
++          if [ "$BUILD_BASE" = "true" ]; then
++            for d in make/photon/*/Dockerfile.base; do
++              component=$(basename "$(dirname "$d")")
++              echo "goharbor/harbor-${component}-base"
++            done | sort -u > "$GITHUB_WORKSPACE/_base_repos_${ARCH}.txt"
++          else
++            : > "$GITHUB_WORKSPACE/_base_repos_${ARCH}.txt"
++          fi
++      - name: Upload repo list
++        uses: actions/upload-artifact@v4
++        with:
++          name: repos-${{ matrix.arch }}
++          path: |
++            ${{ github.workspace }}/_repos_${{ matrix.arch }}.txt
++            ${{ github.workspace }}/_base_repos_${{ matrix.arch }}.txt
++
++  CREATE_MANIFEST:
++    needs: [BUILD_BASE_IMAGE, BUILD_PACKAGE]
++    runs-on: ubuntu-latest
++    permissions:
++      contents: read
++    steps:
++      - uses: actions/checkout@v6
++      - uses: actions/download-artifact@v8
++        with:
++          pattern: repos-*
++          merge-multiple: true
++      - name: Set up Docker Buildx
++        uses: docker/setup-buildx-action@v3
++      - name: Determine image tag
++        id: tag
++        run: |
++          target_branch="$(echo ${GITHUB_REF#refs/heads/})"
++          version=$(cat ./VERSION)
++          if [[ $target_branch == "main" ]]; then
++            echo "image_tag=dev" >> $GITHUB_OUTPUT
++          elif [[ $target_branch == "release-"* ]]; then
++            echo "image_tag=${version}-dev" >> $GITHUB_OUTPUT
++          else
++            echo "image_tag=${version}" >> $GITHUB_OUTPUT
++          fi
++          # base images use BASEIMAGETAG (see Harbor_Build_Base_Tag in BUILD_PACKAGE):
++          # "dev" on main, the release version on release-* branches
++          if [[ $target_branch == "release-"* ]]; then
++            echo "base_tag=${version}" >> $GITHUB_OUTPUT
++          else
++            echo "base_tag=dev" >> $GITHUB_OUTPUT
++          fi
++      - name: Login to Docker Hub
++        run: echo "${{ secrets.DOCKER_HUB_PASSWORD }}" | docker login -u "${{ secrets.DOCKER_HUB_USERNAME }}" --password-stdin
++      - name: Create multi-arch manifests
++        run: |
++          set -euo pipefail
++          image_tag="${{ steps.tag.outputs.image_tag }}"
++          cat _repos_*.txt | sort -u | while IFS= read -r repo; do
++            [ -z "$repo" ] && continue
++            echo "Creating manifest ${repo}:${image_tag}"
++            docker buildx imagetools create -t "${repo}:${image_tag}" \
++              "${repo}:${image_tag}-amd64" \
++              "${repo}:${image_tag}-arm64"
++          done
++          # The harbor-*-base images are only (re)built and pushed (arch-suffixed)
++          # when BUILD_BASE_IMAGE decided to rebuild the base; otherwise the
++          # suffixed tags from this run don't exist and there is nothing to combine.
++          if [ "${{ needs.BUILD_BASE_IMAGE.outputs.build_base }}" = "true" ]; then
++            base_tag="${{ steps.tag.outputs.base_tag }}"
++            cat _base_repos_*.txt | sort -u | while IFS= read -r repo; do
++              [ -z "$repo" ] && continue
++              echo "Creating manifest ${repo}:${base_tag}"
++              docker buildx imagetools create -t "${repo}:${base_tag}" \
++                "${repo}:${base_tag}-amd64" \
++                "${repo}:${base_tag}-arm64"
++            done
++          fi
++          docker logout


### PR DESCRIPTION
> This cherry-pick had conflicts and was opened as a draft. Conflict markers may be present in the diff and must be resolved before marking ready for review.

## Summary

Cherry-picks upstream Harbor commit `838349e91` from goharbor/harbor#23495.

## Upstream Context

- Upstream PR: goharbor/harbor#23495
- Upstream commit: 838349e91a6db4869f01758dca8331c481f951d8
- Upstream title: chore(deps): bump actions/download-artifact from 4 to 8
- Upstream author: @app/dependabot
- Upstream merged by: @Vad1mo
- Upstream approved by: @Vad1mo, @wy65701436
- Upstream PR URL: https://github.com/goharbor/harbor/pull/23495
- Upstream commit URL: https://github.com/goharbor/harbor/commit/838349e91a6db4869f01758dca8331c481f951d8

## Cherry-Pick Status

- Status: conflicted
- Base branch: main
- GitHub folder patch: `upstream-patches/cherry-pick-23495-838349e91.github.patch`
- Workflow run: https://github.com/container-registry/harbor-next/actions/runs/local

## Upstream Description

Bumps [actions/download-artifact](https://github.com/actions/download-artifact) from 4 to 8.
<details>
<summary>Release notes</summary>
<p><em>Sourced from <a href="https://github.com/actions/download-artifact/releases">actions/download-artifact's releases</a>.</em></p>
<blockquote>
<h2>v8.0.0</h2>
<h2>v8 - What's new</h2>
<blockquote>
<p>[!IMPORTANT]
actions/download-artifact@v8 has been migrated to an ESM module. This should be transparent to the caller but forks might need to make significant changes.</p>
</blockquote>
<blockquote>
<p>[!IMPORTANT]
Hash mismatches will now error by default. Users can override this behavior with a setting change (see below).</p>
</blockquote>
<h3>Direct downloads</h3>
<p>To support direct uploads in <code>actions/upload-artifact</code>, the action will no longer attempt to unzip all downloaded files. Instead, the action checks the <code>Content-Type</code> header ahead of unzipping and skips non-zipped files. Callers wishing to download a zipped file as-is can also set the new <code>skip-decompress</code> parameter to <code>true</code>.</p>
<h3>Enforced checks (breaking)</h3>
<p>A previous release introduced digest checks on the download. If a download hash didn't match the expected hash from the server, the action would log a warning. Callers can now configure the behavior on mismatch with the <code>digest-mismatch</code> parameter. To be secure by default, we are now defaulting the behavior to <code>error</code> which will fail the workflow run.</p>
<h3>ESM</h3>
<p>To support new versions of the @actions/* packages, we've upgraded the package to ESM.</p>
<h2>What's Changed</h2>
<ul>
<li>Don't attempt to un-zip non-zipped downloads by <a href="https://github.com/danwkennedy"><code>@​danwkennedy</code></a> in <a href="https://redirect.github.com/actions/download-artifact/pull/460">actions/download-artifact#460</a></li>
<li>Add a setting to specify what to do on hash mismatch and default it to <code>error</code> by <a href="https://github.com/danwkennedy"><code>@​danwkennedy</code></a> in <a href="https://redirect.github.com/actions/download-artifact/pull/461">actions/download-artifact#461</a></li>
</ul>
<p><strong>Full Changelog</strong>: <a href="https://github.com/actions/download-artifact/compare/v7...v8.0.0">https://github.com/actions/download-artifact/compare/v7...v8.0.0</a></p>
<h2>v7.0.0</h2>
<h2>v7 - What's new</h2>
<blockquote>
<p>[!IMPORTANT]
actions/download-artifact@v7 now runs on Node.js 24 (<code>runs.using: node24</code>) and requires a minimum Actions Runner version of 2.327.1. If you are using self-hosted runners, ensure they are updated before upgrading.</p>
</blockquote>
<h3>Node.js 24</h3>
<p>This release updates the runtime to Node.js 24. v6 had preliminary support for Node 24, however this action was by default still running on Node.js 20. Now this action by default will run on Node.js 24.</p>
<h2>What's Changed</h2>
<ul>
<li>Update GHES guidance to include reference to Node 20 version by <a href="https://github.com/patrikpolyak"><code>@​patrikpolyak</code></a> in <a href="https://redirect.github.com/actions/download-artifact/pull/440">actions/download-artifact#440</a></li>
<li>Download Artifact Node24 support by <a href="https://github.com/salmanmkc"><code>@​salmanmkc</code></a> in <a href="https://redirect.github.com/actions/download-artifact/pull/415">actions/download-artifact#415</a></li>
<li>fix: update <code>@​actions/artifact</code> to fix Node.js 24 punycode deprecation by <a href="https://github.com/salmanmkc"><code>@​salmanmkc</code></a> in <a href="https://redirect.github.com/actions/download-artifact/pull/451">actions/download-artifact#451</a></li>
<li>prepare release v7.0.0 for Node.js 24 support by <a href="https://github.com/salmanmkc"><code>@​salmanmkc</code></a> in <a href="https://redirect.github.com/actions/download-artifact/pull/452">actions/download-artifact#452</a></li>
</ul>
<h2>New Contributors</h2>
<ul>
<li><a href="https://github.com/patrikpolya

[Upstream PR body truncated.]

## Review Notes

- Generated by the upstream cherry-pick workflow.
- One upstream commit maps to one Harbor Next PR.
- Changes under `.github/` were written to `upstream-patches/cherry-pick-23495-838349e91.github.patch` because `GITHUB_TOKEN` cannot push workflow file updates.
- Apply the patch with `git apply upstream-patches/cherry-pick-23495-838349e91.github.patch` if those `.github/` changes should be carried forward.
- If this PR is closed without merge, the workflow will not recreate it.

Upstream-Commit: 838349e91a6db4869f01758dca8331c481f951d8
Upstream-PR: goharbor/harbor#23495
Cherry-Pick-Status: conflicted
GitHub-Patch-File: upstream-patches/cherry-pick-23495-838349e91.github.patch
