### PR TITLE
chore: Render Cosign Command as Code Block

### DIFF
--- a/.github/scripts/update-release-notes.sh
+++ b/.github/scripts/update-release-notes.sh
@@ -124,12 +124,12 @@ fi
 
   echo
   echo "**Verify an image signature:**"
-  echo '\`\`\`sh'
+  echo '```sh'
   echo "cosign verify \\"
   echo "  --certificate-identity \"https://github.com/${GITHUB_REPOSITORY}/.github/workflows/publish-images.yml@refs/heads/${release_branch}\" \\"
-  echo '  --certificate-oidc-issuer "https://token.actions.githubusercontent.com" \\'
+  echo '  --certificate-oidc-issuer "https://token.actions.githubusercontent.com" \'
   echo "  ${registry}/harbor-core:${TAG_NAME}"
-  echo '\`\`\`'
+  echo '```'
 
   if [[ -s "${tmp_dir}/contributors.md" ]]; then
     echo


### PR DESCRIPTION
## Summary

- emit real Markdown code fences for the image signature command
- emit a single continuation backslash for the OIDC issuer line

## Testing

- `bash -n .github/scripts/update-release-notes.sh`
- `git diff --check`
- `GH_TOKEN="$(gh auth token)" TAG_NAME=v2.15.4 RELEASE_NOTES_OUTPUT=/tmp/release-notes-v2.15.4-clean-fence.md task release-notes:preview`