### PR TITLE
fix: handle wildcard permissions in robot token authorization

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ make/dev/adminserver/harbor_adminserver
 make/dev/core/harbor_core
 make/dev/jobservice/harbor_jobservice
 make/photon/*/binary/
+make/photon/*/harbor_*
 make/photon/prepare/versions
 
 src/adminserver/adminserver

--- a/src/pkg/permission/types/namespace.go
+++ b/src/pkg/permission/types/namespace.go
@@ -15,6 +15,7 @@
 package types
 
 import (
+	"strings"
 	"sync"
 )
 
@@ -67,7 +68,20 @@ func NamespaceFromResource(resource Resource) (Namespace, bool) {
 }
 
 // ResourceAllowedInNamespace returns true when resource's namespace equal the ns
+// It also handles wildcard resources like /project/*/repository which should match any project namespace
 func ResourceAllowedInNamespace(resource Resource, ns Namespace) bool {
+	resourceStr := resource.String()
+	// Check for wildcard pattern like /project/*/repository
+	if strings.Contains(resourceStr, "/*/") {
+		// Extract the kind from the resource path (e.g., "project" from "/project/*/repository")
+		parts := strings.Split(resourceStr, "/")
+		if len(parts) >= 2 {
+			kind := parts[1]
+			return kind == ns.Kind()
+		}
+		return false
+	}
+
 	n, ok := NamespaceFromResource(resource)
 	if ok {
 		return n.Kind() == ns.Kind() && n.Identity() == ns.Identity()

--- a/src/pkg/permission/types/namespace_test.go
+++ b/src/pkg/permission/types/namespace_test.go
@@ -1,0 +1,86 @@
+// Copyright Project Harbor Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package types
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// MockNamespace for testing
+type mockNamespace struct {
+	kind     string
+	identity any
+}
+
+func (m *mockNamespace) Kind() string {
+	return m.kind
+}
+
+func (m *mockNamespace) Resource(subresources ...Resource) Resource {
+	return ""
+}
+
+func (m *mockNamespace) Identity() any {
+	return m.identity
+}
+
+func (m *mockNamespace) GetPolicies() []*Policy {
+	return nil
+}
+
+func TestResourceAllowedInNamespace_Wildcard(t *testing.T) {
+	projectNamespace := &mockNamespace{
+		kind:     "project",
+		identity: int64(123),
+	}
+
+	tests := []struct {
+		name     string
+		resource Resource
+		ns       *mockNamespace
+		expected bool
+	}{
+		{
+			name:     "wildcard project repository matches project namespace",
+			resource: Resource("/project/*/repository"),
+			ns:       projectNamespace,
+			expected: true,
+		},
+		{
+			name:     "wildcard artifact matches project namespace",
+			resource: Resource("/project/*/artifact"),
+			ns:       projectNamespace,
+			expected: true,
+		},
+		{
+			name:     "wildcard for different kind does not match",
+			resource: Resource("/project/*/repository"),
+			ns: &mockNamespace{
+				kind:     "system",
+				identity: "/",
+			},
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := ResourceAllowedInNamespace(tt.resource, tt.ns)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- When robots/PATs are created with `/project/*` scope (all projects), the permission system was unable to match them against specific project namespaces.
- The namespace parser expected a numeric project ID but received a wildcard (`*`), causing the permission check to always fail with "denied: requested access to the resource is denied".
- Adds wildcard pattern detection in `ResourceAllowedInNamespace` to match `/project/*/*` patterns against any project namespace by comparing namespace kinds instead of requiring exact identity matches.

## Related upstream reports

This class of bug has been reported upstream against goharbor/harbor without a code-level fix landing:
- goharbor/harbor#21922 — "System robot account denied creating project robot account" (closed not-planned)
- goharbor/harbor#21406 — "Error when creating project Robot Accounts using System Robot Accounts" (closed, unresolved at the code level)

Both describe a system-level robot/PAT with all-projects scope being denied against a specific project — the same wildcard-vs-namespace matching gap fixed here.

## Release Notes

Fix robot accounts/PATs created with "all projects" (`/project/*`) scope being unable to push images due to a namespace-matching bug that only handled numeric project IDs.

## Checklist

- [x] PR title follows conventional commits (`fix:`)
- [x] DCO sign-off on every commit
