### PR TITLE
fix(auth): return Basic challenge for requests already carrying Basic auth

### DIFF
--- a/src/server/middleware/v2auth/auth.go
+++ b/src/server/middleware/v2auth/auth.go
@@ -96,6 +96,14 @@ func getChallenge(req *http.Request, accessList []access) string {
 		// Return basic auth challenge by default, incl. request to '/v2/_catalog'
 		return `Basic realm="harbor"`
 	}
+
+	// A request that already carries Basic credentials isn't following the
+	// OCI/Docker Bearer token flow, so challenge it with Basic too instead of
+	// pointing it at the token service.
+	if strings.HasPrefix(auth, "Basic ") {
+		return `Basic realm="harbor"`
+	}
+
 	// No auth header, treat it as CLI and redirect to token service
 	tokenSvc, err := tokenSvcURL(req)
 	if err != nil {

--- a/src/server/middleware/v2auth/auth.go
+++ b/src/server/middleware/v2auth/auth.go
@@ -92,19 +92,16 @@ func (rc *reqChecker) projectID(ctx context.Context, name string) (int64, error)
 func getChallenge(req *http.Request, accessList []access) string {
 	logger := log.G(req.Context())
 	auth := req.Header.Get(authHeader)
-	if len(auth) > 0 || lib.V2CatalogURLRe.MatchString(req.URL.Path) {
-		// Return basic auth challenge by default, incl. request to '/v2/_catalog'
-		return `Basic realm="harbor"`
-	}
-
 	// A request that already carries Basic credentials isn't following the
 	// OCI/Docker Bearer token flow, so challenge it with Basic too instead of
-	// pointing it at the token service.
-	if strings.HasPrefix(auth, "Basic ") {
+	// pointing it at the token service. '/v2/_catalog' always gets a Basic
+	// challenge regardless of any auth header present.
+	if strings.HasPrefix(auth, "Basic ") || lib.V2CatalogURLRe.MatchString(req.URL.Path) {
 		return `Basic realm="harbor"`
 	}
 
-	// No auth header, treat it as CLI and redirect to token service
+	// No auth header, or a Bearer header needing refresh: treat it as an
+	// OCI/CLI client and redirect to token service
 	tokenSvc, err := tokenSvcURL(req)
 	if err != nil {
 		logger.Errorf("failed to get the endpoint for token service, error: %v", err)

--- a/src/server/middleware/v2auth/auth_test.go
+++ b/src/server/middleware/v2auth/auth_test.go
@@ -273,6 +273,15 @@ func TestGetChallenge(t *testing.T) {
 			challenge: `Basic realm="harbor"`,
 		},
 		{
+			name: "Request to '/v2' carrying a Bearer auth header should still get a token service challenge, not Basic",
+			request: func() *http.Request {
+				req, _ := http.NewRequest(http.MethodGet, "https://registry.test/v2/", nil)
+				req.Header.Set("Authorization", "Bearer xx")
+				return req
+			}(),
+			challenge: `Bearer realm="https://registry.test/service/token",service="harbor-registry"`,
+		},
+		{
 			name: "Request to mount a blob from one repo to another should return challenge with scope according to the artifact info in the context of the request",
 			request: func() *http.Request {
 				req, _ := http.NewRequest(http.MethodPost, "https://harbor.test/v2/project_1/ubuntu/blobs/uploads/mount=?mount=sha256:08e4a417ff4e3913d8723a05cc34055db01c2fd165b588e049c5bad16ce6094f&from=project_2/ubuntu", nil)


### PR DESCRIPTION
Fixes the v2auth middleware to return a Basic challenge when the request already carries a Basic Authorization header.

Currently, getChallenge() only special-cases this for the catalog path (/v2/_catalog). For other paths, it always builds a Bearer challenge pointing at the token service — but a client sending Basic auth isn't following the OCI/Docker Bearer token flow, so pointing it at the token service is incorrect.

This change moves the check up as an unconditional early return, matching the existing catalog short-circuit.

## Release Notes

- Fixed: v2auth now returns Basic challenge for requests already carrying Basic auth