### PR TITLE
fix: Correct Committed Key Comment Grammar

### DIFF
--- a/src/pkg/cached/base_manager.go
+++ b/src/pkg/cached/base_manager.go
@@ -52,7 +52,7 @@ func (*cacheClient) Save(ctx context.Context, key string, value any, expiration 
 	// it should ignore save cache if this request is wrapped by orm.Transaction,
 	// because if tx rollback, we cannot rollback cache,
 	// identify whether in transaction by checking the committedKey in context.
-	// committedKey is a context value which be injected in the transaction middleware.
+	// committedKey is a context value which is injected in the transaction middleware.
 	if orm.HasCommittedKey(ctx) {
 		return nil
 	}


### PR DESCRIPTION
## Summary

Correct the cache transaction comment from “which be injected” to “which is injected.”

The original `commitedKey` typo was already fixed in Harbor Next, so this preserves the existing `committedKey` spelling and applies only the remaining grammar correction from goharbor/harbor#23541.

## Validation

- `go test ./pkg/cached`