### PR TITLE
ci: Safely Resolve Validated Commit Reference

### DIFF
--- a/.github/workflows/publish-images.yml
+++ b/.github/workflows/publish-images.yml
@@ -126,7 +126,8 @@ jobs:
         env:
           COMPONENT: ${{ matrix.component }}
           PLATFORM_PAIR: ${{ env.PLATFORM_PAIR }}
-        run: task build:binary:${COMPONENT}:${PLATFORM_PAIR} GIT_COMMIT="$(git rev-parse --short=8 \"${{ inputs.checkout_ref }}\")"
+          CHECKOUT_REF: ${{ inputs.checkout_ref }}
+        run: task build:binary:${COMPONENT}:${PLATFORM_PAIR} GIT_COMMIT="$(git rev-parse --short=8 "$CHECKOUT_REF")"
 
       - name: Compile image helper binaries
         env:


### PR DESCRIPTION
## Summary

- Pass the validated checkout reference through an environment variable before resolving its short SHA.
- Keep image build metadata tied to the validated source revision.

## Why

The previous follow-up to #513 interpolated the workflow input directly in a shell command. Using a quoted environment variable removes that code-injection pattern while preserving the intended commit provenance.

## Validation

- `actionlint .github/workflows/*.yml`

Follow-up to #513.