### PR TITLE
ci: publish rolling 8gcr dev images

### DIFF
--- a/.github/workflows/chart-publish.yml
+++ b/.github/workflows/chart-publish.yml
@@ -103,10 +103,17 @@ jobs:
       - name: Push Flux deploy bundle
         env:
           VERSION: ${{ steps.version.outputs.version }}
+          IMAGE_REVISION: ${{ github.sha }}
         run: |
+          BUNDLE_PATH="${RUNNER_TEMP}/8gcr-dev-flux"
+          rm -rf "${BUNDLE_PATH}"
+          cp -R deploy/flux/8gcr-dev "${BUNDLE_PATH}"
+          find "${BUNDLE_PATH}" -type f -name '*.yaml' \
+            -exec sed -i "s/__IMAGE_REVISION__/${IMAGE_REVISION}/g" {} +
+
           flux push artifact \
             "oci://${REGISTRY_ADDRESS}/${REGISTRY_PROJECT}/deploy:${VERSION}" \
-            --path=./deploy/flux/8gcr-dev \
+            --path="${BUNDLE_PATH}" \
             --source="${{ github.server_url }}/${{ github.repository }}" \
             --revision="${GITHUB_REF_NAME}@sha1:${GITHUB_SHA}"
 
@@ -189,9 +196,16 @@ jobs:
       - name: Push Flux deploy bundle
         env:
           VERSION: ${{ steps.version.outputs.version }}
+          IMAGE_REVISION: ${{ github.sha }}
         run: |
+          BUNDLE_PATH="${RUNNER_TEMP}/8gcr-dev-flux"
+          rm -rf "${BUNDLE_PATH}"
+          cp -R deploy/flux/8gcr-dev "${BUNDLE_PATH}"
+          find "${BUNDLE_PATH}" -type f -name '*.yaml' \
+            -exec sed -i "s/__IMAGE_REVISION__/${IMAGE_REVISION}/g" {} +
+
           flux push artifact \
             "oci://${REGISTRY_ADDRESS}/${REGISTRY_PROJECT}/deploy:${VERSION}" \
-            --path=./deploy/flux/8gcr-dev \
+            --path="${BUNDLE_PATH}" \
             --source="${{ github.server_url }}/${{ github.repository }}" \
             --revision="${{ github.event.release.tag_name }}@sha1:${{ github.sha }}"

