### PR TITLE
fix: Handle scanner outage gracefully during push-triggered scans

### DIFF
--- a/src/controller/event/handler/internal/artifact.go
+++ b/src/controller/event/handler/internal/artifact.go
@@ -308,11 +308,16 @@ func (a *ArtifactEventHandler) onPush(ctx context.Context, event *event.Artifact
 					return
 				}
 
-				if errors.IsErr(err, errors.PreconditionCode) {
+				if errors.IsErr(err, errors.ScannerUnreachableCode) {
 					if attempt < 4 {
-						log.Warningf("%s for artifact %s@%s precondition failed (scanner unreachable). Retrying in 45s (attempt %d/4)...", actionName, event.Artifact.RepositoryName, event.Artifact.Digest, attempt)
-						time.Sleep(45 * time.Second)
-						continue
+						log.Warningf("%s for artifact %s@%s scanner unreachable. Retrying in 45s (attempt %d/4)...", actionName, event.Artifact.RepositoryName, event.Artifact.Digest, attempt)
+						select {
+						case <-ctx.Done():
+							log.Debugf("%s for artifact %s@%s cancelled during retry delay", actionName, event.Artifact.RepositoryName, event.Artifact.Digest)
+							return
+						case <-time.After(45 * time.Second):
+							continue
+						}
 					}
 				}
 

--- a/src/controller/event/handler/internal/artifact.go
+++ b/src/controller/event/handler/internal/artifact.go
@@ -31,6 +31,7 @@ import (
 	"github.com/goharbor/harbor/src/controller/tag"
 	"github.com/goharbor/harbor/src/jobservice/job"
 	"github.com/goharbor/harbor/src/lib/config"
+	"github.com/goharbor/harbor/src/lib/errors"
 	"github.com/goharbor/harbor/src/lib/log"
 	"github.com/goharbor/harbor/src/lib/orm"
 	"github.com/goharbor/harbor/src/lib/q"
@@ -295,14 +296,39 @@ func (a *ArtifactEventHandler) onPush(ctx context.Context, event *event.Artifact
 			ctx = context.WithValue(ctx, operator.ContextKey{}, event.Operator)
 		}
 
-		if err := autoScan(ctx, &artifact.Artifact{Artifact: *event.Artifact}, event.Tags...); err != nil {
-			log.Errorf("scan artifact %s@%s failed, error: %v", event.Artifact.RepositoryName, event.Artifact.Digest, err)
+		executeWithRetry := func(actionName string, action func() error) {
+			for attempt := 1; attempt <= 4; attempt++ {
+				err := action()
+				if err == nil {
+					return
+				}
+
+				if errors.IsConflictErr(err) {
+					log.Debugf("%s for artifact %s@%s failed (conflict): %v", actionName, event.Artifact.RepositoryName, event.Artifact.Digest, err)
+					return
+				}
+
+				if errors.IsErr(err, errors.PreconditionCode) {
+					if attempt < 4 {
+						log.Warningf("%s for artifact %s@%s precondition failed (scanner unreachable). Retrying in 45s (attempt %d/4)...", actionName, event.Artifact.RepositoryName, event.Artifact.Digest, attempt)
+						time.Sleep(45 * time.Second)
+						continue
+					}
+				}
+
+				log.Errorf("%s for artifact %s@%s failed, error: %v", actionName, event.Artifact.RepositoryName, event.Artifact.Digest, err)
+				return
+			}
 		}
 
+		executeWithRetry("scan artifact", func() error {
+			return autoScan(ctx, &artifact.Artifact{Artifact: *event.Artifact}, event.Tags...)
+		})
+
 		log.Debugf("auto generate sbom is triggered for artifact event %+v", event)
-		if err := autoGenSBOM(ctx, &artifact.Artifact{Artifact: *event.Artifact}); err != nil {
-			log.Errorf("generate sbom for artifact %s@%s failed, error: %v", event.Artifact.RepositoryName, event.Artifact.Digest, err)
-		}
+		executeWithRetry("generate sbom", func() error {
+			return autoGenSBOM(ctx, &artifact.Artifact{Artifact: *event.Artifact})
+		})
 	}()
 
 	return nil

--- a/src/controller/scan/base_controller.go
+++ b/src/controller/scan/base_controller.go
@@ -261,6 +261,10 @@ func (bc *basicController) Scan(ctx context.Context, artifact *ar.Artifact, opti
 		return errors.Wrap(err, "scan controller: scan")
 	}
 
+	if r.Metadata == nil {
+		return errors.PreconditionFailedError(nil).WithMessagef("scanner %s is unreachable (metadata ping failed)", r.Name)
+	}
+
 	if !scannable {
 		if opts.FromEvent {
 			// skip to return err for event related scan

--- a/src/controller/scan/base_controller.go
+++ b/src/controller/scan/base_controller.go
@@ -262,7 +262,7 @@ func (bc *basicController) Scan(ctx context.Context, artifact *ar.Artifact, opti
 	}
 
 	if r.Metadata == nil {
-		return errors.PreconditionFailedError(nil).WithMessagef("scanner %s is unreachable (metadata ping failed)", r.Name)
+		return errors.ScannerUnreachableError(nil).WithMessagef("scanner %s is unreachable (metadata ping failed)", r.Name)
 	}
 
 	if !scannable {

--- a/src/controller/scanner/base_controller.go
+++ b/src/controller/scanner/base_controller.go
@@ -369,8 +369,7 @@ func (bc *basicController) getScannerAdapterMetadataWithCache(ctx context.Contex
 	err := cache.FetchOrSave(ctx, bc.Cache(), key, &result, func() (any, error) {
 		meta, err := bc.getScannerAdapterMetadata(registration)
 		if err != nil {
-			// nolint:nilerr // Error is captured in MetadataResult.Error for caching, not returned to caller
-			return &MetadataResult{Error: err.Error()}, nil
+			return nil, err
 		}
 
 		return &MetadataResult{Metadata: meta}, nil

--- a/src/lib/errors/const.go
+++ b/src/lib/errors/const.go
@@ -31,6 +31,8 @@ const (
 	RateLimitCode = "TOO_MANY_REQUEST"
 	// PreconditionCode ...
 	PreconditionCode = "PRECONDITION"
+	// ScannerUnreachableCode is error code for when the scanner adapter metadata ping fails
+	ScannerUnreachableCode = "SCANNER_UNREACHABLE"
 	// GeneralCode ...
 	GeneralCode = "UNKNOWN"
 	// ChallengesUnsupportedCode ...
@@ -89,6 +91,11 @@ func MethodNotAllowedError(err error) *Error {
 // PreconditionFailedError is error for the case of precondition failed
 func PreconditionFailedError(err error) *Error {
 	return New("precondition failed").WithCode(PreconditionCode).WithCause(err)
+}
+
+// ScannerUnreachableError is error for when the scanner adapter is unreachable
+func ScannerUnreachableError(err error) *Error {
+	return New("scanner unreachable").WithCode(ScannerUnreachableCode).WithCause(err)
 }
 
 // UnknownError ...


### PR DESCRIPTION
## Summary

This PR addresses the issues raised in #460 where transient scanner adapter outages (like a Trivy redeploy) cause push-triggered scans to fail silently and spam the logs with misleading errors.

Changes made:
- Added a `PreconditionFailedError` when the scanner adapter metadata ping fails. This stops the controller from throwing a misleading "unsupported MIME type" error.
- Updated the metadata cache logic so we no longer cache ping failures. This lets the scanner recover immediately when it comes back online instead of waiting out a 30s cache penalty.
- Wrapped the push-triggered `autoScan` and `autoGenSBOM` events in a simple retry loop (4 attempts, 45s interval) to handle temporary adapter downtime.
- Cleaned up the logs by demoting the benign `ConflictError` to `DEBUG` during multi-arch pushes.

## Related Issues

Fixes #460

## Type of Change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` / `fix!:`)
- [ ] Documentation (`docs:`)
- [ ] Refactoring (`refactor:`)
- [ ] CI/CD or build changes (`ci:` / `build:`)
- [ ] Upstream Harbor cherry-pick (`upstream:`)
- [ ] Dependencies update (`chore:`)
- [ ] Tests (`test:`)

## Release Notes

<!-- Leave blank -->

## Testing

- [x] Unit tests added/updated
- [x] Manual testing performed

## Checklist

- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] Commits are signed off (`git commit -s`)
- [x] No new warnings introduced