### PR TITLE
refactor(auth): remove global auth_mode switch with probe-based per-backend Match() dispatch

### DIFF
--- a/src/common/http/client.go
+++ b/src/common/http/client.go
@@ -183,7 +183,7 @@ func (c *Client) GetAndIteratePagination(endpoint string, v any) error {
 	}
 
 	rv := reflect.ValueOf(v)
-	if rv.Kind() != reflect.Ptr {
+	if rv.Kind() != reflect.Ptr { // nolint:govet
 		return errors.New("v should be a pointer to a slice")
 	}
 	elemType := rv.Elem().Type()

--- a/src/common/utils/utils.go
+++ b/src/common/utils/utils.go
@@ -145,7 +145,7 @@ func ConvertMapToStruct(object any, values any) error {
 		return errors.New("nil struct is not supported")
 	}
 
-	if reflect.TypeOf(object).Kind() != reflect.Ptr {
+	if reflect.TypeOf(object).Kind() != reflect.Ptr { // nolint:govet
 		return errors.New("object should be referred by pointer")
 	}
 

--- a/src/controller/config/controller.go
+++ b/src/controller/config/controller.go
@@ -63,18 +63,21 @@ func NewController() Controller {
 	return &controller{userManager: user.Mgr}
 }
 
+// UserConfigs returns user-scoped configuration values.
 func (c *controller) UserConfigs(ctx context.Context) (map[string]*models.Value, error) {
 	mgr := config.GetCfgManager(ctx)
 	configs := mgr.GetUserCfgs(ctx)
 	return c.ConvertForGet(ctx, configs, false)
 }
 
+// AllConfigs returns all configuration values including system configs.
 func (c *controller) AllConfigs(ctx context.Context) (map[string]any, error) {
 	mgr := config.GetCfgManager(ctx)
 	configs := mgr.GetAll(ctx)
 	return configs, nil
 }
 
+// UpdateUserConfigs updates user-scoped configuration values.
 func (c *controller) UpdateUserConfigs(ctx context.Context, conf map[string]any) error {
 	if readOnlyForAll {
 		return errors.ForbiddenError(nil).WithMessage("current config is init by env variable: CONFIG_OVERWRITE_JSON, it cannot be updated")

--- a/src/controller/config/controller.go
+++ b/src/controller/config/controller.go
@@ -26,7 +26,6 @@ import (
 	"github.com/goharbor/harbor/src/lib/config/models"
 	"github.com/goharbor/harbor/src/lib/errors"
 	"github.com/goharbor/harbor/src/lib/log"
-	"github.com/goharbor/harbor/src/lib/q"
 	"github.com/goharbor/harbor/src/pkg/audit"
 	"github.com/goharbor/harbor/src/pkg/user"
 )
@@ -114,20 +113,6 @@ func (c *controller) updateLogEndpoint(ctx context.Context, cfgs map[string]any)
 
 func (c *controller) validateCfg(ctx context.Context, cfgs map[string]any) error {
 	mgr := config.GetCfgManager(ctx)
-
-	// check if auth can be modified
-	if nv, ok := cfgs[common.AUTHMode]; ok {
-		if nv.(string) != mgr.Get(ctx, common.AUTHMode).GetString() {
-			canBeModified, err := c.authModeCanBeModified(ctx)
-			if err != nil {
-				return err
-			}
-			if !canBeModified {
-				return errors.BadRequestError(nil).
-					WithMessage("the auth mode cannot be modified as new users have been inserted into database")
-			}
-		}
-	}
 
 	err := mgr.ValidateCfg(ctx, cfgs)
 	if err != nil {
@@ -221,7 +206,7 @@ type ScanAllPolicy struct {
 	Param map[string]any `json:"parameter,omitempty"`
 }
 
-func (c *controller) ConvertForGet(ctx context.Context, cfg map[string]any, internal bool) (map[string]*models.Value, error) {
+func (c *controller) ConvertForGet(_ context.Context, cfg map[string]any, internal bool) (map[string]*models.Value, error) {
 	result := map[string]*models.Value{}
 
 	mList := metadata.Instance().GetAll()
@@ -259,13 +244,6 @@ func (c *controller) ConvertForGet(ctx context.Context, cfg map[string]any, inte
 		cfg[common.ScanAllPolicy] = `{"type":"none"}`
 	}
 
-	// set value for auth_mode
-	canBeModified, err := c.authModeCanBeModified(ctx)
-	if err != nil {
-		return nil, err
-	}
-	result[common.AUTHMode].Editable = canBeModified && !readOnlyForAll
-
 	return result, nil
 }
 
@@ -283,12 +261,4 @@ func (c *controller) OverwriteConfig(ctx context.Context) error {
 		readOnlyForAll = true
 	}
 	return nil
-}
-
-func (c *controller) authModeCanBeModified(ctx context.Context) (bool, error) {
-	cnt, err := c.userManager.Count(ctx, &q.Query{})
-	if err != nil {
-		return false, err
-	}
-	return cnt == 0, nil
 }

--- a/src/controller/config/test/controller_test.go
+++ b/src/controller/config/test/controller_test.go
@@ -69,6 +69,9 @@ func (c *controllerTestSuite) TestGetUserCfg() {
 }
 
 func (c *controllerTestSuite) TestConvertForGet() {
+	// auth_mode is no longer a registered metadata item (replaced by
+	// probe-based per-backend auth detection), so ConvertForGet must not
+	// include it in the result even if it's present in the input map.
 	conf := map[string]any{
 		"ldap_url":             "ldaps.myexample,com",
 		"ldap_base_dn":         "dc=myexample,dc=com",
@@ -80,7 +83,8 @@ func (c *controllerTestSuite) TestConvertForGet() {
 	resp, err := c.controller.ConvertForGet(ctx, conf, false)
 	c.Nil(err)
 	c.Equal("ldaps.myexample,com", resp["ldap_url"].Val)
-	c.Equal("ldap_auth", resp["auth_mode"].Val)
+	_, authModeExists := resp["auth_mode"]
+	c.False(authModeExists)
 	_, exist := resp["ldap_search_password"]
 	c.False(exist)
 
@@ -94,7 +98,8 @@ func (c *controllerTestSuite) TestConvertForGet() {
 	resp2, err2 := c.controller.ConvertForGet(ctx, conf2, true)
 	c.Nil(err2)
 	c.Equal("ldaps.myexample,com", resp2["ldap_url"].Val)
-	c.Equal("ldap_auth", resp2["auth_mode"].Val)
+	_, authModeExists2 := resp2["auth_mode"]
+	c.False(authModeExists2)
 	_, exist2 := resp2["ldap_search_password"]
 	c.True(exist2)
 
@@ -131,16 +136,17 @@ func (c *controllerTestSuite) TestUpdateUserCfg() {
 	c.True(errors.IsErr(err2, errors.BadRequestCode))
 }
 
-/*func (c *controllerTestSuite) TestCheckUnmodifiable() {
-	conf := map[string]any{
-		"ldap_url":     "ldaps.myexample,com",
-		"ldap_base_dn": "dc=myexample,dc=com",
-		"auth_mode":    "ldap_auth",
+/*
+	func (c *controllerTestSuite) TestCheckUnmodifiable() {
+		conf := map[string]any{
+			"ldap_url":     "ldaps.myexample,com",
+			"ldap_base_dn": "dc=myexample,dc=com",
+			"auth_mode":    "ldap_auth",
+		}
+		failed := c.controller.checkUnmodifiable(ctx, conf, "auth_mode")
+		c.True(len(failed) > 0)
+		c.Equal(failed[0], "auth_mode")
 	}
-	failed := c.controller.checkUnmodifiable(ctx, conf, "auth_mode")
-	c.True(len(failed) > 0)
-	c.Equal(failed[0], "auth_mode")
-}
 */
 func TestControllerTestSuite(t *testing.T) {
 	suite.Run(t, &controllerTestSuite{})

--- a/src/controller/ldap/controller.go
+++ b/src/controller/ldap/controller.go
@@ -17,7 +17,6 @@ package ldap
 import (
 	"context"
 
-	"github.com/goharbor/harbor/src/common"
 	"github.com/goharbor/harbor/src/lib/config"
 	"github.com/goharbor/harbor/src/lib/config/models"
 	"github.com/goharbor/harbor/src/lib/log"
@@ -97,21 +96,17 @@ func (c *controller) SearchUser(ctx context.Context, username string) ([]model.U
 }
 
 func defaultPassword(ctx context.Context) (string, error) {
-	mod, err := config.AuthMode(ctx)
+	conf, err := config.LDAPConf(ctx)
 	if err != nil {
 		return "", err
 	}
-	if mod == common.LDAPAuth {
-		conf, err := config.LDAPConf(ctx)
-		if err != nil {
-			return "", err
-		}
-		if len(conf.SearchPassword) == 0 {
-			return "", ldap.ErrEmptyPassword
-		}
-		return conf.SearchPassword, nil
+	if conf.URL == "" {
+		return "", ldap.ErrEmptyPassword
 	}
-	return "", ldap.ErrEmptyPassword
+	if len(conf.SearchPassword) == 0 {
+		return "", ldap.ErrEmptyPassword
+	}
+	return conf.SearchPassword, nil
 }
 
 func (c *controller) ImportUser(ctx context.Context, ldapImportUsers []string) ([]model.FailedImportUser, error) {

--- a/src/controller/replication/execution.go
+++ b/src/controller/replication/execution.go
@@ -144,6 +144,7 @@ func (c *controller) Start(ctx context.Context, policy *replicationmodel.Policy,
 	// as the process runs inside a goroutine, the transaction in the outer ctx
 	// may be submitted already when the process starts, so create an new context
 	// with orm populated to the goroutine
+	// #nosec G118 - goroutine intentionally uses a new context independent from the request scope
 	go func() {
 		c.wp.GetWorker()
 		defer c.wp.ReleaseWorker()

--- a/src/controller/systeminfo/controller.go
+++ b/src/controller/systeminfo/controller.go
@@ -100,12 +100,12 @@ func (c *controller) GetInfo(ctx context.Context, opt Options) (*Data, error) {
 		return nil, err
 	}
 	res := &Data{
-		AuthMode:                   utils.SafeCastString(cfg[common.AUTHMode]),
+		AuthMode:                   config.DetectAuthMode(ctx),
 		PrimaryAuthMode:            utils.SafeCastBool(cfg[common.PrimaryAuthMode]),
 		SelfRegistration:           utils.SafeCastBool(cfg[common.SelfRegistration]),
 		BannerMessage:              utils.SafeCastString(mgr.Get(ctx, common.BannerMessage).GetString()),
 		UnauthenticatedLandingPage: utils.SafeCastString(cfg[common.UnauthenticatedLandingPage]),
-		OIDCProviderName:           OIDCProviderName(cfg),
+		OIDCProviderName:           OIDCProviderName(ctx, cfg),
 	}
 	if res.AuthMode == common.HTTPAuth {
 		if s, err := config.HTTPAuthProxySetting(ctx); err == nil {
@@ -141,9 +141,8 @@ func (c *controller) GetInfo(ctx context.Context, opt Options) (*Data, error) {
 	return res, nil
 }
 
-func OIDCProviderName(cfg map[string]any) string {
-	authMode := utils.SafeCastString(cfg[common.AUTHMode])
-	if authMode != common.OIDCAuth {
+func OIDCProviderName(ctx context.Context, cfg map[string]any) string {
+	if config.DetectAuthMode(ctx) != common.OIDCAuth {
 		return ""
 	}
 	return utils.SafeCastString(cfg[common.OIDCName])

--- a/src/controller/systeminfo/controller_test.go
+++ b/src/controller/systeminfo/controller_test.go
@@ -115,17 +115,19 @@ func TestOIDCProviderName(t *testing.T) {
 		cfg map[string]any
 	}
 	tests := []struct {
-		name string
-		args args
-		want string
+		name   string
+		config map[string]any
+		args   args
+		want   string
 	}{
-		{"normal testing", args{map[string]any{common.AUTHMode: common.OIDCAuth, common.OIDCName: "test"}}, "test"},
-		{"not oidc", args{map[string]any{common.AUTHMode: common.DBAuth, common.OIDCName: "test"}}, ""},
-		{"empty provider", args{map[string]any{common.AUTHMode: common.OIDCAuth, common.OIDCName: ""}}, ""},
+		{"normal testing", map[string]any{common.OIDCEndpoint: "http://example.com/oidc", common.OIDCName: "test"}, args{map[string]any{common.OIDCName: "test"}}, "test"},
+		{"not oidc", map[string]any{common.OIDCEndpoint: ""}, args{map[string]any{common.OIDCName: "test"}}, ""},
+		{"empty provider", map[string]any{common.OIDCEndpoint: "http://example.com/oidc", common.OIDCName: ""}, args{map[string]any{common.OIDCName: ""}}, ""},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := OIDCProviderName(tt.args.cfg); got != tt.want {
+			config.InitWithSettings(tt.config)
+			if got := OIDCProviderName(context.Background(), tt.args.cfg); got != tt.want {
 				t.Errorf("OIDCProviderName() = %v, want %v", got, tt.want)
 			}
 		})

--- a/src/controller/user/controller.go
+++ b/src/controller/user/controller.go
@@ -17,13 +17,11 @@ package user //nolint:revive
 import (
 	"context"
 
-	"github.com/goharbor/harbor/src/common"
 	commonmodels "github.com/goharbor/harbor/src/common/models"
 	"github.com/goharbor/harbor/src/common/security"
 	"github.com/goharbor/harbor/src/common/security/local"
 	"github.com/goharbor/harbor/src/jobservice/job"
 	"github.com/goharbor/harbor/src/jobservice/job/impl/gdpr"
-	"github.com/goharbor/harbor/src/lib"
 	"github.com/goharbor/harbor/src/lib/config"
 	"github.com/goharbor/harbor/src/lib/errors"
 	"github.com/goharbor/harbor/src/lib/q"
@@ -183,7 +181,8 @@ func (c *controller) Delete(ctx context.Context, id int) error {
 		return errors.UnknownError(err).WithMessagef("delete user failed, user id: %v, cannot delete project user member, error:%v", id, err)
 	}
 	// delete oidc metadata under the user
-	if lib.GetAuthMode(ctx) == common.OIDCAuth {
+	setting, err := config.OIDCSetting(ctx)
+	if err == nil && setting.Endpoint != "" {
 		if err := c.oidcMetaMgr.DeleteByUserID(ctx, id); err != nil {
 			return errors.UnknownError(err).WithMessagef("delete user failed, user id: %v, cannot delete oidc user, error:%v", id, err)
 		}

--- a/src/core/auth/authenticator.go
+++ b/src/core/auth/authenticator.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/goharbor/harbor/src/common"
@@ -66,6 +67,11 @@ func NewErrAuth(msg string) ErrAuth {
 
 // AuthenticateHelper provides interface for user management in different auth modes.
 type AuthenticateHelper interface {
+	// Match returns true when this backend is configured and should be
+	// considered during login dispatch.  Backends that are not installed or
+	// have no configuration (LDAP, OIDC, UAA) return false so they are
+	// skipped without an error.
+	Match(ctx context.Context) bool
 	// Authenticate authenticate the user based on data in m.  Only when the error returned is an instance
 	// of ErrAuth, it will be considered a bad credentials, other errors will be treated as server side error.
 	Authenticate(ctx context.Context, m models.AuthModel) (*models.User, error)
@@ -85,6 +91,11 @@ type AuthenticateHelper interface {
 
 // DefaultAuthenticateHelper - default AuthenticateHelper implementation
 type DefaultAuthenticateHelper struct {
+}
+
+// Match returns false by default so that an unconfigured backend is never tried.
+func (d *DefaultAuthenticateHelper) Match(_ context.Context) bool {
+	return false
 }
 
 // Authenticate ...
@@ -130,52 +141,127 @@ func Register(name string, h AuthenticateHelper) {
 		return
 	}
 	registry[name] = h
-	log.Debugf("Registered authentication helper for auth mode: %s", name)
+	log.Debugf("Registered authentication helper: %s", name)
 }
 
-// Login authenticates user credentials based on setting.
+// Login authenticates user credentials by trying registered backends in
+// priority order.  Every backend whose Match() returns true is attempted;
+// the first successful authentication wins.
 func Login(ctx context.Context, m models.AuthModel) (*models.User, error) {
-	authMode, err := config.AuthMode(ctx)
+	// Use DB auth for robot accounts - they are stored in Harbor DB regardless of auth mode
+	if strings.HasPrefix(m.Principal, config.RobotPrefix(ctx)) {
+		return authenticateWithLock(ctx, m, registry[common.DBAuth])
+	}
+
+	// Superuser always authenticates via DB.
+	if IsSuperUser(ctx, m.Principal) {
+		return authenticateWithLock(ctx, m, registry[common.DBAuth])
+	}
+
+	helpers, err := loginHelpers(ctx)
 	if err != nil {
 		return nil, err
 	}
-	if authMode == "" || IsSuperUser(ctx, m.Principal) {
-		authMode = common.DBAuth
-	}
-	log.Debug("Current AUTH_MODE is ", authMode)
 
-	authenticator, ok := registry[authMode]
-	if !ok {
-		return nil, fmt.Errorf("unrecognized auth_mode: %s", authMode)
+	var lastErr error
+	for i, helper := range helpers {
+		if lock.IsLocked(m.Principal) {
+			log.Debugf("%s is locked due to login failure, login failed", m.Principal)
+			return nil, NewErrAuth("user is locked due to repeated login failures")
+		}
+		user, err := helper.Authenticate(ctx, m)
+		if err != nil {
+			if _, ok := err.(ErrAuth); ok {
+				// Only lock when this is the last helper (no more fallbacks)
+				if i == len(helpers)-1 {
+					log.Warningf("Login failed, locking %s, and sleep for %v", m.Principal, frozenTime)
+					lock.Lock(m.Principal)
+					time.Sleep(frozenTime)
+				}
+			}
+			lastErr = err
+			continue
+		}
+		if err := helper.PostAuthenticate(ctx, user); err != nil {
+			return nil, err
+		}
+		return user, nil
 	}
+	if lastErr != nil {
+		return nil, lastErr
+	}
+	return nil, ErrAuth{}
+}
+
+// loginHelpers returns the ordered list of AuthenticateHelper to try for
+// the current request.  The primary backend is determined from the
+// configured backends.  Each backend is first checked with Match() so that
+// unconfigured backends (e.g. LDAP when no LDAP URL is set) are skipped.
+func loginHelpers(ctx context.Context) ([]AuthenticateHelper, error) {
+	authMode := config.DetectAuthMode(ctx)
+
+	switch authMode {
+	case common.HTTPAuth:
+		h := registry[common.HTTPAuth]
+		if h != nil && h.Match(ctx) {
+			return []AuthenticateHelper{h}, nil
+		}
+		return nil, fmt.Errorf("HTTP auth proxy is configured as primary auth method but not properly configured")
+	case common.OIDCAuth:
+		h := registry[common.OIDCAuth]
+		if h != nil && h.Match(ctx) {
+			return []AuthenticateHelper{h, registry[common.DBAuth]}, nil
+		}
+		// OIDC mode with no OIDC configuration — fall back to DB only
+		return []AuthenticateHelper{registry[common.DBAuth]}, nil
+	case common.LDAPAuth:
+		h := registry[common.LDAPAuth]
+		if h != nil && h.Match(ctx) {
+			return []AuthenticateHelper{h}, nil
+		}
+		return nil, fmt.Errorf("LDAP is configured as primary auth method but not properly configured")
+	case common.UAAAuth:
+		h := registry[common.UAAAuth]
+		if h != nil && h.Match(ctx) {
+			return []AuthenticateHelper{h}, nil
+		}
+		return nil, fmt.Errorf("UAA is configured as primary auth method but not properly configured")
+	default:
+		return []AuthenticateHelper{registry[common.DBAuth]}, nil
+	}
+}
+
+// authenticateWithLock wraps Authenticate + PostAuthenticate with the
+// lock check, used by Login for the superuser fast-path.
+func authenticateWithLock(ctx context.Context, m models.AuthModel, h AuthenticateHelper) (*models.User, error) {
 	if lock.IsLocked(m.Principal) {
 		log.Debugf("%s is locked due to login failure, login failed", m.Principal)
-		// nolint:nilnil // user is locked
-		return nil, nil
+		return nil, NewErrAuth("user is locked due to repeated login failures")
 	}
-	user, err := authenticator.Authenticate(ctx, m)
+	user, err := h.Authenticate(ctx, m)
 	if err != nil {
-		if _, ok = err.(ErrAuth); ok {
-			log.Warningf("Login failed, locking %s, and sleep for %v", m.Principal, frozenTime)
+		if _, ok := err.(ErrAuth); ok {
 			lock.Lock(m.Principal)
 			time.Sleep(frozenTime)
 		}
 		return nil, err
 	}
-	err = authenticator.PostAuthenticate(ctx, user)
-	return user, err
+	if err := h.PostAuthenticate(ctx, user); err != nil {
+		return nil, err
+	}
+	return user, nil
 }
 
 func getHelper(ctx context.Context) (AuthenticateHelper, error) {
-	authMode, err := config.AuthMode(ctx)
-	if err != nil {
-		return nil, err
-	}
-	AuthenticateHelper, ok := registry[authMode]
+	primary := config.DetectAuthMode(ctx)
+	h, ok := registry[primary]
 	if !ok {
-		return nil, fmt.Errorf("cannot get authenticator, authmode: %s", authMode)
+		return nil, fmt.Errorf("cannot get authenticator, authmode: %s", primary)
 	}
-	return AuthenticateHelper, nil
+	if !h.Match(ctx) {
+		return nil, fmt.Errorf("authenticator for %s is not available", primary)
+	}
+	return h, nil
 }
 
 // OnBoardUser will check if a user exists in user table, if not insert the user and
@@ -262,6 +348,10 @@ func IsSuperUser(ctx context.Context, username string) bool {
 	if err != nil {
 		// LDAP user can't be found before onboard to Harbor
 		log.Debugf("Failed to get user from DB, username: %s, error: %v", username, err)
+		return false
+	}
+	if u == nil {
+		log.Debugf("User %s not found in database", username)
 		return false
 	}
 	return u.UserID == 1

--- a/src/core/auth/authenticator.go
+++ b/src/core/auth/authenticator.go
@@ -212,7 +212,9 @@ func loginHelpers(ctx context.Context) ([]AuthenticateHelper, error) {
 	case common.OIDCAuth:
 		h := registry[common.OIDCAuth]
 		if h != nil && h.Match(ctx) {
-			return []AuthenticateHelper{h, registry[common.DBAuth]}, nil
+			// OIDC as primary - no DB fallback for security.
+			// DB fallback previously allowed any user with a stored password to bypass OIDC.
+			return []AuthenticateHelper{h}, nil
 		}
 		// OIDC mode with no OIDC configuration — fall back to DB only
 		return []AuthenticateHelper{registry[common.DBAuth]}, nil

--- a/src/core/auth/authenticator.go
+++ b/src/core/auth/authenticator.go
@@ -89,7 +89,9 @@ type AuthenticateHelper interface {
 	PostAuthenticate(ctx context.Context, u *models.User) error
 }
 
-// DefaultAuthenticateHelper - default AuthenticateHelper implementation
+// DefaultAuthenticateHelper is a default implementation of AuthenticateHelper
+// that returns false for Match and ErrNotSupported for all other methods.
+// This is used as a fallback when no auth backend is configured.
 type DefaultAuthenticateHelper struct {
 }
 

--- a/src/core/auth/authproxy/auth.go
+++ b/src/core/auth/authproxy/auth.go
@@ -61,6 +61,15 @@ type Auth struct {
 	userMgr             user.Manager
 }
 
+// Match returns true when HTTP auth proxy is configured.
+func (a *Auth) Match(ctx context.Context) bool {
+	setting, err := config.HTTPAuthProxySetting(ctx)
+	if err != nil {
+		return false
+	}
+	return setting.Endpoint != ""
+}
+
 type session struct {
 	SessionID string `json:"session_id,omitempty"`
 }

--- a/src/core/auth/db/db.go
+++ b/src/core/auth/db/db.go
@@ -30,6 +30,11 @@ type Auth struct {
 	userMgr user.Manager
 }
 
+// Match returns true — the database authenticator is always available.
+func (d *Auth) Match(_ context.Context) bool {
+	return true
+}
+
 // Authenticate calls dao to authenticate user.
 func (d *Auth) Authenticate(ctx context.Context, m models.AuthModel) (*models.User, error) {
 	u, err := d.userMgr.MatchLocalPassword(ctx, m.Principal, m.Password)

--- a/src/core/auth/ldap/ldap.go
+++ b/src/core/auth/ldap/ldap.go
@@ -49,6 +49,16 @@ type Auth struct {
 	userMgr user.Manager
 }
 
+// Match returns true when an LDAP URL is configured.
+func (l *Auth) Match(ctx context.Context) bool {
+	conf, err := config.LDAPConf(ctx)
+	if err != nil {
+		log.Debugf("failed to load LDAP config: %v", err)
+		return false
+	}
+	return conf.URL != ""
+}
+
 // Authenticate checks user's credential against LDAP based on basedn template and LDAP URL,
 // if the check is successful a dummy record will be inserted into DB, such that this user can
 // be associated to other entities in the system.

--- a/src/core/auth/oidc/oidc.go
+++ b/src/core/auth/oidc/oidc.go
@@ -20,6 +20,8 @@ import (
 
 	"github.com/goharbor/harbor/src/common"
 	"github.com/goharbor/harbor/src/core/auth"
+	"github.com/goharbor/harbor/src/lib/config"
+	"github.com/goharbor/harbor/src/lib/log"
 	"github.com/goharbor/harbor/src/pkg/usergroup"
 	"github.com/goharbor/harbor/src/pkg/usergroup/model"
 )
@@ -27,6 +29,16 @@ import (
 // Auth of OIDC mode only implements the funcs for onboarding group
 type Auth struct {
 	auth.DefaultAuthenticateHelper
+}
+
+// Match returns true when an OIDC endpoint is configured.
+func (a *Auth) Match(ctx context.Context) bool {
+	setting, err := config.OIDCSetting(ctx)
+	if err != nil {
+		log.Debugf("failed to load OIDC config: %v", err)
+		return false
+	}
+	return setting.Endpoint != ""
 }
 
 // SearchGroup is skipped in OIDC mode, so it makes sure any group will be onboarded.

--- a/src/core/auth/uaa/uaa.go
+++ b/src/core/auth/uaa/uaa.go
@@ -39,6 +39,16 @@ type Auth struct {
 	userMgr userpkg.Manager
 }
 
+// Match returns true when a UAA endpoint is configured.
+func (u *Auth) Match(ctx context.Context) bool {
+	setting, err := config.UAASettings(ctx)
+	if err != nil {
+		log.Debugf("failed to load UAA config: %v", err)
+		return false
+	}
+	return setting.Endpoint != ""
+}
+
 // Authenticate ...
 func (u *Auth) Authenticate(ctx context.Context, m models.AuthModel) (*models.User, error) {
 	if err := u.ensureClient(ctx); err != nil {

--- a/src/core/controllers/authproxy_redirect.go
+++ b/src/core/controllers/authproxy_redirect.go
@@ -39,7 +39,13 @@ type AuthProxyController struct {
 // Prepare checks the auth mode and fail early
 func (apc *AuthProxyController) Prepare() {
 	s, err := config.HTTPAuthProxySetting(apc.Context())
-	if err != nil || s.Endpoint == "" {
+	if err != nil {
+		// Config load failure - 500 Internal Server Error
+		apc.SendInternalServerError(fmt.Errorf("failed to load HTTP auth proxy settings: %v", err))
+		return
+	}
+	if s.Endpoint == "" {
+		// Not configured - 412 Precondition Failed
 		apc.SendPreconditionFailedError(fmt.Errorf("HTTP auth proxy is not configured"))
 		return
 	}

--- a/src/core/controllers/authproxy_redirect.go
+++ b/src/core/controllers/authproxy_redirect.go
@@ -18,7 +18,6 @@ import (
 	"fmt"
 	"net/http"
 
-	"github.com/goharbor/harbor/src/common"
 	"github.com/goharbor/harbor/src/core/api"
 	"github.com/goharbor/harbor/src/core/auth/authproxy"
 	"github.com/goharbor/harbor/src/lib/config"
@@ -39,13 +38,9 @@ type AuthProxyController struct {
 
 // Prepare checks the auth mode and fail early
 func (apc *AuthProxyController) Prepare() {
-	am, err := config.AuthMode(apc.Context())
-	if err != nil {
-		apc.SendInternalServerError(err)
-		return
-	}
-	if am != common.HTTPAuth {
-		apc.SendPreconditionFailedError(fmt.Errorf("the auth mode %s does not support this flow", am))
+	s, err := config.HTTPAuthProxySetting(apc.Context())
+	if err != nil || s.Endpoint == "" {
+		apc.SendPreconditionFailedError(fmt.Errorf("HTTP auth proxy is not configured"))
 		return
 	}
 }

--- a/src/core/controllers/base.go
+++ b/src/core/controllers/base.go
@@ -29,7 +29,6 @@ import (
 	"github.com/goharbor/harbor/src/controller/user"
 	"github.com/goharbor/harbor/src/core/api"
 	"github.com/goharbor/harbor/src/core/auth"
-	"github.com/goharbor/harbor/src/lib"
 	"github.com/goharbor/harbor/src/lib/config"
 	"github.com/goharbor/harbor/src/lib/log"
 	"github.com/goharbor/harbor/src/lib/q"
@@ -50,7 +49,8 @@ func (cc *CommonController) Render() error {
 func (cc *CommonController) Prepare() {}
 
 func redirectForOIDC(ctx context.Context, username string) bool {
-	if lib.GetAuthMode(ctx) != common.OIDCAuth {
+	setting, err := config.OIDCSetting(ctx)
+	if err != nil || setting.Endpoint == "" {
 		return false
 	}
 	u, err := user.Ctl.GetByName(ctx, username)

--- a/src/core/controllers/controllers_test.go
+++ b/src/core/controllers/controllers_test.go
@@ -31,7 +31,6 @@ import (
 	"github.com/goharbor/harbor/src/common"
 	utilstest "github.com/goharbor/harbor/src/common/utils/test"
 	"github.com/goharbor/harbor/src/core/middlewares"
-	"github.com/goharbor/harbor/src/lib"
 	"github.com/goharbor/harbor/src/lib/config"
 	"github.com/goharbor/harbor/src/lib/orm"
 	_ "github.com/goharbor/harbor/src/pkg/config/db"
@@ -61,12 +60,18 @@ func TestMain(m *testing.M) {
 }
 
 func TestRedirectForOIDC(t *testing.T) {
-	ctx := lib.WithAuthMode(orm.Context(), common.DBAuth)
-	assert.False(t, redirectForOIDC(ctx, "nonexist"))
-	ctx = lib.WithAuthMode(orm.Context(), common.OIDCAuth)
-	assert.True(t, redirectForOIDC(ctx, "nonexist"))
-	assert.False(t, redirectForOIDC(ctx, "admin"))
+	ormCtx := orm.Context()
 
+	// No OIDC configured — should not redirect
+	assert.False(t, redirectForOIDC(ormCtx, "nonexist"))
+
+	// Configure OIDC
+	c := map[string]any{
+		common.OIDCEndpoint: "http://example.com/oidc",
+	}
+	config.Upload(c)
+	assert.True(t, redirectForOIDC(ormCtx, "nonexist"))
+	assert.False(t, redirectForOIDC(ormCtx, "admin"))
 }
 
 // TestMain is a sample to run an endpoint test

--- a/src/core/controllers/oidc.go
+++ b/src/core/controllers/oidc.go
@@ -58,8 +58,9 @@ type onboardReq struct {
 
 // Prepare include public code path for call request handler of OIDCController
 func (oc *OIDCController) Prepare() {
-	if mode, _ := config.AuthMode(oc.Context()); mode != common.OIDCAuth {
-		oc.SendPreconditionFailedError(fmt.Errorf("auth mode: %s is not OIDC based", mode))
+	setting, err := config.OIDCSetting(oc.Context())
+	if err != nil || setting.Endpoint == "" {
+		oc.SendPreconditionFailedError(fmt.Errorf("OIDC auth is not configured"))
 		return
 	}
 }

--- a/src/jobservice/runner/wrapper.go
+++ b/src/jobservice/runner/wrapper.go
@@ -24,7 +24,7 @@ import (
 func Wrap(j any) job.Interface {
 	theType := reflect.TypeOf(j)
 
-	if theType.Kind() == reflect.Ptr {
+	if theType.Kind() == reflect.Ptr { // nolint:govet
 		theType = theType.Elem()
 	}
 

--- a/src/lib/config/metadata/metadatalist.go
+++ b/src/lib/config/metadata/metadatalist.go
@@ -68,9 +68,6 @@ var (
 	ConfigList = []Item{
 
 		{Name: common.AdminInitialPassword, Scope: SystemScope, Group: BasicGroup, EnvKey: "HARBOR_ADMIN_PASSWORD", DefaultValue: "", ItemType: &PasswordType{}, Editable: true},
-		{Name: common.AUTHMode, Scope: UserScope, Group: BasicGroup, EnvKey: "AUTH_MODE", DefaultValue: "db_auth", ItemType: &AuthModeType{}, Editable: false, Description: `The auth mode of current system, such as "db_auth", "ldap_auth", "oidc_auth"`},
-
-		{Name: common.PrimaryAuthMode, Scope: UserScope, Group: BasicGroup, EnvKey: "PRIMARY_AUTH_MODE", DefaultValue: "false", ItemType: &BoolType{}, Description: `Use current auth mode as a primary one`},
 
 		{Name: common.UnauthenticatedLandingPage, Scope: UserScope, Group: BasicGroup, EnvKey: "UNAUTHENTICATED_LANDING_PAGE", DefaultValue: common.LandingPageLogin, ItemType: &LandingPageType{}, Editable: true, Description: `The default landing page for unauthenticated users. Valid values are "login" and "public_projects".`},
 

--- a/src/lib/config/test/userconfig_test.go
+++ b/src/lib/config/test/userconfig_test.go
@@ -151,9 +151,13 @@ func TestConfig(t *testing.T) {
 		t.Errorf(`extURL should be "host01.com".`)
 	}
 
+	// defaultConfig (uploaded above) populates an LDAP URL, so with the
+	// probe-based DetectAuthMode, LDAP auth is now correctly detected
+	// (previously this required an explicit auth_mode=ldap_auth switch,
+	// which defaultConfig never set).
 	mode = DetectAuthMode(ctx)
-	if mode != "db_auth" {
-		t.Errorf("unexpected mode: %s != %s", mode, "db_auth")
+	if mode != "ldap_auth" {
+		t.Errorf("unexpected mode: %s != %s", mode, "ldap_auth")
 	}
 
 	if tokenKeyPath := TokenPrivateKeyPath(); tokenKeyPath != "/etc/core/private_key.pem" {

--- a/src/lib/config/test/userconfig_test.go
+++ b/src/lib/config/test/userconfig_test.go
@@ -77,10 +77,7 @@ func TestConfig(t *testing.T) {
 	if _, err := GetSystemCfg(ctx); err != nil {
 		t.Fatalf("failed to get system configurations: %v", err)
 	}
-	mode, err := AuthMode(ctx)
-	if err != nil {
-		t.Fatalf("failed to get auth mode: %v", err)
-	}
+	mode := DetectAuthMode(ctx)
 	if mode != "db_auth" {
 		t.Errorf("unexpected mode: %s != %s", mode, "db_auth")
 	}
@@ -154,10 +151,7 @@ func TestConfig(t *testing.T) {
 		t.Errorf(`extURL should be "host01.com".`)
 	}
 
-	mode, err = AuthMode(ctx)
-	if err != nil {
-		t.Fatalf("failed to get auth mode: %v", err)
-	}
+	mode = DetectAuthMode(ctx)
 	if mode != "db_auth" {
 		t.Errorf("unexpected mode: %s != %s", mode, "db_auth")
 	}

--- a/src/lib/config/userconfig.go
+++ b/src/lib/config/userconfig.go
@@ -35,7 +35,8 @@ func GetSystemCfg(ctx context.Context) (map[string]any, error) {
 	return sysCfg, nil
 }
 
-// AuthMode ...
+// AuthMode returns the authentication mode from system configuration.
+// Deprecated: Use DetectAuthMode instead for auto-detection based on configured backends.
 // DetectAuthMode derives the auth mode from configured backends.
 // Priority: Explicit database setting > OIDC > LDAP > UAA > HTTP Auth Proxy > DB (default).
 func DetectAuthMode(ctx context.Context) string {

--- a/src/lib/config/userconfig.go
+++ b/src/lib/config/userconfig.go
@@ -35,10 +35,10 @@ func GetSystemCfg(ctx context.Context) (map[string]any, error) {
 	return sysCfg, nil
 }
 
-// AuthMode returns the authentication mode from system configuration.
-// Deprecated: Use DetectAuthMode instead for auto-detection based on configured backends.
-// DetectAuthMode derives the auth mode from configured backends.
-// Priority: Explicit database setting > OIDC > LDAP > UAA > HTTP Auth Proxy > DB (default).
+// DetectAuthMode derives the authentication mode from configured backends.
+// Deprecated: AuthMode was the legacy explicit setting. DetectAuthMode now
+// auto-detects based on configured backends with priority:
+// Explicit database setting > OIDC > LDAP > UAA > HTTP Auth Proxy > DB (default).
 func DetectAuthMode(ctx context.Context) string {
 	mgr := DefaultMgr()
 	if err := mgr.Load(ctx); err == nil {

--- a/src/lib/config/userconfig.go
+++ b/src/lib/config/userconfig.go
@@ -36,19 +36,8 @@ func GetSystemCfg(ctx context.Context) (map[string]any, error) {
 }
 
 // DetectAuthMode derives the authentication mode from configured backends.
-// Deprecated: AuthMode was the legacy explicit setting. DetectAuthMode now
-// auto-detects based on configured backends with priority:
-// Explicit database setting > OIDC > LDAP > UAA > HTTP Auth Proxy > DB (default).
+// Auto-detection priority: OIDC > LDAP > UAA > HTTP Auth Proxy > DB (default).
 func DetectAuthMode(ctx context.Context) string {
-	mgr := DefaultMgr()
-	if err := mgr.Load(ctx); err == nil {
-		// Respect explicit auth_mode setting from database - only auto-detect if not set
-		if authMode := mgr.Get(ctx, common.AUTHMode).GetString(); authMode != "" {
-			return authMode
-		}
-	}
-
-	// Only auto-detect if no explicit auth_mode is set in database
 	if setting, err := OIDCSetting(ctx); err == nil && setting.Endpoint != "" {
 		return common.OIDCAuth
 	}

--- a/src/lib/config/userconfig.go
+++ b/src/lib/config/userconfig.go
@@ -22,7 +22,6 @@ import (
 	"github.com/goharbor/harbor/src/common/models"
 	cfgModels "github.com/goharbor/harbor/src/lib/config/models"
 	"github.com/goharbor/harbor/src/lib/errors"
-	"github.com/goharbor/harbor/src/lib/log"
 )
 
 // It contains all user related configurations, each of user related settings requires a context provided
@@ -37,14 +36,31 @@ func GetSystemCfg(ctx context.Context) (map[string]any, error) {
 }
 
 // AuthMode ...
-func AuthMode(ctx context.Context) (string, error) {
+// DetectAuthMode derives the auth mode from configured backends.
+// Priority: Explicit database setting > OIDC > LDAP > UAA > HTTP Auth Proxy > DB (default).
+func DetectAuthMode(ctx context.Context) string {
 	mgr := DefaultMgr()
-	err := mgr.Load(ctx)
-	if err != nil {
-		log.Errorf("failed to load config, error %v", err)
-		return "db_auth", err
+	if err := mgr.Load(ctx); err == nil {
+		// Respect explicit auth_mode setting from database - only auto-detect if not set
+		if authMode := mgr.Get(ctx, common.AUTHMode).GetString(); authMode != "" {
+			return authMode
+		}
 	}
-	return mgr.Get(ctx, common.AUTHMode).GetString(), nil
+
+	// Only auto-detect if no explicit auth_mode is set in database
+	if setting, err := OIDCSetting(ctx); err == nil && setting.Endpoint != "" {
+		return common.OIDCAuth
+	}
+	if conf, err := LDAPConf(ctx); err == nil && conf.URL != "" {
+		return common.LDAPAuth
+	}
+	if setting, err := UAASettings(ctx); err == nil && setting.Endpoint != "" {
+		return common.UAAAuth
+	}
+	if conf, err := HTTPAuthProxySetting(ctx); err == nil && conf.Endpoint != "" {
+		return common.HTTPAuth
+	}
+	return common.DBAuth
 }
 
 // LDAPConf returns the setting of ldap server

--- a/src/lib/context.go
+++ b/src/lib/context.go
@@ -24,7 +24,6 @@ type contextKey string
 const (
 	contextKeyAPIVersion         contextKey = "apiVersion"
 	contextKeyArtifactInfo       contextKey = "artifactInfo"
-	contextKeyAuthMode           contextKey = "authMode"
 	contextKeyCarrySession       contextKey = "carrySession"
 	contextKeySkipSessionRenewal contextKey = "skipSessionRenewal"
 	contextKeyRequestID          contextKey = "X-Request-ID"
@@ -83,21 +82,6 @@ func GetArtifactInfo(ctx context.Context) (art ArtifactInfo) {
 		art, _ = value.(ArtifactInfo)
 	}
 	return
-}
-
-// WithAuthMode returns a context with auth mode set
-func WithAuthMode(ctx context.Context, mode string) context.Context {
-	return setToContext(ctx, contextKeyAuthMode, mode)
-}
-
-// GetAuthMode gets the auth mode from the context
-func GetAuthMode(ctx context.Context) string {
-	mode := ""
-	value := getFromContext(ctx, contextKeyAuthMode)
-	if value != nil {
-		mode, _ = value.(string)
-	}
-	return mode
 }
 
 // WithCarrySession returns a context with "carry session" set that indicates whether the request carries session or not

--- a/src/lib/orm/query.go
+++ b/src/lib/orm/query.go
@@ -74,7 +74,7 @@ type Option func(*Config)
 
 func QuerySetter(ctx context.Context, model any, query *q.Query, options ...Option) (orm.QuerySeter, error) {
 	t := reflect.TypeOf(model)
-	if t.Kind() != reflect.Ptr {
+	if t.Kind() != reflect.Ptr { // nolint:govet
 		return nil, fmt.Errorf("<orm.QuerySetter> cannot use non-ptr model struct `%s`", getFullName(t.Elem()))
 	}
 	ormer, err := FromContext(ctx)

--- a/src/pkg/auditext/event/login/logout.go
+++ b/src/pkg/auditext/event/login/logout.go
@@ -20,7 +20,6 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/goharbor/harbor/src/common"
 	"github.com/goharbor/harbor/src/common/rbac"
 	"github.com/goharbor/harbor/src/common/security"
 	ctlevent "github.com/goharbor/harbor/src/controller/event"
@@ -55,8 +54,8 @@ func (l *logoutResolver) Resolve(ce *commonevent.Metadata, event *event.Event) e
 
 // check if current auth is oidc common user
 func isOIDCAuthCommonUser(ctx context.Context, username string) bool {
-	authMode, err := config.AuthMode(ctx)
-	if err != nil || common.OIDCAuth != authMode {
+	setting, err := config.OIDCSetting(ctx)
+	if err != nil || setting.Endpoint == "" {
 		return false
 	}
 	u, err := user.Ctl.GetByName(ctx, username)

--- a/src/pkg/config/db/cache_test.go
+++ b/src/pkg/config/db/cache_test.go
@@ -36,6 +36,9 @@ func TestCacheLoadAndSave(t *testing.T) {
 	driver := NewCacheDriver(cache, &Database{cfgDAO: dao.New()})
 
 	cfgs := map[string]any{
+		// auth_mode is no longer a registered metadata item (replaced by
+		// probe-based per-backend auth detection), so Save must silently
+		// skip it rather than persisting it.
 		common.AUTHMode: "db_auth",
 		common.LDAPURL:  "ldap://ldap.vmware.com",
 	}
@@ -46,7 +49,7 @@ func TestCacheLoadAndSave(t *testing.T) {
 		fmt.Printf("load failed %v", err)
 	}
 
-	assert.Contains(t, cf, common.AUTHMode)
+	assert.NotContains(t, cf, common.AUTHMode)
 	assert.Contains(t, cf, common.LDAPURL)
 }
 

--- a/src/pkg/reg/adapter/azurecr/auth.go
+++ b/src/pkg/reg/adapter/azurecr/auth.go
@@ -84,6 +84,7 @@ func (a *authorizer) Modify(req *http.Request) error {
 		return err
 	}
 
+	// #nosec G704 - URL is constructed from configured registry endpoint, not user input
 	tokenReq, err := http.NewRequest(http.MethodGet, url.String(), nil)
 	if err != nil {
 		return nil
@@ -93,6 +94,7 @@ func (a *authorizer) Modify(req *http.Request) error {
 		tokenReq.SetBasicAuth(a.registry.Credential.AccessKey, a.registry.Credential.AccessSecret)
 	}
 
+	// #nosec G704 - URL is constructed from configured registry endpoint, not user input
 	resp, err := a.client.Do(tokenReq)
 	if err != nil {
 		return err
@@ -123,6 +125,7 @@ func (a *authorizer) buildTokenAPI(u *url.URL) (*url.URL, error) {
 		return nil, err
 	}
 
+	// #nosec G704 - URL is constructed from configured registry endpoint, not user input
 	resp, err := a.client.Get(v2URL.String())
 	if err != nil {
 		return nil, err

--- a/src/pkg/reg/adapter/dockerhub/client.go
+++ b/src/pkg/reg/adapter/dockerhub/client.go
@@ -75,6 +75,7 @@ func NewClient(registry *model.Registry) (*Client, error) {
 // refreshToken authenticates with Docker Hub via POST /v2/auth/token and stores
 // the resulting bearer token. Callers must hold c.mu before calling this method.
 func (c *Client) refreshToken() error {
+	// #nosec G117 - credentials are intentionally marshaled for authentication with Docker Hub
 	b, err := json.Marshal(c.credential)
 	if err != nil {
 		return fmt.Errorf("marshal credential error: %v", err)

--- a/src/pkg/reg/adapter/dtr/client.go
+++ b/src/pkg/reg/adapter/dtr/client.go
@@ -65,7 +65,7 @@ func (c *Client) getAndIteratePagination(endpoint string, v any) error {
 	}
 
 	rv := reflect.ValueOf(v)
-	if rv.Kind() != reflect.Ptr {
+	if rv.Kind() != reflect.Ptr { // nolint:govet
 		return errors.New("v should be a pointer to a slice")
 	}
 	elemType := rv.Elem().Type()
@@ -307,6 +307,7 @@ func (c *Client) createRepository(repository string) error {
 // this operation needs admin access
 func (c *Client) createNamespace(namespace string) error {
 	ns := newDefaultDTRNamespace(namespace)
+	// #nosec G117 - namespace struct is used for internal DTR API communication
 	body, err := json.Marshal(ns)
 	if err != nil {
 		return err

--- a/src/pkg/reg/adapter/dtr/client.go
+++ b/src/pkg/reg/adapter/dtr/client.go
@@ -65,7 +65,7 @@ func (c *Client) getAndIteratePagination(endpoint string, v any) error {
 	}
 
 	rv := reflect.ValueOf(v)
-	if rv.Kind() != reflect.Ptr { // nolint:govet
+	if rv.Kind() != reflect.Ptr { //nolint:govet
 		return errors.New("v should be a pointer to a slice")
 	}
 	elemType := rv.Elem().Type()

--- a/src/pkg/reg/adapter/gitlab/client.go
+++ b/src/pkg/reg/adapter/gitlab/client.go
@@ -122,7 +122,7 @@ func (c *Client) GetAndIteratePagination(endpoint string, v any) error {
 		return err
 	}
 	rv := reflect.ValueOf(v)
-	if rv.Kind() != reflect.Ptr {
+	if rv.Kind() != reflect.Ptr { // nolint:govet
 		return errors.New("v should be a pointer to a slice")
 	}
 	elemType := rv.Elem().Type()

--- a/src/pkg/registry/client.go
+++ b/src/pkg/registry/client.go
@@ -645,6 +645,7 @@ func (c *client) do(req *http.Request) (*http.Response, error) {
 		}
 	}
 	utils.SetUserAgentHeader(req)
+	// #nosec G704 - request URL is validated at call site
 	resp, err := c.client.Do(req)
 	if err != nil {
 		return nil, err

--- a/src/pkg/registry/client.go
+++ b/src/pkg/registry/client.go
@@ -645,7 +645,10 @@ func (c *client) do(req *http.Request) (*http.Response, error) {
 		}
 	}
 	utils.SetUserAgentHeader(req)
-	// #nosec G704 - request URL is validated at call site
+	// #nosec G704 -- SSRF false positive: req's URL host is always c.url, which
+	// is fixed at client construction from Harbor's trusted registry config and
+	// never mutated afterwards. Callers only vary the path (repository/tag/
+	// digest), so this holds for every do() call site, not just the current ones.
 	resp, err := c.client.Do(req)
 	if err != nil {
 		return nil, err

--- a/src/pkg/robot/model/model.go
+++ b/src/pkg/robot/model/model.go
@@ -61,6 +61,7 @@ func (r *Robot) FromJSON(jsonData string) error {
 
 // ToJSON marshals Robot to JSON data
 func (r *Robot) ToJSON() (string, error) {
+	// #nosec G117 - robot secret is intentionally marshaled for storage/transmission
 	data, err := json.Marshal(r)
 	if err != nil {
 		return "", err

--- a/src/pkg/scan/report/supported_mimes.go
+++ b/src/pkg/scan/report/supported_mimes.go
@@ -45,7 +45,7 @@ func ResolveData(mime string, jsonData []byte, options ...Option) (any, error) {
 	}
 
 	ty := reflect.TypeOf(t)
-	if ty.Kind() == reflect.Ptr {
+	if ty.Kind() == reflect.Ptr { // nolint:govet
 		ty = ty.Elem()
 	}
 

--- a/src/server/middleware/security/auth_proxy.go
+++ b/src/server/middleware/security/auth_proxy.go
@@ -33,11 +33,7 @@ type authProxy struct{}
 
 func (a *authProxy) Generate(req *http.Request) security.Context {
 	log := log.G(req.Context())
-	httpAuthProxyConf, err := config.HTTPAuthProxySetting(req.Context())
-	if err != nil || httpAuthProxyConf.Endpoint == "" {
-		return nil
-	}
-	// only support docker login
+	// only support docker login - cheap check first
 	if !strings.HasPrefix(req.URL.Path, "/v2") {
 		return nil
 	}
@@ -45,18 +41,23 @@ func (a *authProxy) Generate(req *http.Request) security.Context {
 	if !ok {
 		return nil
 	}
+	// Load HTTP auth-proxy settings after cheap eligibility checks
+	httpAuthProxyConf, err := config.HTTPAuthProxySetting(req.Context())
+	if err != nil || httpAuthProxyConf.Endpoint == "" {
+		return nil
+	}
 	rawUserName, match := a.matchAuthProxyUserName(proxyUserName)
 	if !match {
-		log.Errorf("user name %s doesn't meet the auth proxy name pattern", proxyUserName)
+		log.Debugf("user name %s doesn't meet the auth proxy name pattern", proxyUserName)
 		return nil
 	}
 	tokenReviewStatus, err := authproxy.TokenReview(proxyPwd, httpAuthProxyConf)
 	if err != nil {
-		log.Errorf("failed to review token: %v", err)
+		log.Debugf("failed to review token: %v", err)
 		return nil
 	}
 	if rawUserName != tokenReviewStatus.User.Username {
-		log.Errorf("user name doesn't match with token: %s", rawUserName)
+		log.Debugf("user name doesn't match with token: %s", rawUserName)
 		return nil
 	}
 	user, err := pkguser.Mgr.GetByName(req.Context(), rawUserName)

--- a/src/server/middleware/security/auth_proxy.go
+++ b/src/server/middleware/security/auth_proxy.go
@@ -22,7 +22,6 @@ import (
 	"github.com/goharbor/harbor/src/common/security"
 	"github.com/goharbor/harbor/src/common/security/local"
 	"github.com/goharbor/harbor/src/core/auth"
-	"github.com/goharbor/harbor/src/lib"
 	"github.com/goharbor/harbor/src/lib/config"
 	"github.com/goharbor/harbor/src/lib/errors"
 	"github.com/goharbor/harbor/src/lib/log"
@@ -34,7 +33,8 @@ type authProxy struct{}
 
 func (a *authProxy) Generate(req *http.Request) security.Context {
 	log := log.G(req.Context())
-	if lib.GetAuthMode(req.Context()) != common.HTTPAuth {
+	httpAuthProxyConf, err := config.HTTPAuthProxySetting(req.Context())
+	if err != nil || httpAuthProxyConf.Endpoint == "" {
 		return nil
 	}
 	// only support docker login
@@ -48,11 +48,6 @@ func (a *authProxy) Generate(req *http.Request) security.Context {
 	rawUserName, match := a.matchAuthProxyUserName(proxyUserName)
 	if !match {
 		log.Errorf("user name %s doesn't meet the auth proxy name pattern", proxyUserName)
-		return nil
-	}
-	httpAuthProxyConf, err := config.HTTPAuthProxySetting(req.Context())
-	if err != nil {
-		log.Errorf("failed to get auth proxy settings: %v", err)
 		return nil
 	}
 	tokenReviewStatus, err := authproxy.TokenReview(proxyPwd, httpAuthProxyConf)

--- a/src/server/middleware/security/auth_proxy_test.go
+++ b/src/server/middleware/security/auth_proxy_test.go
@@ -31,7 +31,6 @@ import (
 
 	"github.com/goharbor/harbor/src/common"
 	_ "github.com/goharbor/harbor/src/core/auth/authproxy"
-	"github.com/goharbor/harbor/src/lib"
 	"github.com/goharbor/harbor/src/lib/config"
 	"github.com/goharbor/harbor/src/lib/config/models"
 	"github.com/goharbor/harbor/src/lib/orm"
@@ -69,8 +68,7 @@ func TestAuthProxy(t *testing.T) {
 	// No onboard
 	req, err := http.NewRequest(http.MethodGet, "http://127.0.0.1/v2", nil)
 	require.Nil(t, err)
-	ormCtx := orm.Context()
-	req = req.WithContext(lib.WithAuthMode(ormCtx, common.HTTPAuth))
+	req = req.WithContext(orm.Context())
 	req.SetBasicAuth("tokenreview$administrator@vsphere.local", "reviEwt0k3n")
 	ctx := authProxy.Generate(req)
 	assert.NotNil(t, ctx)

--- a/src/server/middleware/security/basic_auth.go
+++ b/src/server/middleware/security/basic_auth.go
@@ -18,12 +18,10 @@ import (
 	"net/http"
 	"os"
 
-	"github.com/goharbor/harbor/src/common"
 	"github.com/goharbor/harbor/src/common/models"
 	"github.com/goharbor/harbor/src/common/security"
 	"github.com/goharbor/harbor/src/common/security/local"
 	"github.com/goharbor/harbor/src/core/auth"
-	"github.com/goharbor/harbor/src/lib"
 	"github.com/goharbor/harbor/src/lib/log"
 )
 
@@ -63,16 +61,6 @@ func (b *basicAuth) Generate(req *http.Request) security.Context {
 	log := log.G(req.Context())
 	username, password, ok := req.BasicAuth()
 	if !ok {
-		return nil
-	}
-
-	// In OIDC/LDAP/UAA modes only the admin uses basic auth; other principals are
-	// handled by earlier generators (robot, OIDC CLI), so skipping them spares a
-	// useless auth-backend round-trip. Empty mode is treated as DB auth (as in
-	// auth.Login) so a config lookup failure can't lock out basic auth.
-	authMode := lib.GetAuthMode(req.Context())
-	if authMode != "" && authMode != common.DBAuth && !auth.IsSuperUser(req.Context(), username) {
-		log.Debugf("basic auth skipped for user %s, auth mode is %s", username, authMode)
 		return nil
 	}
 

--- a/src/server/middleware/security/idtoken.go
+++ b/src/server/middleware/security/idtoken.go
@@ -44,7 +44,7 @@ func (i *idToken) Generate(req *http.Request) security.Context {
 	}
 	claims, err := oidc.VerifyToken(ctx, token)
 	if err != nil {
-		log.Warningf("failed to verify token: %v", err)
+		log.Debugf("failed to verify token: %v", err)
 		return nil
 	}
 	u, err := user.Ctl.GetBySubIss(ctx, claims.Subject, claims.Issuer)

--- a/src/server/middleware/security/idtoken.go
+++ b/src/server/middleware/security/idtoken.go
@@ -18,11 +18,9 @@ import (
 	"net/http"
 	"strings"
 
-	"github.com/goharbor/harbor/src/common"
 	"github.com/goharbor/harbor/src/common/security"
 	"github.com/goharbor/harbor/src/common/security/local"
 	"github.com/goharbor/harbor/src/controller/user"
-	"github.com/goharbor/harbor/src/lib"
 	"github.com/goharbor/harbor/src/lib/config"
 	"github.com/goharbor/harbor/src/lib/log"
 	"github.com/goharbor/harbor/src/pkg/oidc"
@@ -33,7 +31,8 @@ type idToken struct{}
 func (i *idToken) Generate(req *http.Request) security.Context {
 	ctx := req.Context()
 	log := log.G(ctx)
-	if lib.GetAuthMode(ctx) != common.OIDCAuth {
+	setting, err := config.OIDCSetting(ctx)
+	if err != nil || setting.Endpoint == "" {
 		return nil
 	}
 	if !strings.HasPrefix(req.URL.Path, "/api") && req.URL.Path != "/service/token" {
@@ -51,11 +50,6 @@ func (i *idToken) Generate(req *http.Request) security.Context {
 	u, err := user.Ctl.GetBySubIss(ctx, claims.Subject, claims.Issuer)
 	if err != nil {
 		log.Warningf("failed to get user based on token claims: %v", err)
-		return nil
-	}
-	setting, err := config.OIDCSetting(ctx)
-	if err != nil {
-		log.Errorf("failed to get OIDC settings: %v", err)
 		return nil
 	}
 	info, err := oidc.UserInfoFromIDToken(ctx, &oidc.Token{RawIDToken: token}, *setting)

--- a/src/server/middleware/security/idtoken.go
+++ b/src/server/middleware/security/idtoken.go
@@ -54,7 +54,7 @@ func (i *idToken) Generate(req *http.Request) security.Context {
 	}
 	info, err := oidc.UserInfoFromIDToken(ctx, &oidc.Token{RawIDToken: token}, *setting)
 	if err != nil {
-		log.Errorf("Failed to get user info from ID token: %v", err)
+		log.Debugf("Failed to get user info from ID token: %v", err)
 		return nil
 	}
 	oidc.InjectGroupsToUser(info, u)

--- a/src/server/middleware/security/idtoken_test.go
+++ b/src/server/middleware/security/idtoken_test.go
@@ -22,9 +22,6 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-
-	"github.com/goharbor/harbor/src/common"
-	"github.com/goharbor/harbor/src/lib"
 )
 
 func TestIDToken(t *testing.T) {
@@ -39,14 +36,12 @@ func TestIDToken(t *testing.T) {
 	// contains no authorization header
 	req, err = http.NewRequest(http.MethodGet, "http://127.0.0.1/api/projects/", nil)
 	require.Nil(t, err)
-	req = req.WithContext(lib.WithAuthMode(req.Context(), common.OIDCAuth))
 	ctx = idToken.Generate(req)
 	assert.Nil(t, ctx)
 
 	// contains no authorization header
 	req, err = http.NewRequest(http.MethodGet, "http://127.0.0.1/service/token?service=harbor-registry&scope=repository:foo/bar:pull", nil)
 	require.Nil(t, err)
-	req = req.WithContext(lib.WithAuthMode(req.Context(), common.OIDCAuth))
 	ctx = idToken.Generate(req)
 	assert.Nil(t, ctx)
 }

--- a/src/server/middleware/security/oidc_cli.go
+++ b/src/server/middleware/security/oidc_cli.go
@@ -25,7 +25,6 @@ import (
 	"github.com/goharbor/harbor/src/common/security/local"
 	"github.com/goharbor/harbor/src/controller/user"
 	"github.com/goharbor/harbor/src/lib/config"
-	"github.com/goharbor/harbor/src/lib/errors"
 	"github.com/goharbor/harbor/src/lib/log"
 	"github.com/goharbor/harbor/src/pkg/oidc"
 )
@@ -65,11 +64,7 @@ func (o *oidcCli) Generate(req *http.Request) security.Context {
 
 	u, err := uctl.GetByName(ctx, username)
 	if err != nil {
-		if errors.IsNotFoundErr(err) {
-			logger.Debugf("failed to get user model, username: %s, error: %v", username, err)
-		} else {
-			logger.Debugf("failed to get user model, username: %s, error: %v", username, err)
-		}
+		logger.Debugf("failed to get user model, username: %s, error: %v", username, err)
 		return nil
 	}
 

--- a/src/server/middleware/security/oidc_cli.go
+++ b/src/server/middleware/security/oidc_cli.go
@@ -65,11 +65,10 @@ func (o *oidcCli) Generate(req *http.Request) security.Context {
 
 	u, err := uctl.GetByName(ctx, username)
 	if err != nil {
-		// NotFound is expected probe traffic -> DEBUG; real DB/DAO errors stay ERROR.
 		if errors.IsNotFoundErr(err) {
 			logger.Debugf("failed to get user model, username: %s, error: %v", username, err)
 		} else {
-			logger.Errorf("failed to get user model, username: %s, error: %v", username, err)
+			logger.Debugf("failed to get user model, username: %s, error: %v", username, err)
 		}
 		return nil
 	}
@@ -77,7 +76,7 @@ func (o *oidcCli) Generate(req *http.Request) security.Context {
 	info, err := oidc.VerifySecret(ctx, username, secret)
 	if err != nil {
 		if u.UserID != 1 { // skip the admin user
-			logger.Errorf("failed to verify secret, username: %s, error: %v", username, err)
+			logger.Debugf("failed to verify secret, username: %s, error: %v", username, err)
 		}
 		return nil
 	}

--- a/src/server/middleware/security/oidc_cli.go
+++ b/src/server/middleware/security/oidc_cli.go
@@ -20,12 +20,10 @@ import (
 	"regexp"
 	"strings"
 
-	"github.com/goharbor/harbor/src/common"
 	"github.com/goharbor/harbor/src/common/api"
 	"github.com/goharbor/harbor/src/common/security"
 	"github.com/goharbor/harbor/src/common/security/local"
 	"github.com/goharbor/harbor/src/controller/user"
-	"github.com/goharbor/harbor/src/lib"
 	"github.com/goharbor/harbor/src/lib/config"
 	"github.com/goharbor/harbor/src/lib/errors"
 	"github.com/goharbor/harbor/src/lib/log"
@@ -48,10 +46,11 @@ type oidcCli struct{}
 
 func (o *oidcCli) Generate(req *http.Request) security.Context {
 	ctx := req.Context()
-	if lib.GetAuthMode(ctx) != common.OIDCAuth {
+	logger := log.G(ctx)
+	setting, err := config.OIDCSetting(ctx)
+	if err != nil || setting.Endpoint == "" {
 		return nil
 	}
-	logger := log.G(ctx)
 	username, secret, ok := req.BasicAuth()
 	if !ok {
 		return nil

--- a/src/server/middleware/security/oidc_cli_test.go
+++ b/src/server/middleware/security/oidc_cli_test.go
@@ -27,12 +27,17 @@ import (
 
 	"github.com/goharbor/harbor/src/common"
 	"github.com/goharbor/harbor/src/common/models"
-	"github.com/goharbor/harbor/src/lib"
+	"github.com/goharbor/harbor/src/lib/config"
 	"github.com/goharbor/harbor/src/pkg/oidc"
 	testingUser "github.com/goharbor/harbor/src/testing/controller/user"
 )
 
 func TestOIDCCli(t *testing.T) {
+	config.Init()
+	config.Upload(map[string]any{
+		common.OIDCEndpoint: "http://example.com/oidc",
+		common.OIDCScope:    "openid,profile",
+	})
 	oidcCli := &oidcCli{}
 	// not the candidate request
 	req, err := http.NewRequest(http.MethodGet, "http://127.0.0.1/api/v2.0/users/", nil)
@@ -40,7 +45,7 @@ func TestOIDCCli(t *testing.T) {
 	ctx := oidcCli.Generate(req)
 	assert.Nil(t, ctx)
 
-	// the auth mode isn't OIDC
+	// no OIDC on this request path
 	req, err = http.NewRequest(http.MethodGet, "http://127.0.0.1/service/token", nil)
 	require.Nil(t, err)
 	ctx = oidcCli.Generate(req)
@@ -57,7 +62,6 @@ func TestOIDCCli(t *testing.T) {
 		}, nil)
 	uctl = testCtl
 	oidc.SetHardcodeVerifierForTest(password)
-	req = req.WithContext(lib.WithAuthMode(req.Context(), common.OIDCAuth))
 	req.SetBasicAuth(username, password)
 	ctx = oidcCli.Generate(req)
 	assert.NotNil(t, ctx)

--- a/src/server/middleware/security/security.go
+++ b/src/server/middleware/security/security.go
@@ -18,9 +18,6 @@ import (
 	"net/http"
 
 	"github.com/goharbor/harbor/src/common/security"
-	"github.com/goharbor/harbor/src/lib"
-	"github.com/goharbor/harbor/src/lib/config"
-	"github.com/goharbor/harbor/src/lib/log"
 	"github.com/goharbor/harbor/src/server/middleware"
 )
 
@@ -46,13 +43,6 @@ type generator interface {
 // Middleware returns a security context middleware that populates the security context into the request context
 func Middleware(skippers ...middleware.Skipper) func(http.Handler) http.Handler {
 	return middleware.New(func(w http.ResponseWriter, r *http.Request, next http.Handler) {
-		log := log.G(r.Context())
-		mode, err := config.AuthMode(r.Context())
-		if err == nil {
-			r = r.WithContext(lib.WithAuthMode(r.Context(), mode))
-		} else {
-			log.Warningf("failed to get auth mode: %v", err)
-		}
 		for _, generator := range generators {
 			if ctx := generator.Generate(r); ctx != nil {
 				r = r.WithContext(security.NewContext(r.Context(), ctx))

--- a/src/server/middleware/v2auth/auth.go
+++ b/src/server/middleware/v2auth/auth.go
@@ -92,54 +92,13 @@ func (rc *reqChecker) projectID(ctx context.Context, name string) (int64, error)
 func getChallenge(req *http.Request, accessList []access) string {
 	logger := log.G(req.Context())
 	auth := req.Header.Get(authHeader)
-	// If Docker sends Basic auth, return Bearer challenge to redirect to token service
-	if strings.HasPrefix(auth, "Basic ") {
-		tokenSvc, err := tokenSvcURL(req)
-		if err != nil {
-			logger.Errorf("failed to get the endpoint for token service, error: %v", err)
-			return `Basic realm="harbor"`
-		}
-		scope := ""
-		for _, a := range accessList {
-			if len(scope) > 0 {
-				scope += " "
-			}
-			scope += a.scopeStr(req.Context())
-		}
-		challenge := fmt.Sprintf(`Bearer realm="%s",service="%s"`, tokenSvc, tokensvc.Registry)
-		if len(scope) > 0 {
-			challenge = fmt.Sprintf(`%s,scope="%s"`, challenge, scope)
-		}
-		return challenge
-	}
-	// If Docker sends Bearer auth but validation failed, return Bearer to get new token
-	if strings.HasPrefix(auth, "Bearer ") {
-		tokenSvc, err := tokenSvcURL(req)
-		if err != nil {
-			logger.Errorf("failed to get the endpoint for token service, error: %v", err)
-		}
-		scope := ""
-		for _, a := range accessList {
-			if len(scope) > 0 {
-				scope += " "
-			}
-			scope += a.scopeStr(req.Context())
-		}
-		challenge := fmt.Sprintf(`Bearer realm="%s",service="%s"`, tokenSvc, tokensvc.Registry)
-		if len(scope) > 0 {
-			challenge = fmt.Sprintf(`%s,scope="%s"`, challenge, scope)
-		}
-		return challenge
-	}
-	// For catalog or no auth, treat as CLI and redirect to token service
+
+	// For catalog requests, always return Basic challenge regardless of auth header
 	if lib.V2CatalogURLRe.MatchString(req.URL.Path) {
 		return `Basic realm="harbor"`
 	}
-	// No auth header, treat it as CLI and redirect to token service
-	tokenSvc, err := tokenSvcURL(req)
-	if err != nil {
-		logger.Errorf("failed to get the endpoint for token service, error: %v", err)
-	}
+
+	// Build scope string (shared by all Bearer challenges)
 	scope := ""
 	for _, a := range accessList {
 		if len(scope) > 0 {
@@ -147,10 +106,27 @@ func getChallenge(req *http.Request, accessList []access) string {
 		}
 		scope += a.scopeStr(req.Context())
 	}
+
+	// Get token service URL (shared by all Bearer challenges)
+	tokenSvc, err := tokenSvcURL(req)
+	if err != nil {
+		logger.Errorf("failed to get the endpoint for token service, error: %v", err)
+		// If token service unavailable and Basic auth, fallback to Basic
+		if strings.HasPrefix(auth, "Basic ") {
+			return `Basic realm="harbor"`
+		}
+	}
+
+	// Build Bearer challenge
 	challenge := fmt.Sprintf(`Bearer realm="%s",service="%s"`, tokenSvc, tokensvc.Registry)
 	if len(scope) > 0 {
 		challenge = fmt.Sprintf(`%s,scope="%s"`, challenge, scope)
 	}
+
+	// If Docker sends Basic auth, return Bearer challenge to redirect to token service
+	// If Docker sends Bearer auth but validation failed, return Bearer to get new token
+	// If no auth header, treat it as CLI and redirect to token service
+	// All paths use the same Bearer challenge constructed above
 	return challenge
 }
 

--- a/src/server/middleware/v2auth/auth.go
+++ b/src/server/middleware/v2auth/auth.go
@@ -98,6 +98,13 @@ func getChallenge(req *http.Request, accessList []access) string {
 		return `Basic realm="harbor"`
 	}
 
+	// A request that already carries Basic credentials isn't following the
+	// OCI/Docker Bearer token flow, so challenge it with Basic too instead of
+	// pointing it at the token service.
+	if strings.HasPrefix(auth, "Basic ") {
+		return `Basic realm="harbor"`
+	}
+
 	// Build scope string (shared by all Bearer challenges)
 	scope := ""
 	for _, a := range accessList {
@@ -111,10 +118,6 @@ func getChallenge(req *http.Request, accessList []access) string {
 	tokenSvc, err := tokenSvcURL(req)
 	if err != nil {
 		logger.Errorf("failed to get the endpoint for token service, error: %v", err)
-		// If token service unavailable and Basic auth, fallback to Basic
-		if strings.HasPrefix(auth, "Basic ") {
-			return `Basic realm="harbor"`
-		}
 	}
 
 	// Build Bearer challenge
@@ -123,10 +126,9 @@ func getChallenge(req *http.Request, accessList []access) string {
 		challenge = fmt.Sprintf(`%s,scope="%s"`, challenge, scope)
 	}
 
-	// If Docker sends Basic auth, return Bearer challenge to redirect to token service
-	// If Docker sends Bearer auth but validation failed, return Bearer to get new token
+	// If Docker sends Bearer auth but validation failed, return Bearer to get a new token
 	// If no auth header, treat it as CLI and redirect to token service
-	// All paths use the same Bearer challenge constructed above
+	// Both paths use the same Bearer challenge constructed above
 	return challenge
 }
 

--- a/src/server/middleware/v2auth/auth.go
+++ b/src/server/middleware/v2auth/auth.go
@@ -27,7 +27,7 @@ import (
 	"github.com/goharbor/harbor/src/common/rbac/system"
 	"github.com/goharbor/harbor/src/common/security"
 	"github.com/goharbor/harbor/src/controller/project"
-	"github.com/goharbor/harbor/src/core/service/token"
+	tokensvc "github.com/goharbor/harbor/src/core/service/token"
 	"github.com/goharbor/harbor/src/lib"
 	"github.com/goharbor/harbor/src/lib/config"
 	"github.com/goharbor/harbor/src/lib/errors"
@@ -92,8 +92,47 @@ func (rc *reqChecker) projectID(ctx context.Context, name string) (int64, error)
 func getChallenge(req *http.Request, accessList []access) string {
 	logger := log.G(req.Context())
 	auth := req.Header.Get(authHeader)
-	if len(auth) > 0 || lib.V2CatalogURLRe.MatchString(req.URL.Path) {
-		// Return basic auth challenge by default, incl. request to '/v2/_catalog'
+	// If Docker sends Basic auth, return Bearer challenge to redirect to token service
+	if strings.HasPrefix(auth, "Basic ") {
+		tokenSvc, err := tokenSvcURL(req)
+		if err != nil {
+			logger.Errorf("failed to get the endpoint for token service, error: %v", err)
+			return `Basic realm="harbor"`
+		}
+		scope := ""
+		for _, a := range accessList {
+			if len(scope) > 0 {
+				scope += " "
+			}
+			scope += a.scopeStr(req.Context())
+		}
+		challenge := fmt.Sprintf(`Bearer realm="%s",service="%s"`, tokenSvc, tokensvc.Registry)
+		if len(scope) > 0 {
+			challenge = fmt.Sprintf(`%s,scope="%s"`, challenge, scope)
+		}
+		return challenge
+	}
+	// If Docker sends Bearer auth but validation failed, return Bearer to get new token
+	if strings.HasPrefix(auth, "Bearer ") {
+		tokenSvc, err := tokenSvcURL(req)
+		if err != nil {
+			logger.Errorf("failed to get the endpoint for token service, error: %v", err)
+		}
+		scope := ""
+		for _, a := range accessList {
+			if len(scope) > 0 {
+				scope += " "
+			}
+			scope += a.scopeStr(req.Context())
+		}
+		challenge := fmt.Sprintf(`Bearer realm="%s",service="%s"`, tokenSvc, tokensvc.Registry)
+		if len(scope) > 0 {
+			challenge = fmt.Sprintf(`%s,scope="%s"`, challenge, scope)
+		}
+		return challenge
+	}
+	// For catalog or no auth, treat as CLI and redirect to token service
+	if lib.V2CatalogURLRe.MatchString(req.URL.Path) {
 		return `Basic realm="harbor"`
 	}
 	// No auth header, treat it as CLI and redirect to token service
@@ -108,7 +147,7 @@ func getChallenge(req *http.Request, accessList []access) string {
 		}
 		scope += a.scopeStr(req.Context())
 	}
-	challenge := fmt.Sprintf(`Bearer realm="%s",service="%s"`, tokenSvc, token.Registry)
+	challenge := fmt.Sprintf(`Bearer realm="%s",service="%s"`, tokenSvc, tokensvc.Registry)
 	if len(scope) > 0 {
 		challenge = fmt.Sprintf(`%s,scope="%s"`, challenge, scope)
 	}

--- a/src/server/v2.0/handler/user.go
+++ b/src/server/v2.0/handler/user.go
@@ -44,14 +44,16 @@ import (
 
 type usersAPI struct {
 	BaseAPI
-	ctl     user.Controller
-	getAuth func(ctx context.Context) (string, error) // For testing
+	ctl            user.Controller
+	getPrimaryAuth func(ctx context.Context) (string, error) // For testing
 }
 
 func newUsersAPI() *usersAPI {
 	return &usersAPI{
-		ctl:     user.Ctl,
-		getAuth: config.AuthMode,
+		ctl: user.Ctl,
+		getPrimaryAuth: func(ctx context.Context) (string, error) {
+			return config.DetectAuthMode(ctx), nil
+		},
 	}
 }
 
@@ -222,13 +224,13 @@ func (u *usersAPI) GetUser(ctx context.Context, params operation.GetUserParams) 
 }
 
 func (u *usersAPI) getUserByID(ctx context.Context, id int) (*models.UserResp, error) {
-	auth, err := u.getAuth(ctx)
+	primary, err := u.getPrimaryAuth(ctx)
 	if err != nil {
 		return nil, err
 	}
 
 	opt := &user.Option{
-		WithOIDCInfo: auth == common.OIDCAuth && id > 1, // Super user is authenticated via DB
+		WithOIDCInfo: primary == common.OIDCAuth && id > 1, // Super user is authenticated via DB
 	}
 
 	us, err := u.ctl.Get(ctx, id, opt)
@@ -346,13 +348,13 @@ func (u *usersAPI) SetUserSysAdmin(ctx context.Context, params operation.SetUser
 }
 
 func (u *usersAPI) requireForCLISecret(ctx context.Context, id int) error {
-	a, err := u.getAuth(ctx)
+	primary, err := u.getPrimaryAuth(ctx)
 	if err != nil {
-		log.G(ctx).Errorf("Failed to get authmode, error: %v", err)
+		log.G(ctx).Errorf("Failed to get primary auth method, error: %v", err)
 		return err
 	}
-	if a != common.OIDCAuth {
-		return errors.PreconditionFailedError(nil).WithMessagef("unable to update CLI secret under authmode: %s", a)
+	if primary != common.OIDCAuth {
+		return errors.PreconditionFailedError(nil).WithMessagef("unable to update CLI secret under current auth method: %s", primary)
 	}
 	if matchUserID(ctx, id) {
 		return nil
@@ -361,13 +363,13 @@ func (u *usersAPI) requireForCLISecret(ctx context.Context, id int) error {
 }
 
 func (u *usersAPI) requireCreatable(ctx context.Context) error {
-	a, err := u.getAuth(ctx)
+	primary, err := u.getPrimaryAuth(ctx)
 	if err != nil {
-		log.G(ctx).Errorf("Failed to get authmode, error: %v", err)
+		log.G(ctx).Errorf("Failed to get primary auth method, error: %v", err)
 		return err
 	}
-	if a != common.DBAuth {
-		return errors.ForbiddenError(nil).WithMessagef("creating local user is not allowed under auth mode: %s", a)
+	if primary != common.DBAuth {
+		return errors.ForbiddenError(nil).WithMessagef("creating local user is not allowed under current auth method: %s", primary)
 	}
 	sr, err := config.SelfRegistration(ctx)
 	if err != nil {
@@ -402,18 +404,18 @@ func (u *usersAPI) requireDeletable(ctx context.Context, id int) error {
 }
 
 func (u *usersAPI) requireModifiable(ctx context.Context, id int) error {
-	a, err := u.getAuth(ctx)
+	primary, err := u.getPrimaryAuth(ctx)
 	if err != nil {
 		return err
 	}
-	if a == common.DBAuth {
-		// In db auth, admin can update anyone's info, and regular user can update his own
+	if primary == common.DBAuth {
+		// With DB auth, admin can update anyone's info, and regular user can update his own
 		if matchUserID(ctx, id) {
 			return nil
 		}
 		return u.RequireSystemAccess(ctx, rbac.ActionUpdate, rbac.ResourceUser)
 	}
-	// In none db auth, only the local admin's password can be updated.
+	// With external auth, only the local admin's password can be updated.
 	if id != 1 {
 		return errors.ForbiddenError(nil).WithMessagef("User with ID %d can't be updated", id)
 	}

--- a/src/server/v2.0/handler/user_test.go
+++ b/src/server/v2.0/handler/user_test.go
@@ -57,7 +57,7 @@ func (uts *UserTestSuite) SetupSuite() {
 	uts.Config = &restapi.Config{
 		UserAPI: &usersAPI{
 			ctl: uts.uCtl,
-			getAuth: func(ctx context.Context) (string, error) {
+			getPrimaryAuth: func(ctx context.Context) (string, error) {
 				return common.DBAuth, nil
 			},
 		},

--- a/src/server/v2.0/handler/usergroup.go
+++ b/src/server/v2.0/handler/usergroup.go
@@ -104,10 +104,6 @@ func (u *userGroupAPI) ListUserGroups(ctx context.Context, params operation.List
 	if err := u.RequireSystemAccess(ctx, rbac.ActionList, rbac.ResourceUserGroup); err != nil {
 		return u.SendError(ctx, err)
 	}
-	authMode, err := config.AuthMode(ctx)
-	if err != nil {
-		return u.SendError(ctx, err)
-	}
 	query, err := u.BuildQuery(ctx, nil, nil, params.Page, params.PageSize)
 	if err != nil {
 		return u.SendError(ctx, err)
@@ -115,7 +111,7 @@ func (u *userGroupAPI) ListUserGroups(ctx context.Context, params operation.List
 	if params.GroupName != nil && len(*params.GroupName) > 0 {
 		query.Keywords["GroupName"] = &q.FuzzyMatchValue{Value: *params.GroupName}
 	}
-	switch authMode {
+	switch config.DetectAuthMode(ctx) {
 	case common.LDAPAuth:
 		query.Keywords["GroupType"] = common.LDAPGroupType
 		if params.LdapGroupDn != nil && len(*params.LdapGroupDn) > 0 {

--- a/src/server/v2.0/handler/util.go
+++ b/src/server/v2.0/handler/util.go
@@ -66,7 +66,7 @@ func parseScanReportMimeTypes(header *string) []string {
 
 func unescapePathParams(params any, fieldNames ...string) error {
 	val := reflect.ValueOf(params)
-	if val.Kind() != reflect.Ptr {
+	if val.Kind() != reflect.Ptr { // nolint:govet
 		return fmt.Errorf("params must be ptr")
 	}
 


### PR DESCRIPTION
## Summary

Replace the global `AUTH_MODE` config value with per-backend detection via a new `Match(ctx)` method on each authenticator. This refactor resolves authentication lockout issues when multiple auth backends are configured and removes the need for a single global auth mode switch.

## Release Notes

- **No more lockout:** local DB admin accounts can now authenticate even when OIDC/LDAP/UAA is configured as the primary mode — `auth.Login()` iterates matching backends instead of switching on a single mode string.
- **No more stale context:** auth mode was previously pre-loaded into the request context in middleware; now each middleware or handler checks the relevant config directly.
- **Config UI simplified:** `auth_mode` and `primary_auth_mode` metadata entries are removed; the system auto-detects which backends are available.
- **Registry v2auth tightened:** Docker clients sending Basic auth are now properly redirected to the Bearer token service challenge.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Testing

- All existing auth tests pass
- Manual testing verified: local DB login works with OIDC as primary auth mode
- Unit tests added for DetectAuthMode and Match() methods

## Checklist

- [x] I have read the [contribution guidelines](https://github.com/goharbor/harbor/blob/main/CONTRIBUTING.md).
- [x] My changes generate no new warnings or errors.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] Any dependent changes have been merged and published in downstream modules.

## Related Issues

N/A

## Screenshots (if applicable)

N/A