--- a/.github/workflows/dev-images.yml
+++ b/.github/workflows/dev-images.yml
@@ -1,0 +1,217 @@
+name: Publish Dev Images
+
+on:
+  push:
+    branches:
+      - main
+    paths-ignore:
+      - "**.md"
+      - "docs/**"
+      - "CLAUDE.md"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: dev-images-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  REGISTRY_ADDRESS: ${{ vars.REGISTRY_ADDRESS || '8gears.container-registry.com' }}
+  REGISTRY_PROJECT: 8gcr-dev
+
+jobs:
+  build:
+    name: "${{ matrix.component }} (${{ matrix.platform }})"
+    strategy:
+      fail-fast: false
+      matrix:
+        component: [core, jobservice, registryctl, exporter, portal, registry, trivy-adapter]
+        platform:
+          - linux/amd64
+          - linux/arm64
+    runs-on: ${{ vars.RUNNER || 'ubuntu-latest' }}
+    permissions:
+      contents: read
+    steps:
+      - name: Prepare
+        run: |
+          platform=${{ matrix.platform }}
+          echo "PLATFORM_PAIR=${platform//\//-}" >> "$GITHUB_ENV"
+          echo "DEV_TAG=main-${GITHUB_SHA:0:7}" >> "$GITHUB_ENV"
+          if [ -n "$BUILDX_HOST" ]; then
+            echo "BUILDX_HOST=$BUILDX_HOST" >> "$GITHUB_ENV"
+          fi
+
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Load versions
+        run: grep -E '^[A-Z_]+=' versions.env >> "$GITHUB_ENV"
+
+      - name: Setup Go
+        if: ${{ contains(fromJSON('["core","jobservice","registryctl","exporter","registry","trivy-adapter"]'), matrix.component) }}
+        uses: ./.github/actions/setup-go-cached
+        with:
+          go-version-file: src/go.mod
+          go-sum-path: src/go.sum
+
+      - name: Install Task
+        if: ${{ contains(fromJSON('["core","jobservice","registryctl","exporter","registry","trivy-adapter"]'), matrix.component) }}
+        uses: arduino/setup-task@b91d5d2c96a56797b48ac1e0e89220bf64044611 # v2.0.0
+        with:
+          version: 3.49.1
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Generate API code
+        if: ${{ contains(fromJSON('["core","jobservice","registryctl","exporter","registry","trivy-adapter"]'), matrix.component) }}
+        run: task build:gen-apis
+
+      - name: Compile Go binary
+        if: ${{ contains(fromJSON('["core","jobservice","registryctl","exporter","registry","trivy-adapter"]'), matrix.component) }}
+        run: task build:binary:${{ matrix.component }}:${{ env.PLATFORM_PAIR }} GIT_COMMIT="${GITHUB_SHA:0:8}"
+
+      - uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a # v4.0.0
+        if: env.BUILDX_HOST == ''
+
+      - uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
+        with:
+          driver: ${{ env.BUILDX_HOST && 'remote' || '' }}
+          endpoint: ${{ env.BUILDX_HOST }}
+
+      - name: Log in to registry
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
+        with:
+          registry: ${{ env.REGISTRY_ADDRESS }}
+          username: ${{ vars.REGISTRY_USERNAME }}
+          password: ${{ secrets.REGISTRY_PASSWORD }}
+
+      - name: Build and push by digest
+        id: build
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6.19.2
+        with:
+          context: .
+          file: dockerfile/${{ matrix.component }}.dockerfile
+          platforms: ${{ matrix.platform }}
+          build-args: |
+            ALPINE_VERSION=${{ env.ALPINE_VERSION }}
+            LPROBE_VERSION=${{ env.LPROBE_VERSION }}
+            NGINX_VERSION=${{ env.NGINX_VERSION }}
+            BUN_VERSION=${{ env.BUN_VERSION }}
+            GO_VERSION=${{ env.GO_VERSION }}
+            DISTRIBUTION_VERSION=${{ env.DISTRIBUTION_VERSION }}
+            TRIVY_VERSION=${{ env.TRIVY_VERSION }}
+            TRIVY_BASE_IMAGE_VERSION=${{ env.TRIVY_BASE_IMAGE_VERSION }}
+            HARBOR_SCANNER_TRIVY_VERSION=${{ env.HARBOR_SCANNER_TRIVY_VERSION }}
+          tags: ${{ env.REGISTRY_ADDRESS }}/${{ env.REGISTRY_PROJECT }}/harbor-${{ matrix.component }}
+          outputs: type=image,push-by-digest=true,name-canonical=true,push=true
+
+      - name: Export digest
+        run: |
+          mkdir -p "${{ runner.temp }}/digests"
+          digest="${{ steps.build.outputs.digest }}"
+          touch "${{ runner.temp }}/digests/${digest#sha256:}"
+
+      - name: Upload digest
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: dev-digest-${{ matrix.component }}-${{ env.PLATFORM_PAIR }}
+          path: ${{ runner.temp }}/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  merge:
+    name: "Publish ${{ matrix.component }} tags"
+    needs: [build]
+    strategy:
+      fail-fast: false
+      matrix:
+        component: [core, jobservice, registryctl, exporter, portal, registry, trivy-adapter]
+    runs-on: ${{ vars.RUNNER || 'ubuntu-latest' }}
+    permissions:
+      contents: read
+    steps:
+      - name: Prepare
+        run: |
+          echo "DEV_TAG=main-${GITHUB_SHA:0:7}" >> "$GITHUB_ENV"
+          if [ -n "$BUILDX_HOST" ]; then
+            echo "BUILDX_HOST=$BUILDX_HOST" >> "$GITHUB_ENV"
+          fi
+
+      - name: Download digests
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          path: ${{ runner.temp }}/digests
+          pattern: dev-digest-${{ matrix.component }}-*
+          merge-multiple: true
+
+      - name: Log in to registry
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
+        with:
+          registry: ${{ env.REGISTRY_ADDRESS }}
+          username: ${{ vars.REGISTRY_USERNAME }}
+          password: ${{ secrets.REGISTRY_PASSWORD }}
+
+      - uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
+        with:
+          driver: ${{ env.BUILDX_HOST && 'remote' || '' }}
+          endpoint: ${{ env.BUILDX_HOST }}
+
+      - name: Create manifest list and push
+        working-directory: ${{ runner.temp }}/digests
+        env:
+          IMAGE: ${{ env.REGISTRY_ADDRESS }}/${{ env.REGISTRY_PROJECT }}/harbor-${{ matrix.component }}
+        run: |
+          # shellcheck disable=SC2046
+          docker buildx imagetools create \
+            -t "${IMAGE}:${DEV_TAG}" \
+            -t "${IMAGE}:latest" \
+            $(printf "${IMAGE}@sha256:%s " *)
+
+  publish-deploy-bundle:
+    name: Publish rolling Flux bundle
+    needs: [merge]
+    runs-on: ${{ vars.RUNNER || 'ubuntu-latest' }}
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Prepare
+        run: |
+          echo "DEV_TAG=main-${GITHUB_SHA:0:7}" >> "$GITHUB_ENV"
+
+      - name: Setup ORAS
+        uses: oras-project/setup-oras@5c0b487ce3fe0ce3ab0d034e63669e426e294e4d # v1.2.3
+        with:
+          version: 1.2.0
+
+      - name: Setup Flux CLI
+        uses: fluxcd/flux2/action@8d5f40dca5aa5d3c0fc3414457dda15a0ac92fa4 # v2.4.0
+        with:
+          version: 2.4.0
+
+      - name: Registry login
+        env:
+          REGISTRY_PASSWORD: ${{ secrets.REGISTRY_PASSWORD }}
+        run: |
+          echo "${REGISTRY_PASSWORD}" | oras login "${REGISTRY_ADDRESS}" \
+            --username "${{ vars.REGISTRY_USERNAME }}" --password-stdin
+
+      - name: Publish Flux deploy bundle
+        run: |
+          BUNDLE_PATH="${RUNNER_TEMP}/8gcr-dev-flux"
+          rm -rf "${BUNDLE_PATH}"
+          cp -R deploy/flux/8gcr-dev "${BUNDLE_PATH}"
+          find "${BUNDLE_PATH}" -type f -name '*.yaml' \
+            -exec sed -i "s/__IMAGE_REVISION__/${GITHUB_SHA}/g" {} +
+
+          flux push artifact \
+            "oci://${REGISTRY_ADDRESS}/${REGISTRY_PROJECT}/deploy:${DEV_TAG}" \
+            --path="${BUNDLE_PATH}" \
+            --source="${{ github.server_url }}/${{ github.repository }}" \
+            --revision="${GITHUB_REF_NAME}@sha1:${GITHUB_SHA}"
+
+          oras tag \
+            "${REGISTRY_ADDRESS}/${REGISTRY_PROJECT}/deploy:${DEV_TAG}" \
+            latest

