### PR TITLE
feat(artifact): Recognize standard SPDX and CycloneDX OCI SBOM types

### DIFF
--- a/src/controller/artifact/processor/sbom/sbom.go
+++ b/src/controller/artifact/processor/sbom/sbom.go
@@ -33,14 +33,25 @@ const (
 	ArtifactTypeSBOM = "SBOM"
 	// processorMediaType is the media type for SBOM, it's scope is only used to register the processor
 	processorMediaType = "application/vnd.goharbor.harbor.sbom.v1"
+	// MediaTypeSPDX is the SPDX SBOM media type
+	MediaTypeSPDX = "application/spdx+json"
+	// MediaTypeCycloneDX is the CycloneDX SBOM media type
+	MediaTypeCycloneDX = "application/vnd.cyclonedx+json"
 )
+
+var SupportedMediaTypes = []string{
+	processorMediaType,
+	MediaTypeSPDX,
+	MediaTypeCycloneDX,
+}
 
 func init() {
 	pc := &Processor{}
 	pc.ManifestProcessor = base.NewManifestProcessor()
-	if err := processor.Register(pc, processorMediaType); err != nil {
-		log.Errorf("failed to register processor for media type %s: %v", processorMediaType, err)
-		return
+	for _, mt := range SupportedMediaTypes {
+		if err := processor.Register(pc, mt); err != nil {
+			log.Errorf("failed to register processor for media type %s: %v", mt, err)
+		}
 	}
 }
 
@@ -77,9 +88,17 @@ func (m *Processor) AbstractAddition(_ context.Context, art *artifact.Artifact, 
 	if err != nil {
 		return nil, err
 	}
+	contentType := art.ResolveArtifactType()
+	switch contentType {
+	case MediaTypeSPDX, MediaTypeCycloneDX:
+		// use dynamically resolved type
+	default:
+		contentType = processorMediaType
+	}
+
 	return &processor.Addition{
 		Content:     content,
-		ContentType: processorMediaType,
+		ContentType: contentType,
 	}, nil
 }
 

--- a/src/server/middleware/subject/subject.go
+++ b/src/server/middleware/subject/subject.go
@@ -51,6 +51,10 @@ var (
 
 	// media type of harbor sbom
 	mediaTypeHarborSBOM = "application/vnd.goharbor.harbor.sbom.v1"
+	// media type of spdx sbom
+	mediaTypeSPDX = "application/spdx+json"
+	// media type of cyclonedx sbom
+	mediaTypeCycloneDX = "application/vnd.cyclonedx+json"
 
 	// source of accessory artifact is local, means the accessory is created by harbor itself
 	sourceLocal = "local"
@@ -166,7 +170,7 @@ func Middleware() func(http.Handler) http.Handler {
 				accData.Type = model.TypeNotationSignature
 			case mediaTypeCosignConfig, mediaTypeCosignArtifactType:
 				accData.Type = model.TypeCosignSignature
-			case mediaTypeHarborSBOM:
+			case mediaTypeHarborSBOM, mediaTypeSPDX, mediaTypeCycloneDX:
 				accData.Type = model.TypeHarborSBOM
 			}
 			if subjectArt != nil {


### PR DESCRIPTION
## Summary

This adds support for `application/spdx+json` and `application/vnd.cyclonedx+json` artifact types, allowing Harbor to properly classify industry-standard SBOMs pushed via standard OCI registries (e.g. using `oras attach`) while retaining full backwards compatibility with Harbor's legacy SBOM format.

## Related Issues

Fixes #507

## Type of Change

- [ ] Bug fix (`fix:`)
- [x] New feature (`feat:`)
- [ ] Breaking change (`feat!:` / `fix!:`)
- [ ] Documentation (`docs:`)
- [ ] Refactoring (`refactor:`)
- [ ] CI/CD or build changes (`ci:` / `build:`)
- [ ] Upstream Harbor cherry-pick (`upstream:`)
- [ ] Dependencies update (`chore:`)
- [ ] Tests (`test:`)

## Release Notes

Harbor now natively recognizes standard SPDX (`application/spdx+json`) and CycloneDX (`application/vnd.cyclonedx+json`) OCI SBOM formats. When industry-standard SBOMs are pushed directly to Harbor via standard OCI clients, they will now be properly classified and displayed as SBOM accessories in the UI and API.

## Testing

- [x] Unit tests added/updated
- [x] Manual testing performed

## Checklist

- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] Commits are signed off (`git commit -s`)
- [x] No new warnings introduced