### PR TITLE
ci: Build images when finalizing release tags

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -90,7 +90,7 @@ jobs:
   build:
     name: "${{ matrix.component }} (${{ matrix.platform }})"
     needs: [release-please]
-    if: ${{ needs.release-please.outputs.release_created == 'true' }}
+    if: ${{ always() && (needs.release-please.outputs.release_created == 'true' || inputs.finalize_tag != '') }}
     strategy:
       fail-fast: false
       matrix:
@@ -105,6 +105,7 @@ jobs:
       REGISTRY_ADDRESS: ${{ vars.REGISTRY_ADDRESS || '8gears.container-registry.com' }}
       REGISTRY_PROJECT: ${{ vars.REGISTRY_PROJECT || '8gcr' }}
       VERSION: ${{ needs.release-please.outputs.version }}
+      TAG_NAME: ${{ needs.release-please.outputs.tag_name || inputs.finalize_tag }}
     steps:
       - name: Prepare
         id: prepare
@@ -122,7 +123,7 @@ jobs:
 
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
-          ref: ${{ needs.release-please.outputs.tag_name }}
+          ref: ${{ needs.release-please.outputs.tag_name || inputs.finalize_tag }}
 
       - name: Install Task
         uses: arduino/setup-task@b91d5d2c96a56797b48ac1e0e89220bf64044611 # v2.0.0
@@ -169,7 +170,9 @@ jobs:
         run: task --taskfile taskfile/release-ready.yml apply-commercial-patches
 
       - name: Load versions
-        run: grep -E '^[A-Z_]+=' versions.env >> "$GITHUB_ENV"
+        run: |
+          grep -E '^[A-Z_]+=' versions.env >> "$GITHUB_ENV"
+          echo "VERSION=${VERSION:-${TAG_NAME#v}}" >> "$GITHUB_ENV"
 
       - name: Setup Go
         if: ${{ contains(fromJSON('["core","jobservice","registryctl","exporter","registry","trivy-adapter"]'), matrix.component) }}
@@ -248,6 +251,7 @@ jobs:
   merge:
     name: "Merge ${{ matrix.component }}"
     needs: [release-please, build]
+    if: ${{ always() && needs.build.result == 'success' && (needs.release-please.outputs.release_created == 'true' || inputs.finalize_tag != '') }}
     strategy:
       matrix:
         component: [core, jobservice, registryctl, exporter, portal, registry, trivy-adapter]
@@ -258,7 +262,7 @@ jobs:
       REGISTRY_ADDRESS: ${{ vars.REGISTRY_ADDRESS || '8gears.container-registry.com' }}
       REGISTRY_PROJECT: ${{ vars.REGISTRY_PROJECT || '8gcr' }}
       VERSION: ${{ needs.release-please.outputs.version }}
-      TAG_NAME: ${{ needs.release-please.outputs.tag_name }}
+      TAG_NAME: ${{ needs.release-please.outputs.tag_name || inputs.finalize_tag }}
       RELEASE_BRANCH: ${{ github.ref_name }}
     steps:
       - name: Prepare BuildKit


### PR DESCRIPTION
## Summary

Allow manual `finalize_tag` runs of the Release Please workflow to build and push release images before signing and updating release notes.

## Root cause

The `finalize_tag` dispatch path skips the `release-please` job by design, then tries to sign `${TAG_NAME}` images. For a manually created release like `v2.15.4`, those images may not exist yet. The run failed while signing `8gears.container-registry.com/8gcr/harbor-core:v2.15.4` because the artifact was not found in the registry.

## Change

- Run the image build matrix when either Release Please creates a release or `finalize_tag` is provided.
- Check out `inputs.finalize_tag` for manual finalization builds.
- Derive `VERSION` from the tag when Release Please outputs are absent.
- Run manifest merge for the finalized tag before the existing sign/release-notes job.

## Validation

- YAML parse for `.github/workflows/release-please.yml`
- `git diff --check`

`actionlint` is not installed locally, so it was not run.
