### PR TITLE
fix(tls): Honor Mounted Custom CA Certificates in Scratch-Based Images

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ We're developing Harbor Next as a [community proposal](https://github.com/goharb
 - Continuous delivery
 - Easy Contributor onboarding with out of the box dev environments
 - Multi-architecture artifacts
-- Scratch images with minimal size and attack surface.
+- Scratch images with minimal size and attack surface — see [Custom CA Certificates](docs/custom-ca-certificates.md) for configuring internal TLS trust in these images.
 - Use of Docker Distribution V3
 - Replicate images to SFTP endpoints
 - Harbor Satellite Support

--- a/dockerfile/core.dockerfile
+++ b/dockerfile/core.dockerfile
@@ -7,7 +7,7 @@ RUN addgroup -S -g 10000 harbor && adduser -S -G harbor -u 10000 harbor && \
 FROM scratch
 COPY --from=certs /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 COPY --from=certs /etc/passwd /etc/group /etc/
-COPY --from=certs /harbor-ca-writable /etc/ssl/harbor-custom-ca
+COPY --chown=10000:10000 --from=certs /harbor-ca-writable /etc/ssl/harbor-custom-ca
 ARG TARGETARCH
 COPY bin/linux-${TARGETARCH}/lprobe /lprobe
 COPY bin/linux-${TARGETARCH}/core /core

--- a/dockerfile/core.dockerfile
+++ b/dockerfile/core.dockerfile
@@ -1,11 +1,13 @@
 ARG ALPINE_VERSION=MISSING-BUILD-ARG
 
 FROM alpine:${ALPINE_VERSION} AS certs
-RUN addgroup -S -g 10000 harbor && adduser -S -G harbor -u 10000 harbor
+RUN addgroup -S -g 10000 harbor && adduser -S -G harbor -u 10000 harbor && \
+    mkdir -p /harbor-ca-writable && chown 10000:10000 /harbor-ca-writable
 
 FROM scratch
 COPY --from=certs /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 COPY --from=certs /etc/passwd /etc/group /etc/
+COPY --from=certs /harbor-ca-writable /etc/ssl/harbor-custom-ca
 ARG TARGETARCH
 COPY bin/linux-${TARGETARCH}/lprobe /lprobe
 COPY bin/linux-${TARGETARCH}/core /core

--- a/dockerfile/exporter.dockerfile
+++ b/dockerfile/exporter.dockerfile
@@ -1,11 +1,13 @@
 ARG ALPINE_VERSION=MISSING-BUILD-ARG
 
 FROM alpine:${ALPINE_VERSION} AS certs
-RUN addgroup -S -g 10000 harbor && adduser -S -G harbor -u 10000 harbor
+RUN addgroup -S -g 10000 harbor && adduser -S -G harbor -u 10000 harbor && \
+    mkdir -p /harbor-ca-writable && chown 10000:10000 /harbor-ca-writable
 
 FROM scratch
 COPY --from=certs /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 COPY --from=certs /etc/passwd /etc/group /etc/
+COPY --from=certs /harbor-ca-writable /etc/ssl/harbor-custom-ca
 ARG TARGETARCH
 COPY bin/linux-${TARGETARCH}/lprobe /lprobe
 ARG harbor_version=dev

--- a/dockerfile/exporter.dockerfile
+++ b/dockerfile/exporter.dockerfile
@@ -7,7 +7,7 @@ RUN addgroup -S -g 10000 harbor && adduser -S -G harbor -u 10000 harbor && \
 FROM scratch
 COPY --from=certs /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 COPY --from=certs /etc/passwd /etc/group /etc/
-COPY --from=certs /harbor-ca-writable /etc/ssl/harbor-custom-ca
+COPY --chown=10000:10000 --from=certs /harbor-ca-writable /etc/ssl/harbor-custom-ca
 ARG TARGETARCH
 COPY bin/linux-${TARGETARCH}/lprobe /lprobe
 ARG harbor_version=dev

--- a/dockerfile/jobservice.dockerfile
+++ b/dockerfile/jobservice.dockerfile
@@ -7,7 +7,7 @@ RUN addgroup -S -g 10000 harbor && adduser -S -G harbor -u 10000 harbor && \
 FROM scratch
 COPY --from=certs /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 COPY --from=certs /etc/passwd /etc/group /etc/
