### PR TITLE
fix: Inherit release note workflow permissions

### DIFF
--- a/.github/workflows/release-notes.yml
+++ b/.github/workflows/release-notes.yml
@@ -31,10 +31,6 @@ on:
         default: false
         type: boolean
 
-permissions:
-  contents: write
-  pull-requests: write
-
 concurrency:
   group: release-notes-${{ inputs.tag_name || github.ref_name }}
   cancel-in-progress: false


### PR DESCRIPTION
Allows the reusable release-notes workflow to inherit the caller permissions: release-PR previews receive pull-request write access, while post-tag release updates retain contents-only access.