--- a/deploy/flux/8gcr-dev/README.md
+++ b/deploy/flux/8gcr-dev/README.md
@@ -1,27 +1,35 @@
 # 8gcr-dev FluxCD Bundle
 
-Self-contained continuous-deploy bundle for `https://8gcr.container-registry.dev` on the **hz-hopper** cluster. Everything required to run this Harbor instance lives in this directory — no private repo, no out-of-band secrets store. SOPS encryption protects credential material so the bundle stays safe in a public repo.
+Continuous-deploy bundle for `https://8gcr.container-registry.dev` on the **hz-hopper** cluster. The manifests are safe to keep in a public repo: credential material is either SOPS-encrypted application data or supplied by pre-existing cluster pull secrets.
 
 ## Layout
 
 | File | Purpose |
 |------|---------|
 | `namespace.yaml` | Namespace `8gcr-dev-main` (the cluster runs multiple Harbor instances; namespace is deployment-specific). |
-| `ocirepository.yaml` | Anonymous pull of the chart from `oci://8gears.container-registry.com/8gcr-dev/chart/harbor-next:latest`, 5-min interval. |
+| `ocirepository.yaml` | Authenticated pull of the chart from `oci://8gears.container-registry.com/8gcr-dev/chart/harbor-next:3.0.0-dev`, 5-min interval. |
 | `helmrelease.yaml` | Renders the chart with the dev-environment values; references the secrets below; provisions a CloudNativePG `Cluster` via the chart's `extraManifests` escape hatch. |
-| `secrets.sops.yaml` | SOPS-encrypted `Secret` resources for the admin password, the Harbor↔Postgres password, and the CNPG bootstrap credentials. Decrypted on the cluster by Flux using the existing `flux-system/sops-age` key. |
+| `secrets.sops.yaml` | SOPS-encrypted `Secret` resources for the admin password, the Harbor↔Postgres password, and the CNPG bootstrap credentials. It does not contain registry pull credentials. Decrypted on the cluster by Flux using the existing `flux-system/sops-age` key. |
 | `kustomization.yaml` | Plain Kustomize index, lets the Flux Kustomization controller reconcile this directory. |
