### PR TITLE
fix(scan): Keep SBOM accessory push on the local registry when CORE_URL has no port

### DIFF
--- a/src/pkg/scan/util.go
+++ b/src/pkg/scan/util.go
@@ -40,6 +40,25 @@ func RemoteOptions() []remote.Option {
 	return []remote.Option{remote.WithTransport(tr)}
 }
 
+// accessoryRef builds the reference the accessory artifact is pushed to. The
+// registry host is constructed as a typed name.Registry instead of being
+// string-joined into name.ParseReference: ParseReference only treats the first
+// path segment as a registry if it contains a '.' or ':', so a portless
+// single-label host like "harbor-core" (the in-cluster core service) would be
+// parsed as a Docker Hub namespace and the push would leave the cluster,
+// sending robot credentials to auth.docker.io.
+func accessoryRef(registryURL, repository, dgst string, insecure bool) (name.Reference, error) {
+	var opts []name.Option
+	if insecure {
+		opts = append(opts, name.Insecure)
+	}
+	reg, err := name.NewRegistry(registryURL, opts...)
+	if err != nil {
+		return nil, fmt.Errorf("parsing registry %q: %w", registryURL, err)
+	}
+	return reg.Repo(repository).Digest(dgst), nil
+}
+
 // GenAccessoryArt composes the accessory oci object and push it back to harbor core as an accessory of the scanned artifact.
 func GenAccessoryArt(sq v1sq.ScanRequest, accData []byte, accAnnotations map[string]string, mediaType string, robot *model.Robot) (string, error) {
 	createdTime := v1.Time{}
@@ -83,10 +102,7 @@ func GenAccessoryArt(sq v1sq.ScanRequest, accData []byte, accAnnotations map[str
 	if err != nil {
 		return "", err
 	}
-	accRef, err := name.ParseReference(fmt.Sprintf("%s/%s@%s", sq.Registry.URL, sq.Artifact.Repository, dgst.String()))
-	if sq.Registry.Insecure {
-		accRef, err = name.ParseReference(fmt.Sprintf("%s/%s@%s", sq.Registry.URL, sq.Artifact.Repository, dgst.String()), name.Insecure)
-	}
+	accRef, err := accessoryRef(sq.Registry.URL, sq.Artifact.Repository, dgst.String(), sq.Registry.Insecure)
 	if err != nil {
 		return "", err
 	}

--- a/src/pkg/scan/util_test.go
+++ b/src/pkg/scan/util_test.go
@@ -59,3 +59,72 @@ func TestGenAccessoryArt(t *testing.T) {
 	assert.Nil(t, err)
 	assert.Equal(t, "sha256:a39c6456d3cd1d87b7ee5706f67133d7a6d27a2dbc9ed66d50e504ff8920efc3", s)
 }
+
+func TestAccessoryRef(t *testing.T) {
+	const dgst = "sha256:13b9614bcc1fe99b09889f037935912fab2d98196d6090aef1719aef0511ceb4"
+
+	cases := []struct {
+		name         string
+		registryURL  string
+		repository   string
+		insecure     bool
+		wantRegistry string
+		wantScheme   string
+	}{
+		{
+			// A single-label host without a port is what the in-cluster
+			// CORE_URL resolves to when the chart omits the service port.
+			// name.ParseReference would classify it as a Docker Hub namespace.
+			name:         "portless single-label host stays the registry",
+			registryURL:  "harbor-core",
+			repository:   "library/app",
+			insecure:     true,
+			wantRegistry: "harbor-core",
+			wantScheme:   "http",
+		},
+		{
+			name:         "host with port",
+			registryURL:  "harbor-core:80",
+			repository:   "library/app",
+			insecure:     true,
+			wantRegistry: "harbor-core:80",
+			wantScheme:   "http",
+		},
+		{
+			name:         "fqdn without port, secure",
+			registryURL:  "harbor.example.com",
+			repository:   "library/app",
+			insecure:     false,
+			wantRegistry: "harbor.example.com",
+			wantScheme:   "https",
+		},
+		{
+			// Harbor project names may contain dots; the repository must
+			// never be re-parsed for a registry component.
+			name:         "dotted project name is not mistaken for a registry",
+			registryURL:  "harbor-core",
+			repository:   "my.project/app",
+			insecure:     true,
+			wantRegistry: "harbor-core",
+			wantScheme:   "http",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			ref, err := accessoryRef(tc.registryURL, tc.repository, dgst, tc.insecure)
+			assert.NoError(t, err)
+			assert.Equal(t, tc.wantRegistry, ref.Context().RegistryStr())
+			assert.NotEqual(t, "index.docker.io", ref.Context().RegistryStr())
+			assert.Equal(t, tc.repository, ref.Context().RepositoryStr())
+			assert.Equal(t, tc.wantScheme, ref.Context().Registry.Scheme())
+			assert.Equal(t, dgst, ref.Identifier())
+		})
+	}
+}
+
+func TestAccessoryRefInvalidRegistry(t *testing.T) {
+	_, err := accessoryRef("harbor core with spaces", "library/app",
+		"sha256:13b9614bcc1fe99b09889f037935912fab2d98196d6090aef1719aef0511ceb4", false)
+	assert.Error(t, err)
+}


### PR DESCRIPTION

`GenAccessoryArt` (`src/pkg/scan/util.go`) builds the accessory push target by string-joining the registry URL into `name.ParseReference`:

```go
name.ParseReference(fmt.Sprintf("%s/%s@%s", sq.Registry.URL, sq.Artifact.Repository, dgst))
```

go-containerregistry only treats the first path segment as a registry **iff it contains a `.` or `:`**. The SBOM handler strips the scheme from `CORE_URL` before this point (`sbom.go`), so a portless in-cluster URL (`http://harbor-core`) becomes the bare string `harbor-core` — no dot, no colon — and the whole reference parses as a **Docker Hub repository**:

```
GET https://auth.docker.io/token?scope=repository%3Aharbor-core%2F8gcr%2Ftrivy-adapter%3Apush%2Cpull&service=registry.docker.io
→ 400 Bad Request {"details":"malformed HTTP Authorization header"}
```

The robot account's credentials are sent to `auth.docker.io`, every SBOM generation fails, and the failures are disguised: they log under the `IMAGE_SCAN` job name, while vulnerability scanning keeps working (the trivy adapter re-adds the default port on its own side — that asymmetry is why only SBOM breaks).

Observed in production on three instances running the harbor-next chart (whose `harbor.core.url` helper omits the service port — flagged separately on the chart PR: container-registry/harbor-next#56 [comment](https://github.com/container-registry/harbor-next/pull/56#issuecomment-4963559423)): no `sbom.harbor` accessory created since the chart migration, every scan-all ending `Error`.

## Fix

Construct the reference from typed parts so the registry component is never re-parsed heuristically:

```go
reg, err := name.NewRegistry(registryURL, opts...)   // name.Insecure when http
accRef := reg.Repo(repository).Digest(dgst)
```

Any valid host now works with or without a port, and a dotted repository path segment can never be mistaken for a registry either. Harbor must behave correctly outside Helm too (compose, bare manifests), so this belongs in code rather than relying on installers to always embed a port — though the chart should keep the port regardless, since upstream goharbor images carry this bug in every released version.

Verified against the production repro (ggcr v0.20.7):

```
BUG portless (old code)        registry=index.docker.io  scope=repository:harbor-core/8gcr/trivy-adapter:push,pull
typed construction, portless   registry=harbor-core      scope=repository:8gcr/trivy-adapter:push,pull  scheme=http
```

## Tests

- `TestAccessoryRef`: portless single-label host, host with port, FQDN/secure scheme, dotted project name — plus the explicit `!= index.docker.io` regression assertion.
- `TestAccessoryRefInvalidRegistry`: invalid host errors.
- Pre-existing `TestGenAccessoryArt` (end-to-end against ggcr's in-memory registry) still passes unchanged.

Upstream goharbor/harbor has the identical code path in `GenAccessoryArt`; this is upstreamable as-is.
