### PR TITLE
fix: Grant Manual Release Notes Write Access

### DIFF
--- a/.github/workflows/release-notes-engine.yml
+++ b/.github/workflows/release-notes-engine.yml
@@ -1,0 +1,101 @@
+name: Release Notes Engine
+
+on:
+  workflow_call:
+    inputs:
+      tag_name:
+        description: Existing release tag to update
+        required: true
+        type: string
+      checkout_ref:
+        description: Ref containing the changelog to render
+        required: false
+        type: string
+      preview_pr_number:
+        description: Release PR number to update with a visible preview
+        required: false
+        type: string
+      dry_run:
+        description: Generate the notes without updating the release
+        required: false
+        default: false
+        type: boolean
+    secrets:
+      SYNC_APP_PRIVATE_KEY:
+        description: Private key for reading commercial patch metadata
+        required: true
+concurrency:
+  group: release-notes-${{ inputs.tag_name || github.ref_name }}
+  cancel-in-progress: false
+
+jobs:
+  update:
+    name: Recreate ${{ inputs.tag_name || github.ref_name }} Release Notes
+    runs-on: ${{ vars.RUNNER || 'ubuntu-latest' }}
+    timeout-minutes: 15
+    env:
+      GH_TOKEN: ${{ github.token }}
+      GITHUB_REPOSITORY: ${{ github.repository }}
+      REGISTRY_ADDRESS: ${{ vars.REGISTRY_ADDRESS || '8gears.container-registry.com' }}
+      REGISTRY_PROJECT: ${{ vars.REGISTRY_PROJECT || '8gcr' }}
+      RELEASE_NOTES_DRY_RUN: ${{ inputs.dry_run || false }}
+      TAG_NAME: ${{ inputs.tag_name || github.ref_name }}
+      RELEASE_NOTES_PREVIEW_PR_NUMBER: ${{ inputs.preview_pr_number }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ inputs.checkout_ref || github.ref }}
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Setup Node
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: 24
+          package-manager-cache: false
+
+      - uses: ./.github/actions/setup-go-cached
+        with:
+          go-version-file: src/go.mod
+          go-sum-path: src/go.sum
+
+      - uses: ./.github/actions/setup-task
+
+      - name: Install gh CLI
+        run: |
+          case "$(uname -m)" in
+            x86_64|amd64) arch="amd64" ;;
+            aarch64|arm64) arch="arm64" ;;
+            *) echo "Unsupported architecture for gh: $(uname -m)" >&2; exit 1 ;;
+          esac
+
+          version=$(awk -F= '$1 == "GH_CLI_VERSION" { print $2 }' versions.env)
+          if ! [[ "${version}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "GH_CLI_VERSION must be X.Y.Z" >&2
+            exit 1
+          fi
+
+          archive="gh_${version}_linux_${arch}.tar.gz"
+          tool_dir="${RUNNER_TEMP}/gh-cli"
+          mkdir -p "${tool_dir}/bin"
+          curl -fsSL "https://github.com/cli/cli/releases/download/v${version}/${archive}" -o "${tool_dir}/${archive}"
+          curl -fsSL "https://github.com/cli/cli/releases/download/v${version}/gh_${version}_checksums.txt" -o "${tool_dir}/gh_checksums.txt"
+          (cd "${tool_dir}" && grep "  ${archive}$" gh_checksums.txt | sha256sum -c -)
+          tar -xzf "${tool_dir}/${archive}" -C "${tool_dir}"
+          install -m 0755 "${tool_dir}/gh_${version}_linux_${arch}/bin/gh" "${tool_dir}/bin/gh"
+          echo "${tool_dir}/bin" >> "${GITHUB_PATH}"
+
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          app-id: ${{ vars.SYNC_APP_ID }}
+          private-key: ${{ secrets.SYNC_APP_PRIVATE_KEY }}
+          owner: container-registry
+          repositories: 8gcr
+          permission-contents: read
+
+      - name: Recreate release notes
+        env:
+          PATCHES_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: task release-notes

--- a/.github/workflows/release-notes.yml
+++ b/.github/workflows/release-notes.yml
@@ -1,24 +1,6 @@
 name: Recreate Release Notes
 
 on:
-  workflow_call:
-    inputs:
-      tag_name:
-        description: Existing release tag to update
-        required: true
-        type: string
-      checkout_ref:
-        description: Ref containing the changelog to render
-        required: false
-        type: string
-      preview_pr_number:
-        description: Release PR number to update with a visible preview
-        required: false
-        type: string
-    secrets:
-      SYNC_APP_PRIVATE_KEY:
-        description: Private key for reading commercial patch metadata
-        required: true
   workflow_dispatch:
     inputs:
       tag_name:
@@ -31,78 +13,13 @@ on:
         default: false
         type: boolean
 
-concurrency:
-  group: release-notes-${{ inputs.tag_name || github.ref_name }}
-  cancel-in-progress: false
-
 jobs:
-  update:
-    name: Recreate ${{ inputs.tag_name || github.ref_name }} Release Notes
-    runs-on: ${{ vars.RUNNER || 'ubuntu-latest' }}
-    timeout-minutes: 15
-    env:
-      GH_TOKEN: ${{ github.token }}
-      GITHUB_REPOSITORY: ${{ github.repository }}
-      REGISTRY_ADDRESS: ${{ vars.REGISTRY_ADDRESS || '8gears.container-registry.com' }}
-      REGISTRY_PROJECT: ${{ vars.REGISTRY_PROJECT || '8gcr' }}
-      RELEASE_NOTES_DRY_RUN: ${{ inputs.dry_run || false }}
-      TAG_NAME: ${{ inputs.tag_name || github.ref_name }}
-      RELEASE_NOTES_PREVIEW_PR_NUMBER: ${{ inputs.preview_pr_number }}
-    steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          ref: ${{ inputs.checkout_ref || github.ref }}
-          fetch-depth: 0
-          persist-credentials: false
-
-      - name: Setup Node
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
-        with:
-          node-version: 24
-          package-manager-cache: false
-
-      - uses: ./.github/actions/setup-go-cached
-        with:
-          go-version-file: src/go.mod
-          go-sum-path: src/go.sum
-
-      - uses: ./.github/actions/setup-task
-
-      - name: Install gh CLI
-        run: |
-          case "$(uname -m)" in
-            x86_64|amd64) arch="amd64" ;;
-            aarch64|arm64) arch="arm64" ;;
-            *) echo "Unsupported architecture for gh: $(uname -m)" >&2; exit 1 ;;
-          esac
-
-          version=$(awk -F= '$1 == "GH_CLI_VERSION" { print $2 }' versions.env)
-          if ! [[ "${version}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-            echo "GH_CLI_VERSION must be X.Y.Z" >&2
-            exit 1
-          fi
-
-          archive="gh_${version}_linux_${arch}.tar.gz"
-          tool_dir="${RUNNER_TEMP}/gh-cli"
-          mkdir -p "${tool_dir}/bin"
-          curl -fsSL "https://github.com/cli/cli/releases/download/v${version}/${archive}" -o "${tool_dir}/${archive}"
-          curl -fsSL "https://github.com/cli/cli/releases/download/v${version}/gh_${version}_checksums.txt" -o "${tool_dir}/gh_checksums.txt"
-          (cd "${tool_dir}" && grep "  ${archive}$" gh_checksums.txt | sha256sum -c -)
-          tar -xzf "${tool_dir}/${archive}" -C "${tool_dir}"
-          install -m 0755 "${tool_dir}/gh_${version}_linux_${arch}/bin/gh" "${tool_dir}/bin/gh"
-          echo "${tool_dir}/bin" >> "${GITHUB_PATH}"
-
-      - name: Generate GitHub App token
-        id: app-token
-        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
-        with:
-          app-id: ${{ vars.SYNC_APP_ID }}
-          private-key: ${{ secrets.SYNC_APP_PRIVATE_KEY }}
-          owner: container-registry
-          repositories: 8gcr
-          permission-contents: read
-
-      - name: Recreate release notes
-        env:
-          PATCHES_TOKEN: ${{ steps.app-token.outputs.token }}
-        run: task release-notes
+  recreate:
+    permissions:
+      contents: write
+    uses: ./.github/workflows/release-notes-engine.yml
+    with:
+      tag_name: ${{ inputs.tag_name || github.ref_name }}
+      dry_run: ${{ inputs.dry_run }}
+    secrets:
+      SYNC_APP_PRIVATE_KEY: ${{ secrets.SYNC_APP_PRIVATE_KEY }}

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -110,7 +110,7 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
-    uses: ./.github/workflows/release-notes.yml
+    uses: ./.github/workflows/release-notes-engine.yml
     with:
       tag_name: v${{ needs.release-please.outputs.version }}
       checkout_ref: ${{ fromJSON(needs.release-please.outputs.prs)[0].headBranchName }}
@@ -204,7 +204,7 @@ jobs:
     if: ${{ needs.release-please.outputs.release_created == 'true' }}
     permissions:
       contents: write
-    uses: ./.github/workflows/release-notes.yml
+    uses: ./.github/workflows/release-notes-engine.yml
     with:
       tag_name: ${{ needs.release-please.outputs.tag_name }}
     secrets:


### PR DESCRIPTION
## Summary

- preserve `release-notes.yml` as the user-facing manual workflow
- move shared execution into a reusable release-note engine
- grant manual recreation `contents: write` without forcing preview-only PR permissions on post-tag callers

## Root Cause

Manual run 30884894607 inherited the repository read-only token and `POST /releases/generate-notes` failed with HTTP 403.

## Verification

- [full manual recreation 30887937001](https://github.com/container-registry/harbor-next/actions/runs/30887937001) successfully updated the real `v2.15.4` release from this PR branch
- [manual dry run 30886756001](https://github.com/container-registry/harbor-next/actions/runs/30886756001) completed successfully
- verified the published release has upstream-only classification, plain commercial bullets, and no duplicate commit links
- the automatic preview job succeeded in run 30884254653
- `go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.7 .github/workflows/release-notes.yml .github/workflows/release-notes-engine.yml .github/workflows/release-please.yml`
- `git diff --check`