-| `bootstrap.yaml` | One-time `kubectl apply` target that creates the `OCIRepository` + `Kustomization` in `flux-system` to fetch and apply this bundle. Required only the first time per cluster. |
+| `bootstrap.yaml` | One-time `kubectl apply` target that creates the `OCIRepository` + `Kustomization` in `flux-system` to fetch and apply this bundle using the existing `harbor-8gcr-dev-pull` secret. Required only the first time per cluster. |
 
 ## How it gets to the cluster
 
-1. **Chart + bundle publish** (`.github/workflows/chart-publish.yml`, every push to `main`):
-   - Packages `deploy/chart/` and pushes to `oci://8gears.container-registry.com/8gcr-dev/chart/harbor-next:<version>` and `:latest`.
+1. **Component image publish** (`.github/workflows/dev-images.yml`, every non-doc push to `main`):
+   - Builds all Harbor component images for `linux/amd64` and `linux/arm64`.
+   - Pushes immutable `main-<sha7>` tags and moves `latest` for `8gears.container-registry.com/8gcr-dev/harbor-<component>`.
+   - Publishes this Flux bundle with the commit SHA substituted into each component pod annotation. That gives Helm a pod-template change, so Kubernetes rolls the pods and re-pulls `latest`.
+2. **Chart + bundle publish** (`.github/workflows/chart-publish.yml`, chart/Flux changes on `main`):
+   - Packages `deploy/chart/` and pushes to `oci://8gears.container-registry.com/8gcr-dev/chart/harbor-next:3.0.0-dev` plus an immutable per-commit tag.
    - Bundles this directory (everything except `bootstrap.yaml`) and pushes to `oci://8gears.container-registry.com/8gcr-dev/deploy:<version>` and `:latest` via `flux push artifact`.
-2. **Component images** — maintained out-of-band by an existing buildah pipeline that publishes to `8gears.container-registry.com/8gcr-dev/harbor-<component>:latest`. This bundle consumes those `:latest` tags.
-3. **Reconcile** — Flux on hz-hopper pulls the published deploy bundle every 5 min, decrypts `secrets.sops.yaml`, applies everything.
+3. **Reconcile** — Flux on hz-hopper pulls the published deploy bundle every 5 min, decrypts `secrets.sops.yaml`, applies everything, and Helm rolls pods when the image revision annotation changes.
 
-The Harbor project `8gcr-dev` is public, so every pull above is anonymous: no `imagePullSecrets`, no `OCIRepository.secretRef`.
+The manifests intentionally do not store registry credentials. Pull access is provided by cluster secrets:
+
+| Namespace | Secret | Used by |
+|---|---|---|
+| `flux-system` | `harbor-8gcr-dev-pull` | Root `OCIRepository/harbor-8gcr-dev` pulling `8gcr-dev/deploy`. |
+| `8gcr-dev-main` | `harbor-8gcr-dev-pull` | Chart `OCIRepository/harbor-next-chart` and Harbor component image pulls. |
 
 ## One-time bootstrap
 
