### PR TITLE
ci: Drop Documentation from release notes

### DIFF
--- a/.github/scripts/format-release-notes.mjs
+++ b/.github/scripts/format-release-notes.mjs
@@ -20,8 +20,8 @@ const sectionNames = new Map([
   ['Bug Fixes', 'Fixes'],
   ['Performance Improvements', 'Updates'],
   ['Code Refactoring', 'Updates'],
-  ['Documentation', 'Updates'],
 ]);
+const droppedSections = new Set(['Documentation']);
 const sectionOrder = ['Commercial Features', 'Features', 'Fixes', 'Updates', 'Upstream', 'Reverts'];
 const sections = new Map(sectionOrder.map(section => [section, []]));
 const trailing = [];
@@ -193,9 +193,13 @@ for (const line of releaseNotesLines(releaseBody)) {
   if (line.startsWith('### ')) {
     sawSection = true;
     currentSection = sectionNames.get(line.slice(4)) ?? line.slice(4);
-    if (!sections.has(currentSection)) {
+    if (!droppedSections.has(currentSection) && !sections.has(currentSection)) {
       sections.set(currentSection, []);
     }
+    continue;
+  }
+
+  if (droppedSections.has(currentSection)) {
     continue;
   }
 

--- a/release-please-config-maintenance.json
+++ b/release-please-config-maintenance.json
@@ -13,7 +13,7 @@
     {"type": "upstream", "section": "Upstream"},
     {"type": "revert",   "section": "Reverts"},
     {"type": "refactor", "section": "Code Refactoring"},
-    {"type": "docs",     "section": "Documentation", "hidden": true},
+    {"type": "docs",     "section": "Documentation"},
     {"type": "test",     "section": "Tests", "hidden": true},
     {"type": "chore",    "section": "Miscellaneous", "hidden": true},
     {"type": "ci",       "section": "CI/CD",          "hidden": true},


### PR DESCRIPTION
## Summary

Release notes are user-facing; `docs:` changes are not something a user acts on when upgrading. This drops the Documentation section from the generated GitHub release notes while keeping `CHANGELOG.md` complete.

Today `format-release-notes.mjs` renames `### Documentation` to `### Updates`, so docs commits are silently folded in next to `perf:` and `refactor:` entries on the release page.

- `.github/scripts/format-release-notes.mjs` — drop the Documentation section instead of remapping it into Updates. `perf:` and `refactor:` still fold into Updates.
- `release-please-config-maintenance.json` — remove `"hidden": true` from `docs`. Hiding it in release-please config removes the section from `CHANGELOG.md` too, which is the wrong lever: the patch-line CHANGELOG was missing its Documentation section entirely. The formatter now handles the release-notes side for both the minor and patch lines.

`release-please-config.json` needs no change; `docs` was already visible there.

## Type of Change

- [x] CI/CD change (`ci:`)

## Testing

Ran `format-release-notes.mjs` against a fixture release body containing Features, Bug Fixes, Performance Improvements, Documentation, Code Refactoring, and Reverts sections:

- Documentation entries no longer appear anywhere in the output.
- `perf:` and `refactor:` entries still merge into `### Updates`.
- No empty `### Documentation` heading is emitted, and no other section shifted.

## Checklist

- [x] Title follows Conventional Commits
- [x] Commit is DCO signed off
- [x] No new warnings