### PR TITLE
fix(jobservice): handle nil config manager instead of segfault

### DIFF
--- a/src/jobservice/main.go
+++ b/src/jobservice/main.go
@@ -50,8 +50,12 @@ func main() {
 	lib.StartPprof()
 
 	cfgLib.DefaultCfgManager = common.RestCfgManager
+	mgr := cfgLib.DefaultMgr()
+	if mgr == nil {
+		panic("failed to initialize config manager - check CORE_URL and JOBSERVICE_SECRET env vars")
+	}
 	if err := retry.Retry(func() error {
-		return cfgLib.DefaultMgr().Load(context.Background())
+		return mgr.Load(context.Background())
 	},
 		retry.InitialInterval(500*time.Millisecond),
 		retry.MaxInterval(10*time.Second),

--- a/src/lib/config/config.go
+++ b/src/lib/config/config.go
@@ -81,6 +81,9 @@ func DefaultMgr() Manager {
 	if err != nil {
 		log.Error("failed to get config manager")
 	}
+	if manager == nil {
+		log.Error("config manager is nil")
+	}
 	return manager
 }
 

--- a/src/lib/config/config.go
+++ b/src/lib/config/config.go
@@ -122,10 +122,18 @@ func GetCfgManager(_ context.Context) Manager {
 
 // Load configurations
 func Load(ctx context.Context) error {
-	return DefaultMgr().Load(ctx)
+	mgr := DefaultMgr()
+	if mgr == nil {
+		return errors.New("config manager is not initialized")
+	}
+	return mgr.Load(ctx)
 }
 
 // Upload save all configurations, used by testing
 func Upload(cfg map[string]any) error {
-	return DefaultMgr().UpdateConfig(orm.Context(), cfg)
+	mgr := DefaultMgr()
+	if mgr == nil {
+		return errors.New("config manager is not initialized")
+	}
+	return mgr.UpdateConfig(orm.Context(), cfg)
 }


### PR DESCRIPTION
## Summary

- `DefaultMgr()` could return `nil` when the REST config manager fails to register (missing `CORE_URL` or `JOBSERVICE_SECRET` env vars).
- Both the config manager and the jobservice startup now handle this gracefully with a clear error message instead of a nil pointer dereference.

## Release Notes

Fix a jobservice segfault on startup when `CORE_URL` or `JOBSERVICE_SECRET` are missing/misconfigured; it now fails with a clear panic message instead of a nil pointer dereference.

## Checklist

- [x] PR title follows conventional commits (`fix:`)
- [x] DCO sign-off on every commit