@@ -39,7 +47,8 @@ Equivalent with the Flux CLI:
 ```sh
 flux create source oci harbor-8gcr-dev \
   --url=oci://8gears.container-registry.com/8gcr-dev/deploy \
-  --tag=latest --interval=5m
+  --tag=latest --interval=5m \
+  --secret-ref=harbor-8gcr-dev-pull
 
 flux create kustomization harbor-8gcr-dev \
   --source=OCIRepository/harbor-8gcr-dev \
@@ -56,6 +65,8 @@ Everything else this bundle needs is satisfied by hz-hopper's standing infrastru
 | Requirement | Source |
 |---|---|
 | FluxCD v2 (`source-controller`, `kustomize-controller`, `helm-controller`) | Pre-installed on hz-hopper. |
+| `flux-system/harbor-8gcr-dev-pull` | Pre-created dockerconfigjson for pulling `8gcr-dev/deploy`. Do not commit this secret to the repo. |
+| `8gcr-dev-main/harbor-8gcr-dev-pull` | Pre-created dockerconfigjson for pulling the chart and component images. Do not commit this secret to the repo. |
 | SOPS decryption key | `Secret/sops-age` in `flux-system` (already present; same key used by other Flux Kustomizations). Public key: `age18jfefmcak9zk6jrh7j59ap0rg3zxg577suvmlyrgm3sn0l28zq4slcu94r`. |
 | CloudNativePG operator | Pre-installed in `cnpg-system`. The chart's `extraManifests` renders a `Cluster.postgresql.cnpg.io/v1`; CNPG reconciles it into a Postgres pod + `harbor-db-rw` Service that the chart's `database.host` value points at. |
 | Cert-manager + `letsencrypt-prod` ClusterIssuer | Pre-installed; HelmRelease ingress is annotated to use it. |
@@ -91,7 +102,8 @@ One DB Secret, one source of truth: rotating `harbor-db-password.password` updat
 
 | Trigger | Registry project | Tag | Consumer |
 |---------|------------------|-----|----------|
-| push to `main` (chart + bundle) | `8gcr-dev` | `latest`, `<base>-main.<sha7>` | this bundle (8gcr-dev environment) |
+| push to `main` (component images) | `8gcr-dev` | `latest`, `main-<sha7>` | this bundle (8gcr-dev environment) |
+| push to `main` (chart + bundle) | `8gcr-dev` | `3.0.0-dev`, `<base>-main.<sha7>`, `latest` for deploy bundle | this bundle (8gcr-dev environment) |
 | release-please tag | `8gcr` | `<semver>` | future production overlays (pin to semver) |
 
 ## Local validation

--- a/deploy/flux/8gcr-dev/bootstrap.yaml
+++ b/deploy/flux/8gcr-dev/bootstrap.yaml
@@ -5,13 +5,16 @@
 #
 # This creates the OCIRepository + Kustomization in flux-system that fetches
 # the deploy bundle at oci://8gears.container-registry.com/8gcr-dev/deploy:latest
-# and reconciles every resource in it (including SOPS-encrypted secrets).
+# with the existing flux-system registry pull secret and reconciles every
+# resource in it (including SOPS-encrypted secrets).
 #
 # Re-applying is a no-op. After this single step, all subsequent changes flow
 # through chart-publish.yml → OCI artifact → Flux reconcile.
 #
 # Prerequisites on the cluster:
 #   - FluxCD v2 with source-controller, kustomize-controller, helm-controller
+#   - Secret/harbor-8gcr-dev-pull in flux-system (dockerconfigjson for
+#     8gears.container-registry.com OCI artifact pulls)
 #   - Secret/sops-age in flux-system (holds the age private key matching
 #     age18jfefmcak9zk6jrh7j59ap0rg3zxg577suvmlyrgm3sn0l28zq4slcu94r)
 #   - CloudNativePG operator in cnpg-system (provisions Postgres via extraManifests)
@@ -29,6 +32,8 @@ spec:
   url: oci://8gears.container-registry.com/8gcr-dev/deploy
   ref:
     tag: latest
+  secretRef:
+    name: harbor-8gcr-dev-pull
 ---
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization

--- a/deploy/flux/8gcr-dev/helmrelease.yaml
+++ b/deploy/flux/8gcr-dev/helmrelease.yaml
@@ -20,6 +20,10 @@ spec:
   values:
     externalURL: https://8gcr.container-registry.dev
     logLevel: info
+    image:
+      pullPolicy: Always
+    imagePullSecrets:
+      - name: harbor-8gcr-dev-pull
 
     # Admin password provisioned by secrets.sops.yaml in this bundle.
     existingSecretAdminPassword: harbor-admin
@@ -69,18 +73,22 @@ spec:
       auth:
         enabled: false
 
-    # ---- Component image pins (continuous deploy via existing 8gcr-dev/:latest) ----
-    # The :latest tag in 8gcr-dev/ is maintained by an out-of-band buildah pipeline
-    # (not the harbor-next GitHub workflows). HelmRelease's 5-min OCIRepository
-    # interval picks up new chart digests; component images update via the
-    # imagePullPolicy + the moving :latest tag.
+    # ---- Component image pins (continuous deploy via 8gcr-dev/:latest) ----
+    # The dev image pipeline rewrites __IMAGE_REVISION__ before publishing the
+    # Flux bundle. That pod-template annotation forces a rollout after the
+    # pipeline moves the component :latest tags, and imagePullPolicy: Always
+    # makes the restarted pods pull the new digest.
     core:
+      podAnnotations:
+        deploy.8gears.io/image-revision: "__IMAGE_REVISION__"
       image:
         repository: 8gears.container-registry.com/8gcr-dev/harbor-core
         tag: latest
       replicas: 1
 
     jobservice:
+      podAnnotations:
+        deploy.8gears.io/image-revision: "__IMAGE_REVISION__"
       image:
         repository: 8gears.container-registry.com/8gcr-dev/harbor-jobservice
         tag: latest
@@ -91,6 +99,8 @@ spec:
         size: 1Gi
 
     registry:
+      podAnnotations:
+        deploy.8gears.io/image-revision: "__IMAGE_REVISION__"
       image:
         repository: 8gears.container-registry.com/8gcr-dev/harbor-registry
         tag: latest
@@ -105,6 +115,8 @@ spec:
         size: 10Gi
 
     portal:
+      podAnnotations:
+        deploy.8gears.io/image-revision: "__IMAGE_REVISION__"
       image:
         repository: 8gears.container-registry.com/8gcr-dev/harbor-portal
         tag: latest
@@ -112,6 +124,8 @@ spec:
 
     exporter:
       enabled: true
+      podAnnotations:
+        deploy.8gears.io/image-revision: "__IMAGE_REVISION__"
       image:
         repository: 8gears.container-registry.com/8gcr-dev/harbor-exporter
         tag: latest
@@ -119,6 +133,8 @@ spec:
 
     trivy:
       enabled: true
+      podAnnotations:
+        deploy.8gears.io/image-revision: "__IMAGE_REVISION__"
       image:
         repository: 8gears.container-registry.com/8gcr-dev/harbor-trivy-adapter
         tag: latest

--- a/deploy/flux/8gcr-dev/ocirepository.yaml
+++ b/deploy/flux/8gcr-dev/ocirepository.yaml
@@ -12,4 +12,5 @@ spec:
     # workflow rewrites this tag on every push to main; the underlying
     # versioned tags (3.0.0-main.<sha7>) stay immutable for traceability.
     tag: 3.0.0-dev
-  # 8gcr-dev is a public Harbor project — anonymous pulls work, no secretRef.
+  secretRef:
+    name: harbor-8gcr-dev-pull


### PR DESCRIPTION
## Summary

Adds a rolling dev image pipeline for `8gcr.container-registry.dev` and wires the Flux bundle so moving `:latest` image tags cause a real pod rollout.

## Changes

- Adds `.github/workflows/dev-images.yml` to build all Harbor component images for `linux/amd64` and `linux/arm64` on non-doc pushes to `main`.
- Pushes `8gcr-dev/harbor-<component>:main-<sha7>` and moves `:latest` after both platform digests are merged.
- Publishes the Flux deploy bundle after image publish, replacing `__IMAGE_REVISION__` with the commit SHA so Helm changes pod annotations and Kubernetes re-pulls `latest`.
- Sets `image.pullPolicy: Always` and `imagePullSecrets` for the 8gcr dev HelmRelease.
- Switches OCIRepository manifests to reference a dedicated `harbor-8gcr-dev-pull` pull secret by name, without committing credential material.
- Updates docs to clarify that registry credentials must be provisioned as cluster secrets, not stored in the public repo.

## Secret handling

No registry credential, docker config JSON, kubeconfig, or SOPS secret data is added. The repo only references the required secret name:

- `flux-system/harbor-8gcr-dev-pull`
- `8gcr-dev-main/harbor-8gcr-dev-pull`

Those secrets must be created in-cluster with credentials that can pull `8gcr-dev/deploy`, `8gcr-dev/chart/harbor-next`, and the `8gcr-dev/harbor-*` images.

## Validation

- `yq` parsed changed workflow and Flux YAML files.
- `actionlint .github/workflows/dev-images.yml .github/workflows/chart-publish.yml`
- `helm template harbor deploy/chart -f <values from deploy/flux/8gcr-dev/helmrelease.yaml> --namespace 8gcr-dev-main`
- `git diff --check`
- staged diff scanned for common secret patterns; `deploy/flux/8gcr-dev/secrets.sops.yaml` is unchanged.

## Live cluster note

The current hz-hopper Flux source still reports `UNAUTHORIZED` until `harbor-8gcr-dev-pull` contains credentials with access to the `8gcr-dev` project. Existing cluster secrets checked during validation did not have that access.