-COPY --from=certs /harbor-ca-writable /etc/ssl/harbor-custom-ca
+COPY --chown=10000:10000 --from=certs /harbor-ca-writable /etc/ssl/harbor-custom-ca
 ARG TARGETARCH
 COPY bin/linux-${TARGETARCH}/lprobe /lprobe
 COPY bin/linux-${TARGETARCH}/jobservice /jobservice

--- a/dockerfile/jobservice.dockerfile
+++ b/dockerfile/jobservice.dockerfile
@@ -1,11 +1,13 @@
 ARG ALPINE_VERSION=MISSING-BUILD-ARG
 
 FROM alpine:${ALPINE_VERSION} AS certs
-RUN addgroup -S -g 10000 harbor && adduser -S -G harbor -u 10000 harbor
+RUN addgroup -S -g 10000 harbor && adduser -S -G harbor -u 10000 harbor && \
+    mkdir -p /harbor-ca-writable && chown 10000:10000 /harbor-ca-writable
 
 FROM scratch
 COPY --from=certs /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 COPY --from=certs /etc/passwd /etc/group /etc/
+COPY --from=certs /harbor-ca-writable /etc/ssl/harbor-custom-ca
 ARG TARGETARCH
 COPY bin/linux-${TARGETARCH}/lprobe /lprobe
 COPY bin/linux-${TARGETARCH}/jobservice /jobservice

--- a/dockerfile/registryctl.dockerfile
+++ b/dockerfile/registryctl.dockerfile
@@ -7,7 +7,7 @@ RUN addgroup -S -g 10000 harbor && adduser -S -G harbor -u 10000 harbor && \
 FROM scratch
 COPY --from=certs /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 COPY --from=certs /etc/passwd /etc/group /etc/
-COPY --from=certs /harbor-ca-writable /etc/ssl/harbor-custom-ca
+COPY --chown=10000:10000 --from=certs /harbor-ca-writable /etc/ssl/harbor-custom-ca
 ARG TARGETARCH
 COPY bin/linux-${TARGETARCH}/lprobe /lprobe
 COPY bin/linux-${TARGETARCH}/registryctl /registryctl

--- a/dockerfile/registryctl.dockerfile
+++ b/dockerfile/registryctl.dockerfile
@@ -1,11 +1,13 @@
 ARG ALPINE_VERSION=MISSING-BUILD-ARG
 
 FROM alpine:${ALPINE_VERSION} AS certs
-RUN addgroup -S -g 10000 harbor && adduser -S -G harbor -u 10000 harbor
+RUN addgroup -S -g 10000 harbor && adduser -S -G harbor -u 10000 harbor && \
+    mkdir -p /harbor-ca-writable && chown 10000:10000 /harbor-ca-writable
 
 FROM scratch
 COPY --from=certs /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 COPY --from=certs /etc/passwd /etc/group /etc/
+COPY --from=certs /harbor-ca-writable /etc/ssl/harbor-custom-ca
 ARG TARGETARCH
 COPY bin/linux-${TARGETARCH}/lprobe /lprobe
 COPY bin/linux-${TARGETARCH}/registryctl /registryctl

