### PR TITLE
chore(deps): Update Checkout Pin Example

### DIFF
--- a/.github/workflows/lint-actions.yml
+++ b/.github/workflows/lint-actions.yml
@@ -40,7 +40,7 @@ jobs:
           if [ "$failed" -eq 1 ]; then
             echo ""
             echo "All 'uses:' references must be pinned to a full commit SHA."
-            echo "Example: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v4"
+            echo "Example: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0"
             exit 1
           fi
           echo "All actions are pinned."


### PR DESCRIPTION
## Summary

- Update the pinned-actions lint example from checkout `# v4` to `# v7.0.0`.
- Verified there are no remaining `actions/checkout` v4 references under `.github`.

## Notes

All actual `actions/checkout` uses were already pinned to `9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0`; this PR cleans up the stale error-message example.

## Testing

- `actionlint .github/workflows/lint-actions.yml`
- `rg -n "actions/checkout@.*v4|actions/checkout@v4|actions/checkout@.*# v4" .github` returned no matches.