### PR TITLE
ci: Build release image helper binaries

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -186,6 +186,16 @@ jobs:
         if: ${{ contains(fromJSON('["core","jobservice","registryctl","exporter","registry","trivy-adapter"]'), matrix.component) }}
         run: task build:binary:${{ matrix.component }}:${{ env.PLATFORM_PAIR }} GIT_COMMIT="${GITHUB_SHA:0:8}"
 
+      - name: Compile image helper binaries
+        env:
+          COMPONENT: ${{ matrix.component }}
+          PLATFORM_PAIR: ${{ env.PLATFORM_PAIR }}
+        run: |
+          task build:binary:lprobe:${PLATFORM_PAIR}
+          if [ "${COMPONENT}" = "trivy-adapter" ]; then
+            task build:binary:trivy:${PLATFORM_PAIR}
+          fi
+
       - uses: docker/setup-qemu-action@06116385d9baf250c9f4dcb4858b16962ea869c3 # v4.1.0
         if: env.BUILDX_HOST == ''
 


### PR DESCRIPTION
## Summary

Backports the release image helper binary build step into the `release-2.15` Release Please workflow.

The failed `v2.15.4` release jobs compiled the component binaries, then ran Docker builds immediately. The Dockerfiles expect helper binaries in `bin/linux-${TARGETARCH}/`, especially `lprobe`, and `trivy-adapter` also expects `trivy`. Because the inlined release workflow did not build those helpers, Docker failed with missing `bin/linux-amd64/lprobe` / `bin/linux-arm64/lprobe` paths.

This matches the helper step already present in the reusable image workflow used by `main`.

## Validation

- `python` YAML parse for `.github/workflows/release-please.yml`
- `git diff --check`

`actionlint` is not installed in the local environment, so it was not run.