--- a/docs/custom-ca-certificates.md
+++ b/docs/custom-ca-certificates.md
@@ -1,0 +1,70 @@
+# Custom CA Certificates for Internal TLS
+
+## Table of Contents
+- [Overview](#overview)
+- [Which Services This Applies To](#which-services-this-applies-to)
+- [Mounting a Custom CA Certificate](#mounting-a-custom-ca-certificate)
+- [Overriding the Mount Directory](#overriding-the-mount-directory)
+- [The `harbor-registry` Exception](#the-harbor-registry-exception)
+- [Troubleshooting](#troubleshooting)
+
+## Overview
+
+Harbor's Helm chart has long supported mounting an operator-supplied CA
+certificate bundle into service containers (via `caBundleSecretName`), at the
+conventional path `/harbor_cust_cert`. `core`, `jobservice`, `registryctl`,
+and `exporter` are built `FROM scratch` with no shell and no
+`update-ca-certificates`, so any certificate mounted there is merged into
+those services' trust store automatically at startup, before any TLS
+connection is attempted.
+
+This matters whenever one of these services makes an outbound TLS connection
+to an endpoint whose certificate isn't signed by a public CA — most notably,
+`core` calling back into the registry's token realm (`.../service/token`)
+when internal TLS is enabled with a private/internal CA.
+
+## Which Services This Applies To
+
+- `core`
+- `jobservice`
+- `registryctl`
+- `exporter`
+
+## Mounting a Custom CA Certificate
+
+Mount one or more `.crt`/`.pem` files into `/harbor_cust_cert` (any other
+file extension or subdirectory is ignored). At startup, each of the services
+above merges every certificate found there into its baked-in system CA
+bundle, and points its outbound TLS stack at the merged result. If the
+directory doesn't exist or is empty — the common case for deployments that
+don't use a private CA — this is a no-op.
+
+## Overriding the Mount Directory
+
+Set `CUSTOM_CA_CERT_DIR` on any of the four services above to mount the
+custom CA bundle somewhere other than `/harbor_cust_cert`.
+
+## The `harbor-registry` Exception
+
+`harbor-registry` is not part of this mechanism. Unlike the other four
+services, its running binary is unmodified upstream `distribution` source —
+this repo doesn't own that code, so it can't call into the same
+CA-merging logic. Go's standard library (`crypto/x509`) already reads the
+`SSL_CERT_FILE` environment variable automatically with no application code
+involvement, so if `harbor-registry` itself needs to trust a private CA
+(for example, connecting to an S3-compatible storage backend over TLS),
+set `SSL_CERT_FILE` directly on that container instead, pointing at the
+mounted certificate file.
+
+## Troubleshooting
+
+If a service still logs `x509: certificate signed by unknown authority`
+after mounting a custom CA certificate:
+- Confirm the mounted file has a `.crt` or `.pem` extension.
+- Confirm the mount directory matches `CUSTOM_CA_CERT_DIR` if set, or
+  `/harbor_cust_cert` otherwise.
+- Check the affected service's startup logs for
+  `loaded N custom CA certificate(s) from ... into ...` — its absence means
+  the directory was empty or unreadable.
+- If the failing connection originates from `harbor-registry` itself, see
+  [The `harbor-registry` Exception](#the-harbor-registry-exception) above.

--- a/src/cmd/exporter/main.go
+++ b/src/cmd/exporter/main.go
@@ -34,6 +34,10 @@ import (
 )
 
 func main() {
+	// Merge any mounted custom CA certificates into the trust store before
+	// any TLS connection is attempted.
+	commonthttp.LoadCustomCACertificates()
+
 	// Start pprof server
 	lib.StartPprof()
 

--- a/src/common/http/tls.go
+++ b/src/common/http/tls.go
@@ -151,9 +151,14 @@ func loadCustomCACertificates(certDir, defaultSystemBundlePath, combinedBundlePa
 		return
 	}
 
-	combined, err := os.ReadFile(defaultSystemBundlePath)
+	systemBundlePath := os.Getenv("SSL_CERT_FILE")
+	if systemBundlePath == "" {
+		systemBundlePath = defaultSystemBundlePath
+	}
+	systemBundlePath = filepath.Clean(systemBundlePath)
+	combined, err := os.ReadFile(systemBundlePath)
 	if err != nil {
-		log.Errorf("custom CA certs found in %s but failed to read system CA bundle %s: %v", certDir, defaultSystemBundlePath, err)
+		log.Errorf("custom CA certs found in %s but failed to read system CA bundle %s: %v", certDir, systemBundlePath, err)
 		return
 	}
 

--- a/src/common/http/tls.go
+++ b/src/common/http/tls.go
@@ -18,7 +18,10 @@ import (
 	"crypto/tls"
 	"fmt"
 	"os"
+	"path/filepath"
 	"strings"
+
+	"github.com/goharbor/harbor/src/lib/log"
 )
 
 const (
@@ -27,6 +30,20 @@ const (
 	internalVerifyClientCert = "INTERNAL_VERIFY_CLIENT_CERT"
 	internalTLSKeyPath       = "INTERNAL_TLS_KEY_PATH"
 	internalTLSCertPath      = "INTERNAL_TLS_CERT_PATH"
+
+	// customCACertDirEnv optionally overrides where operator-supplied custom
+	// CA certificates are mounted. Defaults to "/harbor_cust_cert", Harbor's
+	// long-standing Helm chart convention (see caBundleSecretName), if unset.
+	customCACertDirEnv     = "CUSTOM_CA_CERT_DIR"
+	defaultCustomCACertDir = "/harbor_cust_cert"
+	// defaultSystemCABundle is the CA bundle baked into Harbor's scratch-based
+	// service images at build time.
+	defaultSystemCABundle = "/etc/ssl/certs/ca-certificates.crt"
+	// combinedCABundlePath is where the merged (system + custom) bundle is
+	// written at startup, and what SSL_CERT_FILE is pointed at afterward. It
+	// lives in a directory owned by the non-root harbor user, kept separate
+	// from the read-only, root-owned /etc/ssl/certs baked in at build time.
+	combinedCABundlePath = "/etc/ssl/harbor-custom-ca/ca-certificates.crt"
 )
 
 // InternalTLSEnabled returns true if internal TLS enabled
@@ -78,4 +95,88 @@ func NewServerTLSConfig() *tls.Config {
 			tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
 		},
 	}
+}
+
+// LoadCustomCACertificates merges any operator-supplied CA certificates
+// mounted at the directory named by CUSTOM_CA_CERT_DIR (default
+// /harbor_cust_cert, Harbor's long-standing Helm chart convention) into the
+// CA bundle baked into this image at build time, and points Go's TLS stack
+// at the merged bundle via SSL_CERT_FILE.
+//
+// Harbor's scratch-based service images (core, jobservice, registryctl,
+// exporter) have no shell or update-ca-certificates, so without this a
+// mounted custom CA directory is inert: outbound TLS connections these
+// services make back to Harbor's own externally-signed endpoints (e.g. the
+// registry's token realm) fail with "certificate signed by unknown
+// authority" even though the operator supplied the CA. This must be called
+// before any TLS connection is attempted, ideally as the first thing in
+// main().
+//
+// It is a deliberate no-op when the custom cert directory doesn't exist or
+// is empty, which is the common case for deployments that don't use a
+// private CA.
+func LoadCustomCACertificates() {
+	loadCustomCACertificates(resolveCustomCACertDir(), defaultSystemCABundle, combinedCABundlePath)
+}
+
+// resolveCustomCACertDir returns the CUSTOM_CA_CERT_DIR override if set,
+// otherwise the default custom CA cert directory.
+func resolveCustomCACertDir() string {
+	if dir := os.Getenv(customCACertDirEnv); dir != "" {
+		return dir
+	}
+	return defaultCustomCACertDir
+}
+
+// loadCustomCACertificates does the work for LoadCustomCACertificates, with
+// paths as parameters so it can be exercised in tests without touching real
+// filesystem locations.
+func loadCustomCACertificates(certDir, defaultSystemBundlePath, combinedBundlePath string) {
+	entries, err := os.ReadDir(certDir)
+	if err != nil {
+		return
+	}
+
+	var certFiles []string
+	for _, e := range entries {
+		if e.IsDir() {
+			continue
+		}
+		switch strings.ToLower(filepath.Ext(e.Name())) {
+		case ".crt", ".pem":
+			certFiles = append(certFiles, filepath.Join(certDir, e.Name()))
+		}
+	}
+	if len(certFiles) == 0 {
+		return
+	}
+
+	combined, err := os.ReadFile(defaultSystemBundlePath)
+	if err != nil {
+		log.Errorf("custom CA certs found in %s but failed to read system CA bundle %s: %v", certDir, defaultSystemBundlePath, err)
+		return
+	}
+
+	loaded := 0
+	for _, f := range certFiles {
+		data, err := os.ReadFile(f)
+		if err != nil {
+			log.Errorf("failed to read custom CA certificate %s: %v", f, err)
+			continue
+		}
+		combined = append(combined, '\n')
+		combined = append(combined, data...)
+		loaded++
+	}
+	if loaded == 0 {
+		return
+	}
+
+	if err := os.WriteFile(combinedBundlePath, combined, 0o644); err != nil { //nolint:gosec // G703: combinedBundlePath is always the hardcoded combinedCABundlePath constant in production, never derived from external input; only varied by tests
+		log.Errorf("failed to write combined CA bundle %s: %v", combinedBundlePath, err)
+		return
+	}
+
+	os.Setenv("SSL_CERT_FILE", combinedBundlePath)
+	log.Infof("loaded %d custom CA certificate(s) from %s into %s", loaded, certDir, combinedBundlePath)
 }

--- a/src/common/http/tls_test.go
+++ b/src/common/http/tls_test.go
@@ -99,6 +99,25 @@ func TestLoadCustomCACertificatesMerges(t *testing.T) {
 	assert.Contains(t, string(got), customCert)
 }
 
+func TestLoadCustomCACertificatesRespectsExistingSSLCertFile(t *testing.T) {
+	withCleanSSLCertFileEnv(t)
+
+	customCert := generateSelfSignedCert(t)
+	certDir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(certDir, "internal-ca.crt"), []byte(customCert), 0o644))
+
+	overrideBundle := filepath.Join(t.TempDir(), "override-bundle.crt")
+	require.NoError(t, os.WriteFile(overrideBundle, []byte("-----BEGIN OVERRIDE BUNDLE-----\n"), 0o644))
+	os.Setenv("SSL_CERT_FILE", overrideBundle)
+
+	combined := filepath.Join(t.TempDir(), "combined.crt")
+	loadCustomCACertificates(certDir, "/should/not/be/used", combined)
+
+	got, err := os.ReadFile(combined)
+	require.NoError(t, err)
+	assert.Contains(t, string(got), "-----BEGIN OVERRIDE BUNDLE-----")
+}
+
 func TestLoadCustomCACertificatesMissingSystemBundle(t *testing.T) {
 	withCleanSSLCertFileEnv(t)
 

--- a/src/common/http/tls_test.go
+++ b/src/common/http/tls_test.go
@@ -210,3 +210,84 @@ func TestResolveCustomCACertDirOverride(t *testing.T) {
 	os.Setenv(customCACertDirEnv, "/tls")
 	assert.Equal(t, "/tls", resolveCustomCACertDir())
 }
+
+func TestLoadCustomCACertificatesEmptyCertFile(t *testing.T) {
+	withCleanSSLCertFileEnv(t)
+
+	certDir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(certDir, "empty.crt"), []byte(""), 0o644))
+
+	systemBundle := filepath.Join(t.TempDir(), "ca-certificates.crt")
+	require.NoError(t, os.WriteFile(systemBundle, []byte("-----BEGIN SYSTEM BUNDLE-----\n"), 0o644))
+
+	combined := filepath.Join(t.TempDir(), "combined.crt")
+	loadCustomCACertificates(certDir, systemBundle, combined)
+
+	_, ok := os.LookupEnv("SSL_CERT_FILE")
+	assert.True(t, ok, "SSL_CERT_FILE should be set even with empty cert file")
+	got, err := os.ReadFile(combined)
+	require.NoError(t, err)
+	assert.NotContains(t, string(got), "empty.crt", "empty file content should not appear in combined bundle")
+}
+
+func TestLoadCustomCACertificatesSSLCertFileWithTrailingSlash(t *testing.T) {
+	withCleanSSLCertFileEnv(t)
+
+	customCert := generateSelfSignedCert(t)
+	certDir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(certDir, "internal-ca.crt"), []byte(customCert), 0o644))
+
+	sslCertDir := t.TempDir()
+	systemBundle := filepath.Join(sslCertDir, "ca-certificates.crt")
+	require.NoError(t, os.WriteFile(systemBundle, []byte("-----BEGIN SYSTEM BUNDLE-----\n"), 0o644))
+	expected := sslCertDir + "/"
+	os.Setenv("SSL_CERT_FILE", expected)
+
+	combined := filepath.Join(t.TempDir(), "combined.crt")
+	loadCustomCACertificates(certDir, "/should/not/be/used", combined)
+
+	val, ok := os.LookupEnv("SSL_CERT_FILE")
+	assert.True(t, ok, "SSL_CERT_FILE should remain set")
+	assert.Equal(t, expected, val, "SSL_CERT_FILE should be untouched when it points to directory")
+}
+
+func TestLoadCustomCACertificatesAllCustomCertsUnreadable(t *testing.T) {
+	withCleanSSLCertFileEnv(t)
+
+	certDir := t.TempDir()
+	unreadable := filepath.Join(certDir, "unreadable.crt")
+	require.NoError(t, os.WriteFile(unreadable, []byte("cert"), 0o644))
+	require.NoError(t, os.Chmod(unreadable, 0o000))
+
+	systemBundle := filepath.Join(t.TempDir(), "ca-certificates.crt")
+	require.NoError(t, os.WriteFile(systemBundle, []byte("-----BEGIN SYSTEM BUNDLE-----\n"), 0o644))
+
+	combined := filepath.Join(t.TempDir(), "combined.crt")
+	loadCustomCACertificates(certDir, systemBundle, combined)
+
+	_, ok := os.LookupEnv("SSL_CERT_FILE")
+	assert.False(t, ok, "SSL_CERT_FILE should be untouched when all custom certs are unreadable")
+	_, err := os.Stat(combined)
+	assert.True(t, os.IsNotExist(err), "combined bundle should not be written when no custom certs loaded")
+}
+
+func TestLoadCustomCACertificatesExistingSSLCertFileMissing(t *testing.T) {
+	withCleanSSLCertFileEnv(t)
+
+	customCert := generateSelfSignedCert(t)
+	certDir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(certDir, "internal-ca.crt"), []byte(customCert), 0o644))
+
+	missingDir := t.TempDir()
+	expected := filepath.Join(missingDir, "nonexistent-bundle.crt")
+	os.Setenv("SSL_CERT_FILE", expected)
+
+	combined := filepath.Join(t.TempDir(), "combined.crt")
+	loadCustomCACertificates(certDir, "/should/not/be/used", combined)
+
+	val, ok := os.LookupEnv("SSL_CERT_FILE")
+	assert.True(t, ok, "SSL_CERT_FILE should remain set")
+	assert.Equal(t, expected, val, "SSL_CERT_FILE should be untouched when it points to missing file")
+	_, err := os.Stat(combined)
+	assert.True(t, os.IsNotExist(err), "combined bundle should not be written when SSL_CERT_FILE is missing")
+}

