### PR TITLE
fix: Locked users authenticate as nil instead of returning an error

### DIFF
--- a/src/core/auth/authenticator.go
+++ b/src/core/auth/authenticator.go
@@ -150,8 +150,7 @@ func Login(ctx context.Context, m models.AuthModel) (*models.User, error) {
 	}
 	if lock.IsLocked(m.Principal) {
 		log.Debugf("%s is locked due to login failure, login failed", m.Principal)
-		// nolint:nilnil // user is locked
-		return nil, nil
+		return nil, NewErrAuth("user is locked due to repeated login failures")
 	}
 	user, err := authenticator.Authenticate(ctx, m)
 	if err != nil {

--- a/src/core/auth/authenticator_test.go
+++ b/src/core/auth/authenticator_test.go
@@ -1,0 +1,61 @@
+// Copyright Project Harbor Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package auth
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/goharbor/harbor/src/common"
+	"github.com/goharbor/harbor/src/common/models"
+	"github.com/goharbor/harbor/src/lib/config"
+	_ "github.com/goharbor/harbor/src/pkg/config/inmemory"
+)
+
+// stubAuthenticateHelper always succeeds, so any lock rejection observed in
+// a test can only come from the lock check itself, not from Authenticate.
+type stubAuthenticateHelper struct {
+	DefaultAuthenticateHelper
+}
+
+func (*stubAuthenticateHelper) Authenticate(_ context.Context, m models.AuthModel) (*models.User, error) {
+	return &models.User{Username: m.Principal}, nil
+}
+
+// TestLoginLockedUserReturnsError guards against a regression of the bug where a
+// locked principal made Login return (nil, nil): callers that don't explicitly
+// nil-check the user (as opposed to checking err != nil) would treat that as a
+// successful, anonymous authentication instead of a rejection.
+func TestLoginLockedUserReturnsError(t *testing.T) {
+	// AUTH_MODE left unset resolves to "", which Login maps to common.DBAuth
+	// without consulting IsSuperUser (which needs a real user store) - see the
+	// authMode == "" short-circuit in Login.
+	config.InitWithSettings(map[string]any{})
+	Register(common.DBAuth, &stubAuthenticateHelper{})
+
+	principal := "locked-test-user"
+	lock.Lock(principal)
+
+	user, err := Login(context.Background(), models.AuthModel{
+		Principal: principal,
+		Password:  "irrelevant",
+	})
+
+	assert.Nil(t, user)
+	if assert.Error(t, err) {
+		assert.IsType(t, ErrAuth{}, err)
+	}
+}


### PR DESCRIPTION
## Summary

Fixes #480.

`auth.Login()` returned `(nil, nil)` when a principal was locked due to repeated login failures, instead of an error. Callers that check `err != nil` alone (the common Go idiom) rather than explicitly nil-checking the returned user would treat a locked account as a successful, anonymous authentication.

## Change

`src/core/auth/authenticator.go`: the lock check in `Login()` now returns `NewErrAuth("user is locked due to repeated login failures")` instead of `nil, nil`, using the `ErrAuth` type that already exists in this file. Removed the `//nolint:nilnil` comment that was suppressing the linter warning on this exact pattern rather than fixing it.

Both current callers already branch on `err != nil` first:
- `src/core/controllers/base.go` (`CommonController.Login`)
- `src/server/middleware/security/basic_auth.go` (`basicAuth.Generate`)

So this is behaviorally transparent to them today - same 401/nil outcome - but now via the correct typed error instead of relying on every caller remembering to nil-check.

## Testing

Added `src/core/auth/authenticator_test.go` (`TestLoginLockedUserReturnsError`) - this path had zero existing coverage in either the file or its test file. The test registers a stub `AuthenticateHelper`, locks a principal via the package's `lock.Lock()`, calls `Login()`, and asserts an `ErrAuth` is returned with a nil user. Runs fully in-memory (`config.InitWithSettings` + the in-memory config driver), no database required.

## Type of Change
- [x] Bug fix

## Context

Extracted from `goharbor/harbor#23483`, which bundles this fix together with a much larger, unrelated `auth_mode` dispatch refactor that upstream maintainers flagged as too large to review as one PR. This is the locked-user portion in isolation.