### PR TITLE
fix: Remove unintended 2.16 accessory migration from release 2.15

### DIFF
--- a/make/migrations/postgresql/0190_2.16.0_schema.up.sql
+++ b/make/migrations/postgresql/0190_2.16.0_schema.up.sql
@@ -1,1 +1,0 @@
-ALTER TABLE artifact_accessory ADD COLUMN IF NOT EXISTS source varchar(50) DEFAULT 'local';

--- a/src/controller/proxy/controller.go
+++ b/src/controller/proxy/controller.go
@@ -163,7 +163,7 @@ func (c *controller) UseLocalManifest(ctx context.Context, art lib.ArtifactInfo,
 		return true, nil, nil
 	}
 
-	remoteRepo := GetRemoteRepo(art)
+	remoteRepo := getRemoteRepo(art)
 	exist, desc, err := remote.ManifestExist(remoteRepo, getReference(art)) // HEAD
 	if err != nil {
 		if errors.IsRateLimitError(err) && a != nil { // if rate limit, use local if it exists, otherwise return error
@@ -218,7 +218,7 @@ func manifestListContentTypeKey(rep string, art lib.ArtifactInfo) string {
 
 func (c *controller) ProxyManifest(ctx context.Context, art lib.ArtifactInfo, remote RemoteInterface) (distribution.Manifest, error) {
 	var man distribution.Manifest
-	remoteRepo := GetRemoteRepo(art)
+	remoteRepo := getRemoteRepo(art)
 	ref := getReference(art)
 	man, dig, err := remote.Manifest(remoteRepo, ref)
 	if err != nil {
@@ -283,13 +283,13 @@ func (c *controller) sendManifestPullEvent(ctx context.Context, art lib.Artifact
 }
 
 func (c *controller) HeadManifest(_ context.Context, art lib.ArtifactInfo, remote RemoteInterface) (bool, *distribution.Descriptor, error) {
-	remoteRepo := GetRemoteRepo(art)
+	remoteRepo := getRemoteRepo(art)
 	ref := getReference(art)
 	return remote.ManifestExist(remoteRepo, ref)
 }
 
 func (c *controller) ProxyBlob(ctx context.Context, p *proModels.Project, art lib.ArtifactInfo) (int64, io.ReadCloser, error) {
-	remoteRepo := GetRemoteRepo(art)
+	remoteRepo := getRemoteRepo(art)
 	log.Debugf("The blob doesn't exist, proxy the request to the target server, url:%v", remoteRepo)
 	rHelper, err := NewRemoteHelper(ctx, p.RegistryID, WithSpeed(p.ProxyCacheSpeed()))
 	if err != nil {
@@ -335,8 +335,8 @@ func (c *controller) waitAndPushManifest(ctx context.Context, remoteRepo string,
 	h.CacheContent(ctx, remoteRepo, man, art, r, contType)
 }
 
-// GetRemoteRepo get the remote repository name, used in proxy cache
-func GetRemoteRepo(art lib.ArtifactInfo) string {
+// getRemoteRepo get the remote repository name, used in proxy cache
+func getRemoteRepo(art lib.ArtifactInfo) string {
 	return strings.TrimPrefix(art.Repository, art.ProjectName+"/")
 }
 

--- a/src/controller/proxy/controller_test.go
+++ b/src/controller/proxy/controller_test.go
@@ -220,7 +220,7 @@ func TestProxyCacheRemoteRepo(t *testing.T) {
 	}
 	for _, tt := range cases {
 		t.Run(tt.name, func(t *testing.T) {
-			got := GetRemoteRepo(tt.in)
+			got := getRemoteRepo(tt.in)
 			if got != tt.want {
 				t.Errorf(`(%v) = %v; want "%v"`, tt.in, got, tt.want)
 			}

--- a/src/pkg/accessory/dao/model.go
+++ b/src/pkg/accessory/dao/model.go
@@ -32,7 +32,6 @@ type Accessory struct {
 	SubjectArtifactRepo   string    `orm:"column(subject_artifact_repo)" json:"subject_artifact_repo"`
 	SubjectArtifactDigest string    `orm:"column(subject_artifact_digest)" json:"subject_artifact_digest"`
 	Type                  string    `orm:"column(type)" json:"type"`
-	Source                string    `orm:"column(source)" json:"source"`
 	Size                  int64     `orm:"column(size)" json:"size"`
 	Digest                string    `orm:"column(digest)" json:"digest"`
 	CreationTime          time.Time `orm:"column(creation_time);auto_now_add" json:"creation_time"`

--- a/src/pkg/accessory/manager.go
+++ b/src/pkg/accessory/manager.go
@@ -107,7 +107,6 @@ func (m *manager) Get(ctx context.Context, id int64) (model.Accessory, error) {
 		Digest:            acc.Digest,
 		CreatTime:         acc.CreationTime,
 		Icon:              m.GetIcon(acc.Type),
-		Source:            acc.Source,
 	})
 }
 
@@ -132,7 +131,6 @@ func (m *manager) List(ctx context.Context, query *q.Query) ([]model.Accessory, 
 			Digest:            accD.Digest,
 			CreatTime:         accD.CreationTime,
 			Icon:              m.GetIcon(accD.Type),
-			Source:            accD.Source,
 		})
 		if err != nil {
 			return nil, errors.New(err).WithCode(errors.BadRequestCode)
@@ -151,7 +149,6 @@ func (m *manager) Create(ctx context.Context, accessory model.AccessoryData) (in
 		Size:                  accessory.Size,
 		Digest:                accessory.Digest,
 		Type:                  accessory.Type,
-		Source:                accessory.Source,
 	}
 	return m.dao.Create(ctx, acc)
 }

--- a/src/pkg/accessory/model/accessory.go
+++ b/src/pkg/accessory/model/accessory.go
@@ -95,7 +95,6 @@ type AccessoryData struct {
 	Type              string    `json:"type"`
 	Size              int64     `json:"size"`
 	Digest            string    `json:"digest"`
-	Source            string    `json:"source"`
 	CreatTime         time.Time `json:"creation_time"`
 	Icon              string    `json:"icon"`
 }

--- a/src/pkg/project/models/pro_meta.go
+++ b/src/pkg/project/models/pro_meta.go
@@ -26,6 +26,5 @@ const (
 	ProMetaAutoSBOMGen               = "auto_sbom_generation"
 	ProMetaProxySpeed                = "proxy_speed_kb"
 	ProMetaMaxUpstreamConn           = "max_upstream_conn"
-	ProMetaProxyReferrerAPI          = "proxy_referrer_api"
 	ProMetaProxyCacheLocalOnNotFound = "proxy_cache_local_on_not_found"
 )

--- a/src/pkg/project/models/project.go
+++ b/src/pkg/project/models/project.go
@@ -184,15 +184,6 @@ func (p *Project) MaxUpstreamConnection() int {
 	return int(cnt)
 }
 
-// ProxyReferrerAPI
-func (p *Project) ProxyReferrerAPI() bool {
-	enable, exist := p.GetMetadata(ProMetaProxyReferrerAPI)
-	if !exist {
-		return false
-	}
-	return isTrue(enable)
-}
-
 // ProxyCacheLocalOnNotFound returns true if images should be served from local cache when removed from upstream
 func (p *Project) ProxyCacheLocalOnNotFound() bool {
 	val, exist := p.GetMetadata(ProMetaProxyCacheLocalOnNotFound)

--- a/src/server/middleware/subject/subject.go
+++ b/src/server/middleware/subject/subject.go
@@ -24,8 +24,6 @@ import (
 	"github.com/opencontainers/go-digest"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 
-	"github.com/goharbor/harbor/src/common/security"
-	"github.com/goharbor/harbor/src/common/security/proxycachesecret"
 	"github.com/goharbor/harbor/src/controller/artifact"
 	"github.com/goharbor/harbor/src/lib"
 	"github.com/goharbor/harbor/src/lib/errors"
@@ -51,11 +49,6 @@ var (
 
 	// media type of harbor sbom
 	mediaTypeHarborSBOM = "application/vnd.goharbor.harbor.sbom.v1"
-
-	// source of accessory artifact is local, means the accessory is created by harbor itself
-	sourceLocal = "local"
-	// source of accessory artifact is from proxycache, means the accessory is created by proxycache service
-	sourceProxyCache = "proxycache"
 )
 
 /*
@@ -173,13 +166,6 @@ func Middleware() func(http.Handler) http.Handler {
 				accData.SubArtifactID = subjectArt.ID
 			}
 			if err := orm.WithTransaction(func(ctx context.Context) error {
-				source := sourceLocal
-				securityCtx, exist := security.FromContext(ctx)
-				if exist && securityCtx != nil && securityCtx.GetUsername() == proxycachesecret.ProxyCacheService {
-					source = sourceProxyCache
-				}
-				logger.Debugf("source: %s", source)
-				accData.Source = source
 				_, err := accessory.Mgr.Create(ctx, accData)
 				return err
 			})(orm.SetTransactionOpNameToContext(ctx, "tx-create-subject-accessory")); err != nil {

--- a/src/server/v2.0/handler/project_metadata.go
+++ b/src/server/v2.0/handler/project_metadata.go
@@ -144,7 +144,7 @@ func (p *projectMetadataAPI) validate(metas map[string]string) (map[string]strin
 	switch key {
 	case proModels.ProMetaPublic, proModels.ProMetaEnableContentTrust, proModels.ProMetaEnableContentTrustCosign,
 		proModels.ProMetaAutoSBOMGen, proModels.ProMetaPreventVul, proModels.ProMetaAutoScan, proModels.ProMetaReuseSysCVEAllowlist,
-		proModels.ProMetaProxyCacheLocalOnNotFound, proModels.ProMetaProxyReferrerAPI:
+		proModels.ProMetaProxyCacheLocalOnNotFound:
 		v, err := strconv.ParseBool(value)
 		if err != nil {
 			return nil, errors.New(nil).WithCode(errors.BadRequestCode).WithMessagef("invalid value: %s", value)


### PR DESCRIPTION
## Summary

Removes the unintended 2.16 accessory-source feature backport from the 2.15 release branch.

## Root cause

Commit `aa455abf592fe5ff43854e38dcc0b32900ea0712` introduced the 2.16-only PostgreSQL migration `0190_2.16.0_schema.up.sql` along with code that reads and writes its `artifact_accessory.source` column. That feature does not belong in a maintenance release.

## Changes

- Remove migration 0190 and the accessory `source` model, DAO, manager, and middleware logic.
- Remove the related unused proxy-referrer metadata scaffolding.
- Restore the proxy helper's original unexported name.
- Preserve subsequent proxy-cache concurrency fixes.

## Validation

- Passed: `go test ./pkg/accessory/... ./controller/proxy/... ./server/middleware/subject/... ./pkg/project/models/...`
- Handler-package tests require generated Swagger `server/v2.0/models` and `restapi` sources, which are absent from this checkout.