### PR TITLE
ci: Restrict scheduled workflows to canonical repo

### DIFF
--- a/.github/workflows/cache-cleanup.yml
+++ b/.github/workflows/cache-cleanup.yml
@@ -12,6 +12,8 @@ permissions:
 jobs:
   cleanup-host:
     name: Trim host caches
+    # Do not run the upstream maintenance schedule in forks.
+    if: github.event_name != 'schedule' || github.repository == 'container-registry/harbor-next'
     runs-on: ${{ vars.RUNNER || 'ubuntu-latest' }}
     steps:
       - name: Trim Go build cache (files not modified in 7 days)
@@ -54,6 +56,8 @@ jobs:
 
   cleanup-github-cache:
     name: Purge stale GitHub Actions caches
+    # Do not run the upstream maintenance schedule in forks.
+    if: github.event_name != 'schedule' || github.repository == 'container-registry/harbor-next'
     runs-on: ubuntu-latest
     steps:
       - name: Delete cache entries older than 7 days

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -21,6 +21,8 @@ concurrency:
 jobs:
   analyze:
     name: Analyze (${{ matrix.language }})
+    # Keep CodeQL available to fork pushes and PRs; reserve its scheduled scan for the canonical repo.
+    if: github.event_name != 'schedule' || github.repository == 'container-registry/harbor-next'
     runs-on: ubuntu-latest
     permissions:
       actions: read

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -13,6 +13,8 @@ permissions: read-all
 jobs:
   analysis:
     name: Scorecard Analysis
+    # Scheduled runs are reserved for the canonical repository; forks retain push checks.
+    if: github.event_name != 'schedule' || github.repository == 'container-registry/harbor-next'
     # Scorecard result publishing requires a single GitHub-hosted Ubuntu runner.
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/upstream-cherry-pick.yml
+++ b/.github/workflows/upstream-cherry-pick.yml
@@ -23,6 +23,8 @@ concurrency:
 jobs:
   upstream-cherry-pick:
     name: Open upstream cherry-pick PRs
+    # Forks may use the manual dry-run, but must not run the canonical schedule.
+    if: github.event_name != 'schedule' || github.repository == 'container-registry/harbor-next'
     runs-on: ${{ vars.RUNNER || 'ubuntu-latest' }}
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/zero-cve.yml
+++ b/.github/workflows/zero-cve.yml
@@ -43,6 +43,8 @@ env:
 jobs:
   scan-remediate:
     name: Scan, Remediate, and Report
+    # Forks may dispatch an ad-hoc scan, but must not run the canonical remediation schedule.
+    if: github.event_name != 'schedule' || github.repository == 'container-registry/harbor-next'
     runs-on: ${{ vars.RUNNER || 'ubuntu-latest' }}
     env:
       GH_TOKEN: ${{ github.token }}


### PR DESCRIPTION
## Summary

- restrict scheduled workflow jobs to `container-registry/harbor-next`
- preserve push, pull-request, and manual-dispatch behavior in forks

## Why

Forks inherited the canonical scheduled maintenance and security workflows, causing those jobs to execute in each fork.

## Validation

- `actionlint -color .github/workflows/*.yml`