### PR TITLE
fix: Deduplicate upstream release notes

### DIFF
--- a/.github/scripts/format-release-notes.mjs
+++ b/.github/scripts/format-release-notes.mjs
@@ -233,11 +233,20 @@ for (const line of releaseNotesLines(releaseBody)) {
 
 const output = ['## What\'s Changed'];
 const emittedSections = new Set();
+const upstreamCommitShas = new Set(
+  sections.get('Upstream')
+    .map(commitShaFromEntry)
+    .filter(Boolean),
+);
 const emittedCommitShas = new Set();
 
 for (const section of sectionOrder) {
   const entries = (sections.get(section) ?? []).filter(entry => {
     const sha = commitShaFromEntry(entry);
+    if (section !== 'Upstream' && upstreamCommitShas.has(sha)) {
+      return false;
+    }
+
     if (!sha || emittedCommitShas.has(sha)) {
       return !sha;
     }
@@ -245,12 +254,12 @@ for (const section of sectionOrder) {
     emittedCommitShas.add(sha);
     return true;
   });
+  emittedSections.add(section);
   if (entries.length === 0) {
     continue;
   }
 
   output.push('', `### ${section}`, '', ...entries);
-  emittedSections.add(section);
 }
 
 for (const [section, entries] of sections) {

--- a/.github/scripts/format-release-notes.mjs
+++ b/.github/scripts/format-release-notes.mjs
@@ -79,8 +79,9 @@ function normalizeAuthor(value) {
 function parseUpstreamMetadata(message) {
   const pr = normalizeUpstreamPr(message.match(/^Upstream-PR:\s*(.+)$/im)?.[1]);
   const author = normalizeAuthor(message.match(/^Upstream-Author:\s*(.+)$/im)?.[1]);
+  const isUpstream = /^upstream(?:\([^)]*\))?!?:/im.test(message);
 
-  if (!pr && !author) {
+  if (!isUpstream && !pr && !author) {
     return undefined;
   }
 
@@ -205,7 +206,10 @@ for (const line of releaseNotesLines(releaseBody)) {
 
   if (line.startsWith('* ') || line.startsWith('- ')) {
     let entry = formatEntry(line);
-    const targetSection = entry.toLowerCase().includes('[upstream]') || currentSection === 'Upstream' ? 'Upstream' : currentSection;
+    const metadata = metadataForCommit(commitShaFromEntry(entry));
+    const targetSection = metadata || entry.toLowerCase().includes('[upstream]') || currentSection === 'Upstream'
+      ? 'Upstream'
+      : currentSection;
 
     if (targetSection === 'Upstream') {
       entry = formatUpstreamEntry(entry, commitShaFromEntry(entry));
@@ -229,16 +233,18 @@ for (const line of releaseNotesLines(releaseBody)) {
 
 const output = ['## What\'s Changed'];
 const emittedSections = new Set();
-const upstreamCommitShas = new Set(
-  sections.get('Upstream')
-    .map(commitShaFromEntry)
-    .filter(Boolean),
-);
+const emittedCommitShas = new Set();
 
 for (const section of sectionOrder) {
-  const entries = (sections.get(section) ?? []).filter(entry =>
-    section === 'Upstream' || !upstreamCommitShas.has(commitShaFromEntry(entry)),
-  );
+  const entries = (sections.get(section) ?? []).filter(entry => {
+    const sha = commitShaFromEntry(entry);
+    if (!sha || emittedCommitShas.has(sha)) {
+      return !sha;
+    }
+
+    emittedCommitShas.add(sha);
+    return true;
+  });
   if (entries.length === 0) {
     continue;
   }

--- a/.github/scripts/format-release-notes.mjs
+++ b/.github/scripts/format-release-notes.mjs
@@ -229,9 +229,16 @@ for (const line of releaseNotesLines(releaseBody)) {
 
 const output = ['## What\'s Changed'];
 const emittedSections = new Set();
+const upstreamCommitShas = new Set(
+  sections.get('Upstream')
+    .map(commitShaFromEntry)
+    .filter(Boolean),
+);
 
 for (const section of sectionOrder) {
-  const entries = sections.get(section) ?? [];
+  const entries = (sections.get(section) ?? []).filter(entry =>
+    section === 'Upstream' || !upstreamCommitShas.has(commitShaFromEntry(entry)),
+  );
   if (entries.length === 0) {
     continue;
   }


### PR DESCRIPTION
When the same commit is present in both a regular changelog section and `Upstream`, retain only the upstream entry so it keeps its upstream attribution.