--- a/src/common/http/tls_test.go
+++ b/src/common/http/tls_test.go
@@ -1,0 +1,193 @@
+// Copyright Project Harbor Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package http
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func withCleanSSLCertFileEnv(t *testing.T) {
+	t.Helper()
+	original, had := os.LookupEnv("SSL_CERT_FILE")
+	t.Cleanup(func() {
+		if had {
+			os.Setenv("SSL_CERT_FILE", original)
+		} else {
+			os.Unsetenv("SSL_CERT_FILE")
+		}
+	})
+	os.Unsetenv("SSL_CERT_FILE")
+}
+
+func TestLoadCustomCACertificatesNoDir(t *testing.T) {
+	withCleanSSLCertFileEnv(t)
+
+	loadCustomCACertificates(filepath.Join(t.TempDir(), "does-not-exist"), "/does/not/matter", "/does/not/matter")
+
+	_, ok := os.LookupEnv("SSL_CERT_FILE")
+	assert.False(t, ok, "SSL_CERT_FILE should be untouched when the custom cert dir doesn't exist")
+}
+
+func TestLoadCustomCACertificatesEmptyDir(t *testing.T) {
+	withCleanSSLCertFileEnv(t)
+
+	certDir := t.TempDir()
+	loadCustomCACertificates(certDir, "/does/not/matter", "/does/not/matter")
+
+	_, ok := os.LookupEnv("SSL_CERT_FILE")
+	assert.False(t, ok, "SSL_CERT_FILE should be untouched when the custom cert dir is empty")
+}
+
+func TestLoadCustomCACertificatesIgnoresUnrelatedFiles(t *testing.T) {
+	withCleanSSLCertFileEnv(t)
+
+	certDir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(certDir, "readme.txt"), []byte("not a cert"), 0o644))
+	require.NoError(t, os.Mkdir(filepath.Join(certDir, "subdir.crt"), 0o755)) // a directory, not a file
+
+	systemBundle := filepath.Join(t.TempDir(), "ca-certificates.crt")
+	require.NoError(t, os.WriteFile(systemBundle, []byte("system bundle"), 0o644))
+
+	combined := filepath.Join(t.TempDir(), "combined.crt")
+	loadCustomCACertificates(certDir, systemBundle, combined)
+
+	_, ok := os.LookupEnv("SSL_CERT_FILE")
+	assert.False(t, ok, "SSL_CERT_FILE should be untouched when no .crt/.pem files are present")
+	_, err := os.Stat(combined)
+	assert.True(t, os.IsNotExist(err), "combined bundle should not be written")
+}
+
+func TestLoadCustomCACertificatesMerges(t *testing.T) {
+	withCleanSSLCertFileEnv(t)
+
+	customCert := generateSelfSignedCert(t)
+	certDir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(certDir, "internal-ca.crt"), []byte(customCert), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(certDir, "internal-ca-2.pem"), []byte(customCert), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(certDir, "ignored.txt"), []byte("not a cert"), 0o644))
+
+	systemBundle := filepath.Join(t.TempDir(), "ca-certificates.crt")
+	require.NoError(t, os.WriteFile(systemBundle, []byte("-----BEGIN SYSTEM BUNDLE-----\n"), 0o644))
+
+	combinedDir := t.TempDir()
+	combined := filepath.Join(combinedDir, "harbor-custom-ca-certificates.crt")
+
+	loadCustomCACertificates(certDir, systemBundle, combined)
+
+	assert.Equal(t, combined, os.Getenv("SSL_CERT_FILE"))
+
+	got, err := os.ReadFile(combined)
+	require.NoError(t, err)
+	assert.Contains(t, string(got), "-----BEGIN SYSTEM BUNDLE-----")
+	assert.Contains(t, string(got), customCert)
+}
+
+func TestLoadCustomCACertificatesMissingSystemBundle(t *testing.T) {
+	withCleanSSLCertFileEnv(t)
+
+	customCert := generateSelfSignedCert(t)
+	certDir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(certDir, "internal-ca.crt"), []byte(customCert), 0o644))
+
+	combined := filepath.Join(t.TempDir(), "combined.crt")
+	loadCustomCACertificates(certDir, filepath.Join(t.TempDir(), "missing-system-bundle.crt"), combined)
+
+	_, ok := os.LookupEnv("SSL_CERT_FILE")
+	assert.False(t, ok, "SSL_CERT_FILE should be untouched when the system bundle can't be read")
+	_, err := os.Stat(combined)
+	assert.True(t, os.IsNotExist(err), "combined bundle should not be written when the system bundle can't be read")
+}
+
+func TestLoadCustomCACertificatesSkipsUnreadableFile(t *testing.T) {
+	withCleanSSLCertFileEnv(t)
+
+	customCert := generateSelfSignedCert(t)
+	certDir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(certDir, "internal-ca.crt"), []byte(customCert), 0o644))
+
+	unreadable := filepath.Join(certDir, "unreadable.crt")
+	require.NoError(t, os.WriteFile(unreadable, []byte(customCert), 0o644))
+	require.NoError(t, os.Chmod(unreadable, 0o000))
+
+	systemBundle := filepath.Join(t.TempDir(), "ca-certificates.crt")
+	require.NoError(t, os.WriteFile(systemBundle, []byte("-----BEGIN SYSTEM BUNDLE-----\n"), 0o644))
+
+	combined := filepath.Join(t.TempDir(), "combined.crt")
+	loadCustomCACertificates(certDir, systemBundle, combined)
+
+	assert.Equal(t, combined, os.Getenv("SSL_CERT_FILE"), "the readable cert should still be loaded")
+	got, err := os.ReadFile(combined)
+	require.NoError(t, err)
+	assert.Contains(t, string(got), customCert)
+}
+
+func TestLoadCustomCACertificatesWriteFailure(t *testing.T) {
+	withCleanSSLCertFileEnv(t)
+
+	customCert := generateSelfSignedCert(t)
+	certDir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(certDir, "internal-ca.crt"), []byte(customCert), 0o644))
+
+	systemBundle := filepath.Join(t.TempDir(), "ca-certificates.crt")
+	require.NoError(t, os.WriteFile(systemBundle, []byte("-----BEGIN SYSTEM BUNDLE-----\n"), 0o644))
+
+	// Parent directory doesn't exist, so the write fails regardless of
+	// permissions or whether the test runs as root.
+	combined := filepath.Join(t.TempDir(), "does-not-exist", "combined.crt")
+	loadCustomCACertificates(certDir, systemBundle, combined)
+
+	_, ok := os.LookupEnv("SSL_CERT_FILE")
+	assert.False(t, ok, "SSL_CERT_FILE should be untouched when the combined bundle can't be written")
+}
+
+func TestLoadCustomCACertificatesPublicEntrypointIsNoOpByDefault(t *testing.T) {
+	withCleanSSLCertFileEnv(t)
+
+	// /harbor_cust_cert won't exist in the test environment, so the public
+	// entrypoint should be a no-op -- this just guards against a panic.
+	LoadCustomCACertificates()
+
+	_, ok := os.LookupEnv("SSL_CERT_FILE")
+	assert.False(t, ok)
+}
+
+func withCleanCustomCACertDirEnv(t *testing.T) {
+	t.Helper()
+	original, had := os.LookupEnv(customCACertDirEnv)
+	t.Cleanup(func() {
+		if had {
+			os.Setenv(customCACertDirEnv, original)
+		} else {
+			os.Unsetenv(customCACertDirEnv)
+		}
+	})
+	os.Unsetenv(customCACertDirEnv)
+}
+
+func TestResolveCustomCACertDirDefault(t *testing.T) {
+	withCleanCustomCACertDirEnv(t)
+	assert.Equal(t, defaultCustomCACertDir, resolveCustomCACertDir())
+}
+
+func TestResolveCustomCACertDirOverride(t *testing.T) {
+	withCleanCustomCACertDirEnv(t)
+	os.Setenv(customCACertDirEnv, "/tls")
+	assert.Equal(t, "/tls", resolveCustomCACertDir())
+}

