### PR TITLE
fix: Keep Release PR Preview In Sync

### DIFF
--- a/.github/scripts/update-release-notes.sh
+++ b/.github/scripts/update-release-notes.sh
@@ -2,6 +2,12 @@
 set -euo pipefail
 
 : "${GH_TOKEN:?GH_TOKEN is required}"
+
+preview_pr_number="${RELEASE_NOTES_PREVIEW_PR_NUMBER:-}"
+if [[ -n "${preview_pr_number}" && ! "${TAG_NAME:-}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+  preview_version=$(node -e "const manifest = require('./.release-please-manifest.json'); const version = manifest['.']; if (!version) { throw new Error('missing root release version'); } console.log(version);")
+  TAG_NAME="v${preview_version}"
+fi
 : "${TAG_NAME:?TAG_NAME is required}"
 
 PATCHES_TOKEN="${PATCHES_TOKEN:-${GH_TOKEN}}"
@@ -22,7 +28,6 @@ registry_project="${REGISTRY_PROJECT:-8gcr}"
 registry="${registry_address}/${registry_project}"
 dry_run="${RELEASE_NOTES_DRY_RUN:-false}"
 release_notes_output="${RELEASE_NOTES_OUTPUT:-}"
-preview_pr_number="${RELEASE_NOTES_PREVIEW_PR_NUMBER:-}"
 images=(core jobservice registryctl exporter portal registry trivy-adapter)
 
 tmp_dir=$(mktemp -d)
@@ -38,13 +43,13 @@ node .github/scripts/extract-changelog-release.mjs \
   "${version}" \
   "${tmp_dir}/release-source.md"
 
+generated_notes_args=(-f "tag_name=${TAG_NAME}")
 if [[ -n "${preview_pr_number}" ]]; then
-  : > "${tmp_dir}/generated-notes.md"
-else
-  gh api "repos/${GITHUB_REPOSITORY}/releases/generate-notes" \
-    -f "tag_name=${TAG_NAME}" \
-    --jq .body > "${tmp_dir}/generated-notes.md"
+  generated_notes_args+=(-f "target_commitish=$(git rev-parse HEAD)")
 fi
+gh api "repos/${GITHUB_REPOSITORY}/releases/generate-notes" \
+  "${generated_notes_args[@]}" \
+  --jq .body > "${tmp_dir}/generated-notes.md"
 
 node .github/scripts/format-release-notes.mjs \
   "${tmp_dir}/release-source.md" \
@@ -143,6 +148,7 @@ if [[ -n "${preview_pr_number}" ]]; then
   gh pr edit "${preview_pr_number}" \
     --repo "${GITHUB_REPOSITORY}" \
     --body-file "${tmp_dir}/release-pr-body-with-preview.md"
+  exit 0
 elif [[ "${dry_run}" == "true" ]]; then
   if [[ -n "${release_notes_output}" ]]; then
     cp "${tmp_dir}/release-notes.md" "${release_notes_output}"


### PR DESCRIPTION
## Summary

- retain automatic release-note previews in Release Please PR descriptions
- derive the preview version from `.release-please-manifest.json` when Release Please returns an empty version output
- use GitHub generated notes for both preview and published release rendering
- stop preview mode after updating the PR instead of editing a release that does not exist yet

## Verification

- reproduced the original `TAG_NAME=v` input against release PR #268
- `task release-notes` derived `v2.16.0`, updated the PR, and exited successfully
- verified exactly one preview section, New Contributors, and plain commercial-feature bullets
- `bash -n .github/scripts/update-release-notes.sh`
- `go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.7 .github/workflows/release-please.yml .github/workflows/release-notes.yml`
- `git diff --check`