### PR TITLE
refactor: Extract Manifest Abstraction Into A Registry

### DIFF
--- a/src/controller/artifact/abstractor.go
+++ b/src/controller/artifact/abstractor.go
@@ -16,22 +16,10 @@ package artifact
 
 import (
 	"context"
-	"encoding/json"
-	"fmt"
-
-	"github.com/docker/distribution/manifest/manifestlist"
-	"github.com/docker/distribution/manifest/schema1"
-	"github.com/docker/distribution/manifest/schema2"
-	v1 "github.com/opencontainers/image-spec/specs-go/v1"
 
 	"github.com/goharbor/harbor/src/controller/artifact/manifest"
 	"github.com/goharbor/harbor/src/controller/artifact/processor"
-	"github.com/goharbor/harbor/src/controller/artifact/processor/wasm"
-	"github.com/goharbor/harbor/src/lib/log"
-	"github.com/goharbor/harbor/src/lib/q"
-	"github.com/goharbor/harbor/src/pkg"
 	"github.com/goharbor/harbor/src/pkg/artifact"
-	"github.com/goharbor/harbor/src/pkg/blob"
 	"github.com/goharbor/harbor/src/pkg/registry"
 )
 
@@ -44,176 +32,33 @@ type Abstractor interface {
 // NewAbstractor creates a new abstractor
 func NewAbstractor() Abstractor {
 	return &abstractor{
-		artMgr:      pkg.ArtifactMgr,
-		blobMgr:     blob.Mgr,
-		regCli:      registry.Cli,
-		attestation: manifest.NewInTotoAttestationClassifier(pkg.ArtifactMgr, registry.Cli),
+		regCli: registry.Cli,
 	}
 }
 
 type abstractor struct {
-	artMgr      artifact.Manager
-	blobMgr     blob.Manager
-	regCli      registry.Client
-	attestation *manifest.InTotoAttestationClassifier
+	regCli registry.Client
 }
 
-func (a *abstractor) AbstractMetadata(ctx context.Context, artifact *artifact.Artifact) error {
+func (a *abstractor) AbstractMetadata(ctx context.Context, art *artifact.Artifact) error {
 	// read manifest content
-	manifest, _, err := a.regCli.PullManifest(artifact.RepositoryName, artifact.Digest)
+	mf, _, err := a.regCli.PullManifest(art.RepositoryName, art.Digest)
 	if err != nil {
 		return err
 	}
-	manifestMediaType, content, err := manifest.Payload()
+	manifestMediaType, content, err := mf.Payload()
 	if err != nil {
 		return err
 	}
-	artifact.ManifestMediaType = manifestMediaType
+	art.ManifestMediaType = manifestMediaType
 
-	switch artifact.ManifestMediaType {
-	case "", "application/json", schema1.MediaTypeSignedManifest:
-		if err := a.abstractManifestV1Metadata(ctx, artifact, content); err != nil {
-			return err
-		}
-	case v1.MediaTypeImageManifest, schema2.MediaTypeManifest:
-		if err = a.abstractManifestV2Metadata(artifact, content); err != nil {
-			return err
-		}
-	case v1.MediaTypeImageIndex, manifestlist.MediaTypeManifestList:
-		if err = a.abstractIndexMetadata(ctx, artifact, content); err != nil {
-			return err
-		}
-	default:
-		return fmt.Errorf("unsupported manifest media type: %s", artifact.ManifestMediaType)
-	}
-	return processor.Get(artifact.ResolveArtifactType()).AbstractMetadata(ctx, artifact, content)
-}
-
-// the artifact is enveloped by docker manifest v1
-func (a *abstractor) abstractManifestV1Metadata(ctx context.Context, artifact *artifact.Artifact, content []byte) error {
-	// unify the media type of v1 manifest to "schema1.MediaTypeSignedManifest"
-	artifact.ManifestMediaType = schema1.MediaTypeSignedManifest
-	// as no config layer in the docker v1 manifest, use the "schema1.MediaTypeSignedManifest"
-	// as the media type of artifact
-	artifact.MediaType = schema1.MediaTypeSignedManifest
-
-	manifest := &schema1.Manifest{}
-	if err := json.Unmarshal(content, manifest); err != nil {
-		return err
-	}
-
-	var ol q.OrList
-	for _, fsLayer := range manifest.FSLayers {
-		ol.Values = append(ol.Values, fsLayer.BlobSum.String())
-	}
-
-	// there is no layer size in v1 manifest, compute the artifact size from the blobs
-	blobs, err := a.blobMgr.List(ctx, q.New(q.KeyWords{"digest": &ol}))
-	if err != nil {
-		log.G(ctx).Errorf("failed to get blobs of the artifact %s, error %v", artifact.Digest, err)
-		return err
-	}
-
-	artifact.Size = int64(len(content))
-	for _, blob := range blobs {
-		artifact.Size += blob.Size
-	}
-
-	return nil
-}
-
-// the artifact is enveloped by OCI manifest or docker manifest v2
-func (a *abstractor) abstractManifestV2Metadata(artifact *artifact.Artifact, content []byte) error {
-	manifest := &v1.Manifest{}
-	if err := json.Unmarshal(content, manifest); err != nil {
-		return err
-	}
-	// use the "manifest.config.mediatype" as the media type of the artifact
-	artifact.MediaType = manifest.Config.MediaType
-	if manifest.Annotations[wasm.AnnotationVariantKey] == wasm.AnnotationVariantValue || manifest.Annotations[wasm.AnnotationHandlerKey] == wasm.AnnotationHandlerValue {
-		artifact.MediaType = wasm.MediaType
-	}
-	/*
-		https://github.com/opencontainers/distribution-spec/blob/v1.1.0/spec.md#listing-referrers
-		For referrers list, if the artifactType is empty or missing in the image manifest, the value of artifactType MUST be set to the config descriptor mediaType value
-	*/
-	if manifest.ArtifactType != "" {
-		artifact.ArtifactType = manifest.ArtifactType
-	} else {
-		artifact.ArtifactType = manifest.Config.MediaType
-	}
-
-	// set size
-	artifact.Size = int64(len(content)) + manifest.Config.Size
-	for _, layer := range manifest.Layers {
-		artifact.Size += layer.Size
-	}
-	// set annotations
-	artifact.Annotations = manifest.Annotations
-	return nil
-}
-
-// the artifact is enveloped by OCI index or docker manifest list
-func (a *abstractor) abstractIndexMetadata(ctx context.Context, art *artifact.Artifact, content []byte) error {
-	// the identity of index is still in progress, we use the manifest mediaType
-	// as the media type of artifact
-	art.MediaType = art.ManifestMediaType
-
-	index := &v1.Index{}
-	if err := json.Unmarshal(content, index); err != nil {
-		return err
-	}
-
-	/*
-		https://github.com/opencontainers/distribution-spec/blob/v1.1.0/spec.md#listing-referrers
-		For referrers list, If the artifactType is empty or missing in an index, the artifactType MUST be omitted.
-	*/
-	if index.ArtifactType != "" {
-		art.ArtifactType = index.ArtifactType
-	} else {
-		art.ArtifactType = ""
-	}
-
-	// set annotations
-	art.Annotations = index.Annotations
-
-	art.Size += int64(len(content))
-
-	references, candidates, err := a.attestation.Classify(ctx, art.RepositoryName, index.Manifests)
+	abs, err := manifest.Get(art.ManifestMediaType)
 	if err != nil {
 		return err
 	}
-	for _, candidate := range candidates {
-		art.Size += candidate.Size
-		art.AccessoryCandidates = append(art.AccessoryCandidates, candidate)
+	if err = abs.Abstract(ctx, art, content); err != nil {
+		return err
 	}
 
-	// populate the referenced artifacts
-	for _, mani := range references {
-		digest := mani.Digest.String()
-		// make sure the child artifact exist
-		ar, err := a.artMgr.GetByDigest(ctx, art.RepositoryName, digest)
-		if err != nil {
-			return err
-		}
-		art.Size += ar.Size
-		art.References = append(art.References, &artifact.Reference{
-			ChildID:     ar.ID,
-			ChildDigest: digest,
-			Platform:    mani.Platform,
-			URLs:        mani.URLs,
-			Annotations: mani.Annotations,
-		})
-	}
-
-	// Currently, CNAB put its media type inside the annotations
-	// try to parse the artifact media type from the annotations
-	if art.Annotations != nil {
-		mediaType := art.Annotations["org.opencontainers.artifactType"]
-		if len(mediaType) > 0 {
-			art.MediaType = mediaType
-		}
-	}
-
-	return nil
+	return processor.Get(art.ResolveArtifactType()).AbstractMetadata(ctx, art, content)
 }

--- a/src/controller/artifact/abstractor_test.go
+++ b/src/controller/artifact/abstractor_test.go
@@ -16,12 +16,10 @@ package artifact
 
 import (
 	"context"
-	"fmt"
-	"io"
-	"strings"
 	"testing"
 
 	"github.com/docker/distribution"
+	"github.com/docker/distribution/manifest/manifestlist"
 	"github.com/docker/distribution/manifest/schema1"
 	"github.com/docker/distribution/manifest/schema2"
 	v1 "github.com/opencontainers/image-spec/specs-go/v1"
@@ -294,95 +292,6 @@ var (
      "com.example.key1": "value1"
    }
  }`
-	attestationIndex = `{
-  "schemaVersion": 2,
-  "mediaType": "application/vnd.oci.image.index.v1+json",
-  "manifests": [
-    {
-      "mediaType": "application/vnd.oci.image.manifest.v1+json",
-      "size": 7143,
-      "digest": "sha256:cad250bb95ea402adf4f687cc7d6747ecf0de875e6d6117f74437893964903df",
-      "platform": {
-        "architecture": "amd64",
-        "os": "linux"
-      }
-    },
-    {
-      "mediaType": "application/vnd.oci.image.manifest.v1+json",
-      "size": 1024,
-      "digest": "sha256:44401ce7f2bf39029d0d56f095374b7f344e1986c8b4970ef4f4fdb98e3f7220",
-      "annotations": {
-        "vnd.docker.reference.digest": "sha256:480b518ed0138eacf2d070de80cb8eb019fb0b3565e2598ed654a541c31061a0",
-        "vnd.docker.reference.type": "attestation-manifest"
-      },
-      "platform": {
-        "architecture": "unknown",
-        "os": "unknown"
-      }
-    }
-  ],
-  "annotations": {
-    "com.example.key1": "value1"
-  }
-}`
-	attestationManifestFixture = `{
-  "schemaVersion": 2,
-  "mediaType": "application/vnd.oci.image.manifest.v1+json",
-  "config": {
-    "mediaType": "application/vnd.oci.image.config.v1+json",
-    "size": 167,
-    "digest": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
-  },
-  "layers": [
-    {
-      "mediaType": "application/vnd.in-toto+json",
-      "size": 2156,
-      "digest": "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
-    }
-  ]
-}`
-	attestationStatement = `{
-  "_type": "https://in-toto.io/Statement/v0.1",
-  "subject": [
-    {
-      "name": "amd64",
-      "digest": {
-        "sha256": "480b518ed0138eacf2d070de80cb8eb019fb0b3565e2598ed654a541c31061a0"
-      }
-    }
-  ],
-  "predicateType": "https://slsa.dev/provenance/v1"
-}`
-	// Index where the attestation annotation digest points directly at the
-	// platform child so resolution works without in-toto subject loading.
-	attestationIndexAnnotationOnly = `{
-  "schemaVersion": 2,
-  "mediaType": "application/vnd.oci.image.index.v1+json",
-  "manifests": [
-    {
-      "mediaType": "application/vnd.oci.image.manifest.v1+json",
-      "size": 7143,
-      "digest": "sha256:cad250bb95ea402adf4f687cc7d6747ecf0de875e6d6117f74437893964903df",
-      "platform": {
-        "architecture": "amd64",
-        "os": "linux"
-      }
-    },
-    {
-      "mediaType": "application/vnd.oci.image.manifest.v1+json",
-      "size": 1024,
-      "digest": "sha256:44401ce7f2bf39029d0d56f095374b7f344e1986c8b4970ef4f4fdb98e3f7220",
-      "annotations": {
-        "vnd.docker.reference.digest": "sha256:cad250bb95ea402adf4f687cc7d6747ecf0de875e6d6117f74437893964903df",
-        "vnd.docker.reference.type": "attestation-manifest"
-      },
-      "platform": {
-        "architecture": "unknown",
-        "os": "unknown"
-      }
-    }
-  ]
-}`
 )
 
 type abstractorTestSuite struct {
@@ -399,15 +308,22 @@ func (a *abstractorTestSuite) SetupTest() {
 	a.argMgr = &tart.Manager{}
 	a.blobMgr = &tblob.Manager{}
 	a.abstractor = &abstractor{
-		artMgr:      a.argMgr,
-		blobMgr:     a.blobMgr,
-		regCli:      a.regCli,
-		attestation: manifest.NewInTotoAttestationClassifier(a.argMgr, a.regCli),
+		regCli: a.regCli,
 	}
 	a.processor = &tpro.Processor{}
 	// clear all registered processors
 	processor.Registry = map[string]processor.Processor{}
 	processor.Registry[schema2.MediaTypeImageConfig] = a.processor
+	// replace the registered manifest abstractors with mock-backed ones so the
+	// suite exercises them against its own managers instead of the globals
+	// wired up by the manifest package's init()
+	manifest.Registry = map[string]manifest.Abstractor{}
+	a.Require().NoError(manifest.Register(manifest.NewV1(a.blobMgr),
+		"", "application/json", schema1.MediaTypeSignedManifest))
+	a.Require().NoError(manifest.Register(manifest.NewV2(),
+		v1.MediaTypeImageManifest, schema2.MediaTypeManifest))
+	a.Require().NoError(manifest.Register(manifest.NewIndex(a.argMgr, a.regCli),
+		v1.MediaTypeImageIndex, manifestlist.MediaTypeManifestList))
 }
 
 // docker manifest v1
@@ -555,78 +471,6 @@ func (a *abstractorTestSuite) TestAbstractMetadataOfIndexWithArtifactType() {
 	a.Require().Len(artifact.Annotations, 1)
 	a.Assert().Equal("value1", artifact.Annotations["com.example.key1"])
 	a.Len(artifact.References, 2)
-}
-
-func (a *abstractorTestSuite) TestAbstractMetadataOfIndexWithAttestation() {
-	indexManifest, _, err := distribution.UnmarshalManifest(v1.MediaTypeImageIndex, []byte(attestationIndex))
-	a.Require().Nil(err)
-	attestationManifest, _, err := distribution.UnmarshalManifest(v1.MediaTypeImageManifest, []byte(attestationManifestFixture))
-	a.Require().Nil(err)
-
-	const repo = "library/test"
-	a.regCli.On("PullManifest", repo, mock.Anything).Return(indexManifest, "", nil).Once()
-	a.regCli.On("PullManifest", repo, "sha256:44401ce7f2bf39029d0d56f095374b7f344e1986c8b4970ef4f4fdb98e3f7220").Return(attestationManifest, "", nil).Once()
-	a.regCli.On("PullBlob", repo, "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb").Return(
-		int64(len(attestationStatement)),
-		io.NopCloser(strings.NewReader(attestationStatement)),
-		nil,
-	).Once()
-	a.argMgr.On("GetByDigest", mock.Anything, repo, "sha256:cad250bb95ea402adf4f687cc7d6747ecf0de875e6d6117f74437893964903df").Return(&artifact.Artifact{
-		ID:     2,
-		Digest: "sha256:cad250bb95ea402adf4f687cc7d6747ecf0de875e6d6117f74437893964903df",
-		Size:   10,
-	}, nil).Twice()
-	a.argMgr.On("GetByDigest", mock.Anything, repo, "sha256:44401ce7f2bf39029d0d56f095374b7f344e1986c8b4970ef4f4fdb98e3f7220").Return(&artifact.Artifact{
-		ID:     3,
-		Digest: "sha256:44401ce7f2bf39029d0d56f095374b7f344e1986c8b4970ef4f4fdb98e3f7220",
-		Size:   3,
-	}, nil).Once()
-
-	artifact := &artifact.Artifact{ID: 1, RepositoryName: repo}
-	err = a.abstractor.AbstractMetadata(context.TODO(), artifact)
-	a.Require().Nil(err)
-	a.Equal(v1.MediaTypeImageIndex, artifact.ManifestMediaType)
-	a.Equal(v1.MediaTypeImageIndex, artifact.MediaType)
-	a.Equal(int64(len([]byte(attestationIndex))+13), artifact.Size)
-	a.Len(artifact.References, 1)
-	a.Len(artifact.AccessoryCandidates, 1)
-	a.Equal(int64(3), artifact.AccessoryCandidates[0].ArtifactID)
-	a.Equal(int64(2), artifact.AccessoryCandidates[0].SubArtifactID)
-	a.Equal("sha256:cad250bb95ea402adf4f687cc7d6747ecf0de875e6d6117f74437893964903df", artifact.AccessoryCandidates[0].SubArtifactDigest)
-	a.Equal("attestation.intoto", artifact.AccessoryCandidates[0].Type)
-}
-
-// TestAbstractMetadataOfIndexResolvesFromAnnotation verifies
-// that annotation-based subject resolution works when in-toto subject loading
-// fails (e.g. no in-toto layer in the attestation manifest).
-func (a *abstractorTestSuite) TestAbstractMetadataOfIndexResolvesFromAnnotation() {
-	indexManifest, _, err := distribution.UnmarshalManifest(v1.MediaTypeImageIndex, []byte(attestationIndexAnnotationOnly))
-	a.Require().Nil(err)
-
-	const repo = "library/test"
-	a.regCli.On("PullManifest", repo, mock.Anything).Return(indexManifest, "", nil).Once()
-	// PullManifest for the attestation returns an error to simulate loading failure
-	a.regCli.On("PullManifest", repo, "sha256:44401ce7f2bf39029d0d56f095374b7f344e1986c8b4970ef4f4fdb98e3f7220").Return(nil, "", fmt.Errorf("no in-toto payload")).Once()
-	a.argMgr.On("GetByDigest", mock.Anything, repo, "sha256:cad250bb95ea402adf4f687cc7d6747ecf0de875e6d6117f74437893964903df").Return(&artifact.Artifact{
-		ID:     2,
-		Digest: "sha256:cad250bb95ea402adf4f687cc7d6747ecf0de875e6d6117f74437893964903df",
-		Size:   10,
-	}, nil).Twice()
-	a.argMgr.On("GetByDigest", mock.Anything, repo, "sha256:44401ce7f2bf39029d0d56f095374b7f344e1986c8b4970ef4f4fdb98e3f7220").Return(&artifact.Artifact{
-		ID:     3,
-		Digest: "sha256:44401ce7f2bf39029d0d56f095374b7f344e1986c8b4970ef4f4fdb98e3f7220",
-		Size:   3,
-	}, nil).Once()
-
-	artifact := &artifact.Artifact{ID: 1, RepositoryName: repo}
-	err = a.abstractor.AbstractMetadata(context.TODO(), artifact)
-	a.Require().Nil(err)
-	a.Len(artifact.References, 1)
-	a.Len(artifact.AccessoryCandidates, 1)
-	a.Equal(int64(3), artifact.AccessoryCandidates[0].ArtifactID)
-	a.Equal(int64(2), artifact.AccessoryCandidates[0].SubArtifactID)
-	a.Equal("sha256:cad250bb95ea402adf4f687cc7d6747ecf0de875e6d6117f74437893964903df", artifact.AccessoryCandidates[0].SubArtifactDigest)
-	a.Equal("attestation.intoto", artifact.AccessoryCandidates[0].Type)
 }
 
 type unknownManifest struct{}

--- a/src/controller/artifact/manifest/abstractor_test.go
+++ b/src/controller/artifact/manifest/abstractor_test.go
@@ -1,0 +1,181 @@
+// Copyright Project Harbor Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package manifest
+
+import (
+	"context"
+	"testing"
+
+	"github.com/docker/distribution/manifest/schema1"
+	v1 "github.com/opencontainers/image-spec/specs-go/v1"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/goharbor/harbor/src/pkg/artifact"
+	"github.com/goharbor/harbor/src/pkg/blob"
+	"github.com/goharbor/harbor/src/testing/mock"
+	tart "github.com/goharbor/harbor/src/testing/pkg/artifact"
+	tblob "github.com/goharbor/harbor/src/testing/pkg/blob"
+	tregistry "github.com/goharbor/harbor/src/testing/pkg/registry"
+)
+
+// Driving each abstractor directly with mocks is what the exported constructors are for.
+
+const (
+	v1ManifestContent = `{
+   "schemaVersion": 1,
+   "name": "library/hello-world",
+   "tag": "latest",
+   "architecture": "amd64",
+   "fsLayers": [
+      {"blobSum": "sha256:a3ed95caeb02ffe68cdd9fd84406680ae93d633cb16422d00e8a7c22955b46d4"},
+      {"blobSum": "sha256:1b930d010525941c1d56ec53b97bd057a67ae1865eebf042686d2a2d18271ced"}
+   ],
+   "history": []
+}`
+
+	v2ManifestContent = `{
+   "schemaVersion": 2,
+   "mediaType": "application/vnd.oci.image.manifest.v1+json",
+   "config": {
+      "mediaType": "application/vnd.oci.image.config.v1+json",
+      "size": 7023,
+      "digest": "sha256:b5b2b2c507a0944348e0303114d8d93aaaa081732b86451d9bce1f432a537bc7"
+   },
+   "layers": [
+      {
+         "mediaType": "application/vnd.oci.image.layer.v1.tar+gzip",
+         "size": 32654,
+         "digest": "sha256:9834876dcfb05cb167a5c24953eba58c4ac89b1adf57f28f2f9d09af107ee8f0"
+      }
+   ],
+   "annotations": {"com.example.key1": "value1"}
+}`
+
+	indexContent = `{
+   "schemaVersion": 2,
+   "mediaType": "application/vnd.oci.image.index.v1+json",
+   "manifests": [
+      {
+         "mediaType": "application/vnd.oci.image.manifest.v1+json",
+         "size": 7143,
+         "digest": "sha256:e692418e4cbaf90ca69d05a66403747baa33ee08806650b51fab815ad7fc331f",
+         "platform": {"architecture": "ppc64le", "os": "linux"}
+      }
+   ]
+}`
+)
+
+func TestV1AbstractorUsesInjectedBlobManager(t *testing.T) {
+	blobMgr := &tblob.Manager{}
+	mock.OnAnything(blobMgr, "List").Return([]*blob.Blob{{Size: 10}, {Size: 20}}, nil)
+
+	art := &artifact.Artifact{ID: 1}
+	require.NoError(t, NewV1(blobMgr).Abstract(context.Background(), art, []byte(v1ManifestContent)))
+
+	assert.Equal(t, schema1.MediaTypeSignedManifest, art.ManifestMediaType)
+	assert.Equal(t, schema1.MediaTypeSignedManifest, art.MediaType)
+	// there is no layer size in a v1 manifest, so it is summed from the blobs
+	assert.Equal(t, int64(30+len(v1ManifestContent)), art.Size)
+}
+
+func TestV2Abstractor(t *testing.T) {
+	art := &artifact.Artifact{ID: 1}
+	require.NoError(t, NewV2().Abstract(context.Background(), art, []byte(v2ManifestContent)))
+
+	assert.Equal(t, v1.MediaTypeImageConfig, art.MediaType)
+	// artifactType is absent, so it falls back to the config media type
+	assert.Equal(t, v1.MediaTypeImageConfig, art.ArtifactType)
+	assert.Equal(t, int64(7023+32654+len(v2ManifestContent)), art.Size)
+	assert.Equal(t, "value1", art.Annotations["com.example.key1"])
+}
+
+func TestIndexAbstractorUsesInjectedArtifactManager(t *testing.T) {
+	artMgr := &tart.Manager{}
+	mock.OnAnything(artMgr, "GetByDigest").Return(&artifact.Artifact{ID: 2, Size: 100}, nil)
+
+	art := &artifact.Artifact{ID: 1, ManifestMediaType: v1.MediaTypeImageIndex}
+	require.NoError(t, NewIndex(artMgr, &tregistry.Client{}).Abstract(context.Background(), art, []byte(indexContent)))
+
+	assert.Equal(t, v1.MediaTypeImageIndex, art.MediaType)
+	assert.Empty(t, art.ArtifactType)
+	require.Len(t, art.References, 1)
+	assert.Equal(t, int64(2), art.References[0].ChildID)
+	assert.Equal(t, int64(100+len(indexContent)), art.Size)
+}
+
+func TestIndexAbstractorPropagatesChildLookupError(t *testing.T) {
+	artMgr := &tart.Manager{}
+	mock.OnAnything(artMgr, "GetByDigest").Return(nil, assert.AnError)
+
+	art := &artifact.Artifact{ID: 1, ManifestMediaType: v1.MediaTypeImageIndex}
+	assert.Error(t, NewIndex(artMgr, &tregistry.Client{}).Abstract(context.Background(), art, []byte(indexContent)))
+}
+
+// CNAB carries its media type in an index annotation, not in the descriptor.
+func TestIndexAbstractorReadsMediaTypeFromAnnotations(t *testing.T) {
+	artMgr := &tart.Manager{}
+	art := &artifact.Artifact{ID: 1, ManifestMediaType: v1.MediaTypeImageIndex}
+	content := `{
+   "schemaVersion": 2,
+   "mediaType": "application/vnd.oci.image.index.v1+json",
+   "manifests": [],
+   "annotations": {"org.opencontainers.artifactType": "application/vnd.cnab.manifest.v1"}
+}`
+	require.NoError(t, NewIndex(artMgr, &tregistry.Client{}).Abstract(context.Background(), art, []byte(content)))
+	assert.Equal(t, "application/vnd.cnab.manifest.v1", art.MediaType)
+}
+
+func TestIndexAbstractorReadsArtifactType(t *testing.T) {
+	artMgr := &tart.Manager{}
+	art := &artifact.Artifact{ID: 1, ManifestMediaType: v1.MediaTypeImageIndex}
+	content := `{
+   "schemaVersion": 2,
+   "mediaType": "application/vnd.oci.image.index.v1+json",
+   "artifactType": "application/vnd.example.sbom",
+   "manifests": []
+}`
+	require.NoError(t, NewIndex(artMgr, &tregistry.Client{}).Abstract(context.Background(), art, []byte(content)))
+	assert.Equal(t, "application/vnd.example.sbom", art.ArtifactType)
+}
+
+func TestV2AbstractorReadsArtifactType(t *testing.T) {
+	art := &artifact.Artifact{ID: 1}
+	content := `{
+   "schemaVersion": 2,
+   "mediaType": "application/vnd.oci.image.manifest.v1+json",
+   "artifactType": "application/vnd.example.sbom",
+   "config": {"mediaType": "application/vnd.oci.image.config.v1+json", "size": 1, "digest": "sha256:b5b2b2c507a0944348e0303114d8d93aaaa081732b86451d9bce1f432a537bc7"},
+   "layers": []
+}`
+	require.NoError(t, NewV2().Abstract(context.Background(), art, []byte(content)))
+	assert.Equal(t, "application/vnd.example.sbom", art.ArtifactType)
+}
+
+func TestV1AbstractorPropagatesBlobListError(t *testing.T) {
+	blobMgr := &tblob.Manager{}
+	mock.OnAnything(blobMgr, "List").Return(nil, assert.AnError)
+
+	art := &artifact.Artifact{ID: 1}
+	assert.Error(t, NewV1(blobMgr).Abstract(context.Background(), art, []byte(v1ManifestContent)))
+}
+
+func TestAbstractorsRejectMalformedContent(t *testing.T) {
+	malformed := []byte("{not json")
+
+	assert.Error(t, NewV1(&tblob.Manager{}).Abstract(context.Background(), &artifact.Artifact{}, malformed))
+	assert.Error(t, NewV2().Abstract(context.Background(), &artifact.Artifact{}, malformed))
+	assert.Error(t, NewIndex(&tart.Manager{}, &tregistry.Client{}).Abstract(context.Background(), &artifact.Artifact{}, malformed))
+}

--- a/src/controller/artifact/manifest/attestation_bench_test.go
+++ b/src/controller/artifact/manifest/attestation_bench_test.go
@@ -1,0 +1,74 @@
+// Copyright Project Harbor Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package manifest
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	specs "github.com/opencontainers/image-spec/specs-go"
+	v1 "github.com/opencontainers/image-spec/specs-go/v1"
+
+	"github.com/goharbor/harbor/src/pkg/artifact"
+	"github.com/goharbor/harbor/src/pkg/registry"
+)
+
+// The testify mocks record every call, so their bookkeeping would dominate the
+// measurement and grow without bound across iterations.
+type benchArtMgr struct {
+	artifact.Manager
+	art *artifact.Artifact
+}
+
+func (m *benchArtMgr) GetByDigest(_ context.Context, _, _ string) (*artifact.Artifact, error) {
+	return m.art, nil
+}
+
+type benchRegCli struct {
+	registry.Client
+}
+
+// The attestations resolve from their annotation, so no registry round trip is
+// needed and the measurement isolates the in-memory cost of walking the children.
+func benchmarkIndexAbstract(b *testing.B, platforms, attestations int) {
+	content, err := json.Marshal(v1.Index{
+		Versioned: specs.Versioned{SchemaVersion: 2},
+		MediaType: v1.MediaTypeImageIndex,
+		Manifests: syntheticManifests(platforms, attestations, true),
+	})
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	abstractor := NewIndex(&benchArtMgr{art: &artifact.Artifact{ID: 2, Size: 10}}, &benchRegCli{})
+	ctx := context.Background()
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for range b.N {
+		art := &artifact.Artifact{ID: 1, RepositoryName: "library/test", ManifestMediaType: v1.MediaTypeImageIndex}
+		if err := abstractor.Abstract(ctx, art, content); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+// What a BuildKit multi-arch build actually produces.
+func BenchmarkIndexAbstractRealistic(b *testing.B) { benchmarkIndexAbstract(b, 2, 2) }
+
+// A 4MiB index body holds roughly this many descriptors, which is the shape an
+// attacker controls for free.
+func BenchmarkIndexAbstractWide(b *testing.B) { benchmarkIndexAbstract(b, 1, 512) }

--- a/src/controller/artifact/manifest/attestation_index_test.go
+++ b/src/controller/artifact/manifest/attestation_index_test.go
@@ -1,0 +1,187 @@
+// Copyright Project Harbor Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package manifest
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"strings"
+	"testing"
+
+	"github.com/docker/distribution"
+	v1 "github.com/opencontainers/image-spec/specs-go/v1"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/goharbor/harbor/src/pkg/accessory/model"
+	"github.com/goharbor/harbor/src/pkg/artifact"
+	"github.com/goharbor/harbor/src/testing/mock"
+	tart "github.com/goharbor/harbor/src/testing/pkg/artifact"
+	tregistry "github.com/goharbor/harbor/src/testing/pkg/registry"
+)
+
+const (
+	amd64Digest       = "sha256:cad250bb95ea402adf4f687cc7d6747ecf0de875e6d6117f74437893964903df"
+	attestationDigest = "sha256:44401ce7f2bf39029d0d56f095374b7f344e1986c8b4970ef4f4fdb98e3f7220"
+	inTotoLayerDigest = "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+
+	// the attestation's reference digest is not a child of the index, so the
+	// subject has to come from the in-toto payload
+	attestationIndex = `{
+  "schemaVersion": 2,
+  "mediaType": "application/vnd.oci.image.index.v1+json",
+  "manifests": [
+    {
+      "mediaType": "application/vnd.oci.image.manifest.v1+json",
+      "size": 7143,
+      "digest": "sha256:cad250bb95ea402adf4f687cc7d6747ecf0de875e6d6117f74437893964903df",
+      "platform": {"architecture": "amd64", "os": "linux"}
+    },
+    {
+      "mediaType": "application/vnd.oci.image.manifest.v1+json",
+      "size": 1024,
+      "digest": "sha256:44401ce7f2bf39029d0d56f095374b7f344e1986c8b4970ef4f4fdb98e3f7220",
+      "annotations": {
+        "vnd.docker.reference.digest": "sha256:480b518ed0138eacf2d070de80cb8eb019fb0b3565e2598ed654a541c31061a0",
+        "vnd.docker.reference.type": "attestation-manifest"
+      },
+      "platform": {"architecture": "unknown", "os": "unknown"}
+    }
+  ],
+  "annotations": {"com.example.key1": "value1"}
+}`
+
+	// here the reference digest points straight at the platform child, so the
+	// in-toto payload is never needed
+	attestationIndexAnnotationOnly = `{
+  "schemaVersion": 2,
+  "mediaType": "application/vnd.oci.image.index.v1+json",
+  "manifests": [
+    {
+      "mediaType": "application/vnd.oci.image.manifest.v1+json",
+      "size": 7143,
+      "digest": "sha256:cad250bb95ea402adf4f687cc7d6747ecf0de875e6d6117f74437893964903df",
+      "platform": {"architecture": "amd64", "os": "linux"}
+    },
+    {
+      "mediaType": "application/vnd.oci.image.manifest.v1+json",
+      "size": 1024,
+      "digest": "sha256:44401ce7f2bf39029d0d56f095374b7f344e1986c8b4970ef4f4fdb98e3f7220",
+      "annotations": {
+        "vnd.docker.reference.digest": "sha256:cad250bb95ea402adf4f687cc7d6747ecf0de875e6d6117f74437893964903df",
+        "vnd.docker.reference.type": "attestation-manifest"
+      },
+      "platform": {"architecture": "unknown", "os": "unknown"}
+    }
+  ]
+}`
+
+	attestationManifestFixture = `{
+  "schemaVersion": 2,
+  "mediaType": "application/vnd.oci.image.manifest.v1+json",
+  "config": {
+    "mediaType": "application/vnd.oci.image.config.v1+json",
+    "size": 167,
+    "digest": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+  },
+  "layers": [
+    {
+      "mediaType": "application/vnd.in-toto+json",
+      "size": 2156,
+      "digest": "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+    }
+  ]
+}`
+
+	attestationStatement = `{
+  "_type": "https://in-toto.io/Statement/v0.1",
+  "subject": [
+    {
+      "name": "amd64",
+      "digest": {"sha256": "480b518ed0138eacf2d070de80cb8eb019fb0b3565e2598ed654a541c31061a0"}
+    }
+  ],
+  "predicateType": "https://slsa.dev/provenance/v1"
+}`
+)
+
+func attestationIndexMocks(t *testing.T) (*tart.Manager, *tregistry.Client) {
+	t.Helper()
+	artMgr := &tart.Manager{}
+	regCli := &tregistry.Client{}
+	artMgr.On("GetByDigest", mock.Anything, mock.Anything, amd64Digest).
+		Return(&artifact.Artifact{ID: 2, Digest: amd64Digest, Size: 10}, nil)
+	artMgr.On("GetByDigest", mock.Anything, mock.Anything, attestationDigest).
+		Return(&artifact.Artifact{ID: 3, Digest: attestationDigest, Size: 3}, nil)
+	return artMgr, regCli
+}
+
+// The attestation must become an accessory of the platform image rather than an
+// unknown/unknown child of the index.
+func TestIndexAbstractorClassifiesAttestationAsAccessory(t *testing.T) {
+	artMgr, regCli := attestationIndexMocks(t)
+
+	attestationManifest, _, err := distribution.UnmarshalManifest(v1.MediaTypeImageManifest, []byte(attestationManifestFixture))
+	require.NoError(t, err)
+	regCli.On("PullManifest", mock.Anything, attestationDigest).Return(attestationManifest, "", nil).Once()
+	regCli.On("PullBlob", mock.Anything, inTotoLayerDigest).Return(
+		int64(len(attestationStatement)),
+		io.NopCloser(strings.NewReader(attestationStatement)),
+		nil,
+	).Once()
+
+	art := &artifact.Artifact{ID: 1, RepositoryName: "library/test", ManifestMediaType: v1.MediaTypeImageIndex}
+	require.NoError(t, NewIndex(artMgr, regCli).Abstract(context.Background(), art, []byte(attestationIndex)))
+
+	require.Len(t, art.References, 1, "the attestation must not be listed as a child of the index")
+	require.Len(t, art.AccessoryCandidates, 1)
+	assert.Equal(t, int64(3), art.AccessoryCandidates[0].ArtifactID)
+	assert.Equal(t, int64(2), art.AccessoryCandidates[0].SubArtifactID)
+	assert.Equal(t, amd64Digest, art.AccessoryCandidates[0].SubArtifactDigest)
+	assert.Equal(t, model.TypeInTotoAttestation, art.AccessoryCandidates[0].Type)
+	assert.Equal(t, int64(len(attestationIndex)+13), art.Size)
+}
+
+// An annotation naming a child of the index resolves without touching the
+// payload, which is the whole point of trying it first.
+func TestIndexAbstractorResolvesFromAnnotationWithoutPullingPayload(t *testing.T) {
+	artMgr, regCli := attestationIndexMocks(t)
+
+	art := &artifact.Artifact{ID: 1, RepositoryName: "library/test", ManifestMediaType: v1.MediaTypeImageIndex}
+	require.NoError(t, NewIndex(artMgr, regCli).Abstract(context.Background(), art, []byte(attestationIndexAnnotationOnly)))
+
+	regCli.AssertNotCalled(t, "PullManifest", mock.Anything, attestationDigest)
+	regCli.AssertNotCalled(t, "PullBlob", mock.Anything, mock.Anything)
+	require.Len(t, art.References, 1)
+	require.Len(t, art.AccessoryCandidates, 1)
+	assert.Equal(t, amd64Digest, art.AccessoryCandidates[0].SubArtifactDigest)
+	assert.Equal(t, model.TypeInTotoAttestation, art.AccessoryCandidates[0].Type)
+}
+
+// With the annotation pointing outside the index and the payload unreadable,
+// nothing resolves and the attestation stays an ordinary child rather than
+// being dropped.
+func TestIndexAbstractorKeepsUnresolvableAttestationAsChild(t *testing.T) {
+	artMgr, regCli := attestationIndexMocks(t)
+	regCli.On("PullManifest", mock.Anything, attestationDigest).Return(nil, "", fmt.Errorf("boom")).Once()
+
+	art := &artifact.Artifact{ID: 1, RepositoryName: "library/test", ManifestMediaType: v1.MediaTypeImageIndex}
+	require.NoError(t, NewIndex(artMgr, regCli).Abstract(context.Background(), art, []byte(attestationIndex)))
+
+	regCli.AssertCalled(t, "PullManifest", mock.Anything, attestationDigest)
+	assert.Empty(t, art.AccessoryCandidates)
+	assert.Len(t, art.References, 2, "the unresolved attestation is still a child")
+}

--- a/src/controller/artifact/manifest/index.go
+++ b/src/controller/artifact/manifest/index.go
@@ -1,0 +1,112 @@
+// Copyright Project Harbor Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package manifest
+
+import (
+	"context"
+	"encoding/json"
+
+	"github.com/docker/distribution/manifest/manifestlist"
+	v1 "github.com/opencontainers/image-spec/specs-go/v1"
+
+	"github.com/goharbor/harbor/src/lib/log"
+	"github.com/goharbor/harbor/src/pkg"
+	"github.com/goharbor/harbor/src/pkg/artifact"
+	"github.com/goharbor/harbor/src/pkg/registry"
+)
+
+func init() {
+	mediaTypes := []string{v1.MediaTypeImageIndex, manifestlist.MediaTypeManifestList}
+	if err := Register(NewIndex(pkg.ArtifactMgr, registry.Cli), mediaTypes...); err != nil {
+		log.Errorf("failed to register the abstractor for manifest media types %v: %v", mediaTypes, err)
+	}
+}
+
+// indexAbstractor abstracts artifacts enveloped by OCI index or docker manifest list.
+type indexAbstractor struct {
+	artMgr      artifact.Manager
+	attestation *InTotoAttestationClassifier
+}
+
+func NewIndex(artMgr artifact.Manager, regCli registry.Client) Abstractor {
+	return &indexAbstractor{
+		artMgr:      artMgr,
+		attestation: NewInTotoAttestationClassifier(artMgr, regCli),
+	}
+}
+
+func (a *indexAbstractor) Abstract(ctx context.Context, art *artifact.Artifact, content []byte) error {
+	// the identity of index is still in progress, we use the manifest mediaType
+	// as the media type of artifact
+	art.MediaType = art.ManifestMediaType
+
+	index := &v1.Index{}
+	if err := json.Unmarshal(content, index); err != nil {
+		return err
+	}
+
+	/*
+		https://github.com/opencontainers/distribution-spec/blob/v1.1.0/spec.md#listing-referrers
+		For referrers list, If the artifactType is empty or missing in an index, the artifactType MUST be omitted.
+	*/
+	if index.ArtifactType != "" {
+		art.ArtifactType = index.ArtifactType
+	} else {
+		art.ArtifactType = ""
+	}
+
+	// set annotations
+	art.Annotations = index.Annotations
+
+	art.Size += int64(len(content))
+	// populate the referenced artifacts
+	for _, mani := range index.Manifests {
+		candidate, err := a.attestation.Classify(ctx, art.RepositoryName, mani, index.Manifests)
+		if err != nil {
+			return err
+		}
+		if candidate != nil {
+			art.Size += candidate.Size
+			art.AccessoryCandidates = append(art.AccessoryCandidates, candidate)
+			continue
+		}
+
+		digest := mani.Digest.String()
+		// make sure the child artifact exist
+		ar, err := a.artMgr.GetByDigest(ctx, art.RepositoryName, digest)
+		if err != nil {
+			return err
+		}
+		art.Size += ar.Size
+		art.References = append(art.References, &artifact.Reference{
+			ChildID:     ar.ID,
+			ChildDigest: digest,
+			Platform:    mani.Platform,
+			URLs:        mani.URLs,
+			Annotations: mani.Annotations,
+		})
+	}
+
+	// Currently, CNAB put its media type inside the annotations
+	// try to parse the artifact media type from the annotations
+	if art.Annotations != nil {
+		mediaType := art.Annotations["org.opencontainers.artifactType"]
+		if len(mediaType) > 0 {
+			art.MediaType = mediaType
+		}
+	}
+
+	return nil
+}

--- a/src/controller/artifact/manifest/index.go
+++ b/src/controller/artifact/manifest/index.go
@@ -71,18 +71,18 @@ func (a *indexAbstractor) Abstract(ctx context.Context, art *artifact.Artifact, 
 	art.Annotations = index.Annotations
 
 	art.Size += int64(len(content))
-	// populate the referenced artifacts
-	for _, mani := range index.Manifests {
-		candidate, err := a.attestation.Classify(ctx, art.RepositoryName, mani, index.Manifests)
-		if err != nil {
-			return err
-		}
-		if candidate != nil {
-			art.Size += candidate.Size
-			art.AccessoryCandidates = append(art.AccessoryCandidates, candidate)
-			continue
-		}
 
+	references, candidates, err := a.attestation.Classify(ctx, art.RepositoryName, index.Manifests)
+	if err != nil {
+		return err
+	}
+	for _, candidate := range candidates {
+		art.Size += candidate.Size
+		art.AccessoryCandidates = append(art.AccessoryCandidates, candidate)
+	}
+
+	// populate the referenced artifacts
+	for _, mani := range references {
 		digest := mani.Digest.String()
 		// make sure the child artifact exist
 		ar, err := a.artMgr.GetByDigest(ctx, art.RepositoryName, digest)

--- a/src/controller/artifact/manifest/index.go
+++ b/src/controller/artifact/manifest/index.go
@@ -21,7 +21,6 @@ import (
 	"github.com/docker/distribution/manifest/manifestlist"
 	v1 "github.com/opencontainers/image-spec/specs-go/v1"
 
-	"github.com/goharbor/harbor/src/lib/log"
 	"github.com/goharbor/harbor/src/pkg"
 	"github.com/goharbor/harbor/src/pkg/artifact"
 	"github.com/goharbor/harbor/src/pkg/registry"
@@ -30,7 +29,7 @@ import (
 func init() {
 	mediaTypes := []string{v1.MediaTypeImageIndex, manifestlist.MediaTypeManifestList}
 	if err := Register(NewIndex(pkg.ArtifactMgr, registry.Cli), mediaTypes...); err != nil {
-		log.Errorf("failed to register the abstractor for manifest media types %v: %v", mediaTypes, err)
+		panic(err)
 	}
 }
 

--- a/src/controller/artifact/manifest/manifest.go
+++ b/src/controller/artifact/manifest/manifest.go
@@ -40,6 +40,11 @@ func Register(abstractor Abstractor, mediaTypes ...string) error {
 	if abstractor == nil {
 		return errors.New("refusing to register a nil manifest abstractor")
 	}
+	// Registering nothing would otherwise succeed and only surface as an
+	// unsupported media type at dispatch, far from the faulty call.
+	if len(mediaTypes) == 0 {
+		return errors.New("no manifest media types given to register")
+	}
 
 	seen := make(map[string]struct{}, len(mediaTypes))
 	for _, mediaType := range mediaTypes {

--- a/src/controller/artifact/manifest/manifest.go
+++ b/src/controller/artifact/manifest/manifest.go
@@ -1,0 +1,70 @@
+// Copyright Project Harbor Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package manifest
+
+import (
+	"context"
+
+	"github.com/goharbor/harbor/src/lib/errors"
+	"github.com/goharbor/harbor/src/lib/log"
+	"github.com/goharbor/harbor/src/pkg/artifact"
+)
+
+// Registry holds the registered manifest abstractors, keyed by manifest media type.
+var Registry = map[string]Abstractor{}
+
+// Abstractor abstracts the metadata carried by one manifest format into the
+// artifact model.
+type Abstractor interface {
+	Abstract(ctx context.Context, art *artifact.Artifact, content []byte) error
+}
+
+// Register an abstractor for one or more manifest media types. Callers only log
+// registration errors, so the batch is validated before anything is written: a
+// half-applied batch would make dispatch depend on the order of the media types.
+func Register(abstractor Abstractor, mediaTypes ...string) error {
+	// Get treats any present entry as usable, so a nil stored here would panic on
+	// the next artifact of that media type instead of failing at registration.
+	if abstractor == nil {
+		return errors.New("refusing to register a nil manifest abstractor")
+	}
+
+	seen := make(map[string]struct{}, len(mediaTypes))
+	for _, mediaType := range mediaTypes {
+		if _, exist := Registry[mediaType]; exist {
+			return errors.Errorf("the abstractor for manifest media type %s already exists", mediaType)
+		}
+		if _, duplicate := seen[mediaType]; duplicate {
+			return errors.Errorf("the manifest media type %s is listed twice", mediaType)
+		}
+		seen[mediaType] = struct{}{}
+	}
+
+	for _, mediaType := range mediaTypes {
+		Registry[mediaType] = abstractor
+		log.Debugf("the abstractor for manifest media type %s registered", mediaType)
+	}
+	return nil
+}
+
+// Get the abstractor for the manifest media type. Unlike processor.Get there is
+// no default fallback: guessing at an unknown format would corrupt the artifact model.
+func Get(mediaType string) (Abstractor, error) {
+	abstractor, exist := Registry[mediaType]
+	if !exist {
+		return nil, errors.Errorf("unsupported manifest media type: %s", mediaType).WithCode(errors.UNSUPPORTED)
+	}
+	return abstractor, nil
+}

--- a/src/controller/artifact/manifest/manifest.go
+++ b/src/controller/artifact/manifest/manifest.go
@@ -31,9 +31,11 @@ type Abstractor interface {
 	Abstract(ctx context.Context, art *artifact.Artifact, content []byte) error
 }
 
-// Register an abstractor for one or more manifest media types. Callers only log
-// registration errors, so the batch is validated before anything is written: a
-// half-applied batch would make dispatch depend on the order of the media types.
+// Register an abstractor for one or more manifest media types. Registration
+// failures are fatal at startup: an unregistered media type would fail every
+// push and pull of that manifest format at runtime, far from the actual cause.
+// The batch is validated before anything is written, since a half-applied batch
+// would make dispatch depend on the order of the media types.
 func Register(abstractor Abstractor, mediaTypes ...string) error {
 	// Get treats any present entry as usable, so a nil stored here would panic on
 	// the next artifact of that media type instead of failing at registration.

--- a/src/controller/artifact/manifest/manifest_test.go
+++ b/src/controller/artifact/manifest/manifest_test.go
@@ -102,6 +102,20 @@ func TestRegisterRejectedBatchIsNotApplied(t *testing.T) {
 	assert.Len(t, Registry, 1)
 }
 
+func TestRegisterRequiresMediaTypes(t *testing.T) {
+	withRegistry(t, map[string]Abstractor{})
+
+	assert.Error(t, Register(stubAbstractor{}), "registering nothing must not silently succeed")
+	assert.Empty(t, Registry)
+}
+
+func TestRegisterRejectsNil(t *testing.T) {
+	withRegistry(t, map[string]Abstractor{})
+
+	assert.Error(t, Register(nil, "a"))
+	assert.Empty(t, Registry)
+}
+
 func TestRegisterDuplicateWithinBatch(t *testing.T) {
 	withRegistry(t, map[string]Abstractor{})
 

--- a/src/controller/artifact/manifest/manifest_test.go
+++ b/src/controller/artifact/manifest/manifest_test.go
@@ -1,0 +1,110 @@
+// Copyright Project Harbor Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package manifest
+
+import (
+	"context"
+	"testing"
+
+	"github.com/docker/distribution/manifest/manifestlist"
+	"github.com/docker/distribution/manifest/schema1"
+	"github.com/docker/distribution/manifest/schema2"
+	v1 "github.com/opencontainers/image-spec/specs-go/v1"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/goharbor/harbor/src/lib/errors"
+	"github.com/goharbor/harbor/src/pkg/artifact"
+)
+
+type stubAbstractor struct{}
+
+func (stubAbstractor) Abstract(_ context.Context, _ *artifact.Artifact, _ []byte) error {
+	return nil
+}
+
+func withRegistry(t *testing.T, registry map[string]Abstractor) {
+	t.Helper()
+	original := Registry
+	Registry = registry
+	t.Cleanup(func() { Registry = original })
+}
+
+// An empty registry means no artifact can be abstracted at all, so pin the bootstrap.
+func TestDefaultRegistrations(t *testing.T) {
+	for _, mediaType := range []string{
+		"",
+		"application/json",
+		schema1.MediaTypeSignedManifest,
+		v1.MediaTypeImageManifest,
+		schema2.MediaTypeManifest,
+		v1.MediaTypeImageIndex,
+		manifestlist.MediaTypeManifestList,
+	} {
+		abstractor, err := Get(mediaType)
+		require.NoError(t, err, "no abstractor registered for %q", mediaType)
+		assert.NotNil(t, abstractor)
+	}
+}
+
+func TestGetUnsupportedMediaType(t *testing.T) {
+	abstractor, err := Get("application/vnd.example.unknown")
+	require.Error(t, err)
+	assert.Nil(t, abstractor)
+	assert.Equal(t, errors.UNSUPPORTED, errors.ErrCode(err))
+}
+
+// A layer media type must not resolve to the image manifest abstractor.
+func TestGetRejectsLayerMediaType(t *testing.T) {
+	_, err := Get(v1.MediaTypeImageLayerGzip)
+	assert.Error(t, err)
+}
+
+func TestRegister(t *testing.T) {
+	withRegistry(t, map[string]Abstractor{})
+
+	require.NoError(t, Register(stubAbstractor{}, "a", "b"))
+	assert.Len(t, Registry, 2)
+
+	abstractor, err := Get("a")
+	require.NoError(t, err)
+	assert.NotNil(t, abstractor)
+}
+
+func TestRegisterDuplicate(t *testing.T) {
+	withRegistry(t, map[string]Abstractor{})
+
+	require.NoError(t, Register(stubAbstractor{}, "a"))
+	assert.Error(t, Register(stubAbstractor{}, "a"))
+}
+
+// A partly applied batch would make dispatch depend on the order of the media types.
+func TestRegisterRejectedBatchIsNotApplied(t *testing.T) {
+	withRegistry(t, map[string]Abstractor{})
+
+	require.NoError(t, Register(stubAbstractor{}, "existing"))
+	assert.Error(t, Register(stubAbstractor{}, "new", "existing"))
+
+	_, err := Get("new")
+	assert.Error(t, err, "the rest of the batch must not have been registered")
+	assert.Len(t, Registry, 1)
+}
+
+func TestRegisterDuplicateWithinBatch(t *testing.T) {
+	withRegistry(t, map[string]Abstractor{})
+
+	assert.Error(t, Register(stubAbstractor{}, "a", "a"))
+	assert.Empty(t, Registry)
+}

--- a/src/controller/artifact/manifest/v1.go
+++ b/src/controller/artifact/manifest/v1.go
@@ -29,7 +29,7 @@ import (
 func init() {
 	mediaTypes := []string{"", "application/json", schema1.MediaTypeSignedManifest}
 	if err := Register(NewV1(blob.Mgr), mediaTypes...); err != nil {
-		log.Errorf("failed to register the abstractor for manifest media types %v: %v", mediaTypes, err)
+		panic(err)
 	}
 }
 

--- a/src/controller/artifact/manifest/v1.go
+++ b/src/controller/artifact/manifest/v1.go
@@ -1,0 +1,75 @@
+// Copyright Project Harbor Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package manifest
+
+import (
+	"context"
+	"encoding/json"
+
+	"github.com/docker/distribution/manifest/schema1"
+
+	"github.com/goharbor/harbor/src/lib/log"
+	"github.com/goharbor/harbor/src/lib/q"
+	"github.com/goharbor/harbor/src/pkg/artifact"
+	"github.com/goharbor/harbor/src/pkg/blob"
+)
+
+func init() {
+	mediaTypes := []string{"", "application/json", schema1.MediaTypeSignedManifest}
+	if err := Register(NewV1(blob.Mgr), mediaTypes...); err != nil {
+		log.Errorf("failed to register the abstractor for manifest media types %v: %v", mediaTypes, err)
+	}
+}
+
+// v1Abstractor abstracts artifacts enveloped by docker manifest v1.
+type v1Abstractor struct {
+	blobMgr blob.Manager
+}
+
+func NewV1(blobMgr blob.Manager) Abstractor {
+	return &v1Abstractor{blobMgr: blobMgr}
+}
+
+func (a *v1Abstractor) Abstract(ctx context.Context, art *artifact.Artifact, content []byte) error {
+	// unify the media type of v1 manifest to "schema1.MediaTypeSignedManifest"
+	art.ManifestMediaType = schema1.MediaTypeSignedManifest
+	// as no config layer in the docker v1 manifest, use the "schema1.MediaTypeSignedManifest"
+	// as the media type of artifact
+	art.MediaType = schema1.MediaTypeSignedManifest
+
+	mf := &schema1.Manifest{}
+	if err := json.Unmarshal(content, mf); err != nil {
+		return err
+	}
+
+	var ol q.OrList
+	for _, fsLayer := range mf.FSLayers {
+		ol.Values = append(ol.Values, fsLayer.BlobSum.String())
+	}
+
+	// there is no layer size in v1 manifest, compute the artifact size from the blobs
+	blobs, err := a.blobMgr.List(ctx, q.New(q.KeyWords{"digest": &ol}))
+	if err != nil {
+		log.G(ctx).Errorf("failed to get blobs of the artifact %s, error %v", art.Digest, err)
+		return err
+	}
+
+	art.Size = int64(len(content))
+	for _, b := range blobs {
+		art.Size += b.Size
+	}
+
+	return nil
+}

--- a/src/controller/artifact/manifest/v2.go
+++ b/src/controller/artifact/manifest/v2.go
@@ -1,0 +1,71 @@
+// Copyright Project Harbor Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package manifest
+
+import (
+	"context"
+	"encoding/json"
+
+	"github.com/docker/distribution/manifest/schema2"
+	v1 "github.com/opencontainers/image-spec/specs-go/v1"
+
+	"github.com/goharbor/harbor/src/controller/artifact/processor/wasm"
+	"github.com/goharbor/harbor/src/lib/log"
+	"github.com/goharbor/harbor/src/pkg/artifact"
+)
+
+func init() {
+	mediaTypes := []string{v1.MediaTypeImageManifest, schema2.MediaTypeManifest}
+	if err := Register(NewV2(), mediaTypes...); err != nil {
+		log.Errorf("failed to register the abstractor for manifest media types %v: %v", mediaTypes, err)
+	}
+}
+
+// v2Abstractor abstracts artifacts enveloped by OCI manifest or docker manifest v2.
+type v2Abstractor struct{}
+
+func NewV2() Abstractor {
+	return &v2Abstractor{}
+}
+
+func (a *v2Abstractor) Abstract(_ context.Context, art *artifact.Artifact, content []byte) error {
+	mf := &v1.Manifest{}
+	if err := json.Unmarshal(content, mf); err != nil {
+		return err
+	}
+	// use the "manifest.config.mediatype" as the media type of the artifact
+	art.MediaType = mf.Config.MediaType
+	if mf.Annotations[wasm.AnnotationVariantKey] == wasm.AnnotationVariantValue || mf.Annotations[wasm.AnnotationHandlerKey] == wasm.AnnotationHandlerValue {
+		art.MediaType = wasm.MediaType
+	}
+	/*
+		https://github.com/opencontainers/distribution-spec/blob/v1.1.0/spec.md#listing-referrers
+		For referrers list, if the artifactType is empty or missing in the image manifest, the value of artifactType MUST be set to the config descriptor mediaType value
+	*/
+	if mf.ArtifactType != "" {
+		art.ArtifactType = mf.ArtifactType
+	} else {
+		art.ArtifactType = mf.Config.MediaType
+	}
+
+	// set size
+	art.Size = int64(len(content)) + mf.Config.Size
+	for _, layer := range mf.Layers {
+		art.Size += layer.Size
+	}
+	// set annotations
+	art.Annotations = mf.Annotations
+	return nil
+}

--- a/src/controller/artifact/manifest/v2.go
+++ b/src/controller/artifact/manifest/v2.go
@@ -22,14 +22,13 @@ import (
 	v1 "github.com/opencontainers/image-spec/specs-go/v1"
 
 	"github.com/goharbor/harbor/src/controller/artifact/processor/wasm"
-	"github.com/goharbor/harbor/src/lib/log"
 	"github.com/goharbor/harbor/src/pkg/artifact"
 )
 
 func init() {
 	mediaTypes := []string{v1.MediaTypeImageManifest, schema2.MediaTypeManifest}
 	if err := Register(NewV2(), mediaTypes...); err != nil {
-		log.Errorf("failed to register the abstractor for manifest media types %v: %v", mediaTypes, err)
+		panic(err)
 	}
 }
 


### PR DESCRIPTION
## Summary

Adopts the shape proposed upstream in goharbor/harbor#23647, so the fork stops diverging in this file.

`AbstractMetadata()` dispatched on manifest media type through a hardcoded `switch`, with the three abstraction bodies as private methods on `abstractor`. The struct carried the union of every dependency: `blob.Manager` for schema1, `artifact.Manager` for indexes, neither for v2. Those three formats now sit behind the `Abstractor` interface in the `manifest` package, keyed by media type, each carrying only what it needs.

> **Stacked on #524.** Base is `refactor/index-child-classifier`; merge that first. The index abstractor here keeps the child-classifier chain from #524, so attestations are still resolved as accessories.

No behaviour change — same media types accepted, same metadata produced, same accessories.

## Why this matters for the fork

`src/controller/artifact/manifest/` is now **byte-identical** to the upstream branch (verified with `diff -rq`). Together with #524 this removes the whole area as a source of cherry-pick conflicts against `upstream-cherry-pick.yml`, which runs twice daily. Our remaining delta in artifact abstraction drops to the accessory plumbing that upstream hasn't taken yet.

The upstream counterparts are goharbor/harbor#23647 (this registry) and goharbor/harbor#23648 (the attestation classifier, stacked on it). If both land, this area of the fork converges to zero.

## What this opens up

- New manifest formats become registrations rather than edits to core dispatch.
- Each abstractor is independently testable: constructors are exported and take their dependencies, so they can be driven directly with mocks instead of only through the full `AbstractMetadata` path.

## Notes

- `Get` returns an error rather than falling back to a default. `processor.Get` defaults, which is right for artifact types; guessing at an unknown manifest format would corrupt the artifact model. The error carries `errors.UNSUPPORTED`.
- `Register` validates the whole batch before writing, so a rejected call leaves the registry untouched — callers only log registration errors, and a half-applied batch would make dispatch depend on the order of the media types.
- `schema1.MediaTypeManifest` is left unregistered, matching the previous switch exactly.
- A failed registration now panics at startup instead of logging and limping into an instance that 500s every push of that media type (raised by a maintainer on goharbor/harbor#23647; same commit here).
- The attestation index tests move from the controller suite into the `manifest` package, next to the code they cover.
- The index abstractor hands its whole child list to the classifier in one call, so the sibling list is walked once instead of rebuilt per descriptor, and the in-toto payload lookups share one budget of `min(len(children), 32)` per index. `BenchmarkIndexAbstract`, 1 platform child + 512 attestations: 12.5 ms / 34.1 MB / 8,230 allocs before, 1.76 ms / 0.74 MB / 7,726 allocs after; a realistic two-platform build is unchanged at one extra allocation. Raised by Copilot on goharbor/harbor#23648 (comment).

## Testing

`go build ./...` clean. `go test ./controller/artifact/manifest/...` green at 91.9% statement coverage; `go test ./controller/artifact/ -run TestAbstractorTestSuite` green. `golangci-lint`, `gofmt`, `go vet` clean.

`TestClassifyBoundsSubjectLookups` pins the payload-lookup budget and its ceiling. `TestDefaultRegistrations` pins the bootstrap — it fails if `init()` ever stops populating the registry. An empty registry would break every artifact push, so it is worth a test rather than a convention.