--- a/src/core/main.go
+++ b/src/core/main.go
@@ -137,6 +137,10 @@ func gracefulShutdown(closing, done chan struct{}, shutdowns ...func()) {
 }
 
 func main() {
+	// Merge any mounted custom CA certificates into the trust store before
+	// any TLS connection is attempted.
+	common_http.LoadCustomCACertificates()
+
 	// Start pprof server
 	lib.StartPprof()
 

--- a/src/jobservice/main.go
+++ b/src/jobservice/main.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	"github.com/goharbor/harbor/src/common"
+	common_http "github.com/goharbor/harbor/src/common/http"
 	"github.com/goharbor/harbor/src/jobservice/common/utils"
 	"github.com/goharbor/harbor/src/jobservice/config"
 	"github.com/goharbor/harbor/src/jobservice/job"
@@ -46,6 +47,10 @@ import (
 )
 
 func main() {
+	// Merge any mounted custom CA certificates into the trust store before
+	// any TLS connection is attempted.
+	common_http.LoadCustomCACertificates()
+
 	// Start pprof server
 	lib.StartPprof()
 

--- a/src/registryctl/main.go
+++ b/src/registryctl/main.go
@@ -92,6 +92,10 @@ func (s *RegistryCtl) Start() {
 }
 
 func main() {
+	// Merge any mounted custom CA certificates into the trust store before
+	// any TLS connection is attempted.
+	common_http.LoadCustomCACertificates()
+
 	// Start pprof server
 	lib.StartPprof()
 


### PR DESCRIPTION
## Summary
- `core`, `jobservice`, `registryctl`, and `exporter` are built `FROM scratch` with no shell/`update-ca-certificates`, so the long-standing `/harbor_cust_cert` mount convention (used by the Helm chart's `caBundleSecretName`) was silently inert — nothing in these images ever read that directory.
- Surfaced as a 500 on the artifact Dockerfile/Build History tabs: `core`'s outbound TLS connection to the registry's token realm failed with `certificate signed by unknown authority` whenever that realm's certificate was issued by a private CA.
- Adds `LoadCustomCACertificates()`, called first thing in each service's `main()`, which merges any `.crt`/`.pem` files found in the mount directory into the baked-in system CA bundle and points `SSL_CERT_FILE` at the merged result — `crypto/x509` reads that env var automatically, so no other application code needs to change. It's a no-op when the mount is absent or empty (the common case).
- The mount directory defaults to `/harbor_cust_cert` (unchanged, for Helm chart compatibility) but can be overridden via the new `CUSTOM_CA_CERT_DIR` env var.
- The merged bundle is written to a new directory (`/etc/ssl/harbor-custom-ca`) created empty and owned by the non-root `harbor` user at build time, kept separate from the baked-in `/etc/ssl/certs/ca-certificates.crt` (which stays root-owned and read-only) — avoids giving the running process write access to its own trusted root store.
- Adds `docs/custom-ca-certificates.md` covering the mount convention, the env var override, and the `harbor-registry` exception (its binary is unmodified upstream `distribution` source, so it needs `SSL_CERT_FILE` set directly rather than going through this mechanism).

## Release Notes

Fixes custom CA certificates mounted at `/harbor_cust_cert` (or `CUSTOM_CA_CERT_DIR` if overridden) being silently ignored by `core`, `jobservice`, `registryctl`, and `exporter`, which caused internal TLS connections between these services to fail with `certificate signed by unknown authority` for deployments using a private CA. See [Custom CA Certificates](docs/custom-ca-certificates.md) for configuration details.

## Test plan
- [x] `go build ./...` passes
- [x] `go vet ./common/http/...` clean
- [x] `golangci-lint run ./common/http/...` clean (pre-existing, unrelated `govet` finding in `client.go` not touched by this PR)
- [x] `hadolint` clean on all 4 changed Dockerfiles
- [x] `go test ./common/http/...` passes; new code coverage: `LoadCustomCACertificates` 100%, `resolveCustomCACertDir` 100%, `loadCustomCACertificates` 96.8%
- [x] Verified live: fixed a real production 500 on the Dockerfile/Build History artifact tabs caused by this exact gap