### PR TITLE
ci: Require Release Ready Before Main Images

### DIFF
--- a/.github/workflows/main-images.yml
+++ b/.github/workflows/main-images.yml
@@ -1,8 +1,9 @@
 name: Main Images
 
 on:
-  workflow_dispatch:
-  push:
+  workflow_run:
+    workflows: [Release Ready]
+    types: [completed]
     branches: [main]
 
 permissions:
@@ -15,13 +16,14 @@ concurrency:
 jobs:
   version:
     name: Read Version
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     runs-on: ${{ vars.RUNNER || 'ubuntu-latest' }}
     outputs:
       version: ${{ steps.version.outputs.version }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
-          ref: ${{ github.sha }}
+          ref: ${{ github.event.workflow_run.head_sha }}
 
       - name: Read VERSION
         id: version
@@ -37,7 +39,7 @@ jobs:
       id-token: write
     uses: ./.github/workflows/publish-images.yml
     with:
-      checkout_ref: ${{ github.sha }}
+      checkout_ref: ${{ github.event.workflow_run.head_sha }}
       image_tag: latest
       version: ${{ needs.version.outputs.version }}
       artifact_prefix: main-latest

--- a/.github/workflows/publish-images.yml
+++ b/.github/workflows/publish-images.yml
@@ -126,7 +126,7 @@ jobs:
         env:
           COMPONENT: ${{ matrix.component }}
           PLATFORM_PAIR: ${{ env.PLATFORM_PAIR }}
-        run: task build:binary:${COMPONENT}:${PLATFORM_PAIR} GIT_COMMIT="${GITHUB_SHA:0:8}"
+        run: task build:binary:${COMPONENT}:${PLATFORM_PAIR} GIT_COMMIT="$(git rev-parse --short=8 \"${{ inputs.checkout_ref }}\")"
 
       - name: Compile image helper binaries
         env:


### PR DESCRIPTION
## Summary

- Trigger `Main Images` only after `Release Ready` completes on `main`.
- Run image publishing only when release patch validation succeeds.
- Build the exact commit SHA that passed validation.

## Why

`Main Images` previously ran directly on every push to `main`, so it could build and apply patches even when release-ready validation had already failed. This makes Release Ready the required canary before image publication.

## Validation

- `actionlint .github/workflows/*.yml`

Fixes #506