### PR TITLE
fix(db): Honour an explicitly configured min_conns of 0

### DIFF
--- a/src/cmd/exporter/main.go
+++ b/src/cmd/exporter/main.go
@@ -55,7 +55,7 @@ func main() {
 			ConnMaxIdleTime:   getConnMaxIdleTime(viper.GetString("database.conn_max_idle_time")),
 			HealthCheckPeriod: viper.GetDuration("database.health_check_period"),
 			ConnectTimeout:    viper.GetDuration("database.connect_timeout"),
-			MinConns:          int32(viper.GetInt("database.min_conns")),
+			MinConns:          getMinConns(),
 		},
 	}
 	if err := dao.InitDatabase(dbCfg); err != nil {
@@ -123,6 +123,17 @@ func main() {
 
 	dao.ClosePool()
 	os.Exit(exitCode)
+}
+
+// getMinConns returns nil unless HARBOR_DATABASE_MIN_CONNS is set to a
+// non-empty value, so dbpool can tell an explicit 0 (no warm floor) from an
+// unset knob. viper.GetInt collapses both to 0; IsSet does not.
+func getMinConns() *int32 {
+	if !viper.IsSet("database.min_conns") {
+		return nil
+	}
+	v := int32(viper.GetInt("database.min_conns"))
+	return &v
 }
 
 func getConnMaxLifetime(duration string) time.Duration {

--- a/src/cmd/exporter/main.go
+++ b/src/cmd/exporter/main.go
@@ -15,6 +15,7 @@
 package main
 
 import (
+	"math"
 	"net/http"
 	"os"
 	"os/signal"
@@ -132,8 +133,15 @@ func getMinConns() *int32 {
 	if !viper.IsSet("database.min_conns") {
 		return nil
 	}
-	v := int32(viper.GetInt("database.min_conns"))
-	return &v
+	v := viper.GetInt("database.min_conns")
+	// viper parses the full int range; a bare int32() would wrap — 1<<32
+	// becomes an explicit 0. Treat out-of-range as unset instead.
+	if v < math.MinInt32 || v > math.MaxInt32 {
+		log.Warningf("database.min_conns %d exceeds int32 range, using the pool default", v)
+		return nil
+	}
+	i := int32(v)
+	return &i
 }
 
 func getConnMaxLifetime(duration string) time.Duration {

--- a/src/cmd/exporter/main_test.go
+++ b/src/cmd/exporter/main_test.go
@@ -15,6 +15,7 @@
 package main
 
 import (
+	"os"
 	"strings"
 	"testing"
 
@@ -36,6 +37,10 @@ func TestGetMinConns(t *testing.T) {
 		{name: "empty reads as unset", set: true, env: "", want: nil},
 		{name: "explicit zero is honoured", set: true, env: "0", want: ptr(0)},
 		{name: "explicit value is honoured", set: true, env: "5", want: ptr(5)},
+		// A bare int32() would wrap 1<<32 to an explicit 0 — the opposite of
+		// the configured intent. Out-of-range reads as unset instead.
+		{name: "value above int32 range reads as unset", set: true, env: "4294967296", want: nil},
+		{name: "value below int32 range reads as unset", set: true, env: "-4294967296", want: nil},
 	}
 
 	for _, tt := range tests {
@@ -45,8 +50,11 @@ func TestGetMinConns(t *testing.T) {
 			viper.AutomaticEnv()
 			viper.SetEnvKeyReplacer(strings.NewReplacer(".", "_"))
 
-			if tt.set {
-				t.Setenv("HARBOR_DATABASE_MIN_CONNS", tt.env)
+			// t.Setenv registers restoration of the pre-test value; the unset
+			// case then removes the variable so ambient CI env cannot leak in.
+			t.Setenv("HARBOR_DATABASE_MIN_CONNS", tt.env)
+			if !tt.set {
+				require.NoError(t, os.Unsetenv("HARBOR_DATABASE_MIN_CONNS"))
 			}
 
 			got := getMinConns()

--- a/src/cmd/exporter/main_test.go
+++ b/src/cmd/exporter/main_test.go
@@ -1,0 +1,63 @@
+// Copyright Project Harbor Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/spf13/viper"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// getMinConns must distinguish an unset knob from an explicit 0, which is a
+// valid pgxpool setting (no warm floor). See harbor-next#564.
+func TestGetMinConns(t *testing.T) {
+	tests := []struct {
+		name string
+		env  string // "" means the variable is not set at all
+		set  bool
+		want *int32
+	}{
+		{name: "unset falls back to the dbpool default", set: false, want: nil},
+		{name: "empty reads as unset", set: true, env: "", want: nil},
+		{name: "explicit zero is honoured", set: true, env: "0", want: ptr(0)},
+		{name: "explicit value is honoured", set: true, env: "5", want: ptr(5)},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			viper.Reset()
+			viper.SetEnvPrefix("harbor")
+			viper.AutomaticEnv()
+			viper.SetEnvKeyReplacer(strings.NewReplacer(".", "_"))
+
+			if tt.set {
+				t.Setenv("HARBOR_DATABASE_MIN_CONNS", tt.env)
+			}
+
+			got := getMinConns()
+			if tt.want == nil {
+				assert.Nil(t, got)
+				return
+			}
+			require.NotNil(t, got)
+			assert.Equal(t, *tt.want, *got)
+		})
+	}
+}
+
+func ptr(v int32) *int32 { return &v }

--- a/src/common/models/database.go
+++ b/src/common/models/database.go
@@ -37,6 +37,6 @@ type PostGreSQL struct {
 	ConnMaxIdleTime   time.Duration `json:"conn_max_idle_time"`
 	HealthCheckPeriod time.Duration `json:"health_check_period"`
 	ConnectTimeout    time.Duration `json:"connect_timeout"`
-	MinConns          int32         `json:"min_conns"`
+	MinConns          *int32        `json:"min_conns,omitempty"` // nil = unset (dbpool.DefaultMinConns); 0 is a valid setting
 	URL               string        `json:"url"`
 }

--- a/src/lib/config/metadata/value.go
+++ b/src/lib/config/metadata/value.go
@@ -16,6 +16,7 @@ package metadata
 
 import (
 	"errors"
+	"math"
 	"time"
 
 	"github.com/goharbor/harbor/src/lib/log"
@@ -88,8 +89,16 @@ func (c *ConfigureValue) GetOptionalInt32() *int32 {
 	if _, ok := Instance().GetByName(c.Name); !ok {
 		return nil
 	}
-	v := int32(c.GetInt())
-	return &v
+	v := c.GetInt()
+	// parseInt's float fallback admits values beyond int32 (e.g. "4294967296"),
+	// which a bare int32() would wrap — 1<<32 becomes an explicit 0. Treat
+	// out-of-range as unset rather than smuggle a wrapped value downstream.
+	if v < math.MinInt32 || v > math.MaxInt32 {
+		log.Errorf("GetOptionalInt32 failed: value %d of %s exceeds int32 range, treating as unset", v, c.Name)
+		return nil
+	}
+	i := int32(v)
+	return &i
 }
 
 // GetInt64 - return the int64 value of current value

--- a/src/lib/config/metadata/value.go
+++ b/src/lib/config/metadata/value.go
@@ -80,6 +80,18 @@ func (c *ConfigureValue) GetInt() int {
 	return 0
 }
 
+// GetOptionalInt32 - return the int32 value of current value, or nil when the
+// value carries no metadata. CfgManager.Get hands back an empty ConfigureValue
+// for an unknown key, which GetInt reports as 0 — indistinguishable from a
+// configured 0. Callers that treat 0 as a meaningful setting use this instead.
+func (c *ConfigureValue) GetOptionalInt32() *int32 {
+	if _, ok := Instance().GetByName(c.Name); !ok {
+		return nil
+	}
+	v := int32(c.GetInt())
+	return &v
+}
+
 // GetInt64 - return the int64 value of current value
 func (c *ConfigureValue) GetInt64() int64 {
 	if item, ok := Instance().GetByName(c.Name); ok {

--- a/src/lib/config/metadata/value_test.go
+++ b/src/lib/config/metadata/value_test.go
@@ -73,6 +73,11 @@ func TestConfigureValue_GetInt(t *testing.T) {
 }
 
 func TestConfigureValue_GetOptionalInt32(t *testing.T) {
+	// Neighbouring tests swap the global metadata for testingMetaDataArray,
+	// which lacks postgresql_min_conns — pin the real ConfigList so this test
+	// does not depend on execution order.
+	Instance().init()
+
 	// A configured 0 must come back as a non-nil 0, not collapse into "unset".
 	zero := createCfgValue("postgresql_min_conns", "0").GetOptionalInt32()
 	require.NotNil(t, zero)
@@ -84,6 +89,11 @@ func TestConfigureValue_GetOptionalInt32(t *testing.T) {
 
 	// CfgManager.Get hands back a bare ConfigureValue for an unknown key.
 	assert.Nil(t, (&ConfigureValue{}).GetOptionalInt32())
+
+	// parseInt's float fallback admits values beyond int32; a bare int32()
+	// would wrap 1<<32 to an explicit 0. Out-of-range reads as unset.
+	assert.Nil(t, createCfgValue("postgresql_min_conns", "4294967296").GetOptionalInt32())
+	assert.Nil(t, createCfgValue("postgresql_min_conns", "-4294967296").GetOptionalInt32())
 }
 
 func TestConfigureValue_GetInt64(t *testing.T) {

--- a/src/lib/config/metadata/value_test.go
+++ b/src/lib/config/metadata/value_test.go
@@ -20,6 +20,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 var testingMetaDataArray = []Item{
@@ -69,6 +70,20 @@ func TestConfigureValue_GetDuration(t *testing.T) {
 
 func TestConfigureValue_GetInt(t *testing.T) {
 	assert.Equal(t, createCfgValue("ldap_timeout", "5").GetInt(), 5)
+}
+
+func TestConfigureValue_GetOptionalInt32(t *testing.T) {
+	// A configured 0 must come back as a non-nil 0, not collapse into "unset".
+	zero := createCfgValue("postgresql_min_conns", "0").GetOptionalInt32()
+	require.NotNil(t, zero)
+	assert.Equal(t, int32(0), *zero)
+
+	five := createCfgValue("postgresql_min_conns", "5").GetOptionalInt32()
+	require.NotNil(t, five)
+	assert.Equal(t, int32(5), *five)
+
+	// CfgManager.Get hands back a bare ConfigureValue for an unknown key.
+	assert.Nil(t, (&ConfigureValue{}).GetOptionalInt32())
 }
 
 func TestConfigureValue_GetInt64(t *testing.T) {

--- a/src/lib/config/systemconfig.go
+++ b/src/lib/config/systemconfig.go
@@ -342,7 +342,7 @@ func Database() (*models.Database, error) {
 		ConnMaxIdleTime:   DefaultMgr().Get(backgroundCtx, common.PostGreSQLConnMaxIdleTime).GetDuration(),
 		HealthCheckPeriod: DefaultMgr().Get(backgroundCtx, common.PostGreSQLHealthCheckPeriod).GetDuration(),
 		ConnectTimeout:    DefaultMgr().Get(backgroundCtx, common.PostGreSQLConnectTimeout).GetDuration(),
-		MinConns:          int32(DefaultMgr().Get(backgroundCtx, common.PostGreSQLMinConns).GetInt()),
+		MinConns:          DefaultMgr().Get(backgroundCtx, common.PostGreSQLMinConns).GetOptionalInt32(),
 		URL:               DefaultMgr().Get(backgroundCtx, common.PostGreSQLURL).GetString(),
 	}
 	database.PostGreSQL = postgresql

--- a/src/lib/dbpool/pool.go
+++ b/src/lib/dbpool/pool.go
@@ -35,6 +35,12 @@ import (
 // Defaults are chosen for backward compatibility with the pre-pgxpool Harbor
 // configuration. PostgreSQL server's own max_connections defaults to 100;
 // the metadata default for MaxOpenConns is 100 to match.
+//
+// DefaultMinConns is inherited from the removed POSTGRESQL_MAX_IDLE_CONNS,
+// whose default was also 2 — but that was a cap on idle connections, whereas
+// MinConns is a floor pgxpool keeps warm. pgxpool's own default is 0, and an
+// explicitly configured 0 is honoured (see applyPoolConfig); only an unset
+// value falls back to this constant.
 const (
 	DefaultMinConns          = 2
 	DefaultMaxConnIdleTime   = 10 * time.Minute
@@ -61,7 +67,9 @@ func New(ctx context.Context, cfg *models.PostGreSQL, opts ...Option) (*Pool, er
 		return nil, fmt.Errorf("dbpool: parse config: %w", err)
 	}
 
-	applyPoolConfig(poolCfg, cfg)
+	if err := applyPoolConfig(poolCfg, cfg); err != nil {
+		return nil, err
+	}
 
 	for _, opt := range opts {
 		opt(poolCfg)
@@ -95,14 +103,19 @@ func BuildDSN(cfg *models.PostGreSQL) string {
 		cfg.Host, cfg.Port, cfg.Username, escaped, cfg.Database, cfg.SSLMode)
 }
 
-func applyPoolConfig(poolCfg *pgxpool.Config, cfg *models.PostGreSQL) {
+func applyPoolConfig(poolCfg *pgxpool.Config, cfg *models.PostGreSQL) error {
 	// 0 means "not set" — leave pgxpool's default: max(4, runtime.NumCPU()).
 	if cfg.MaxOpenConns > 0 {
 		poolCfg.MaxConns = int32(cfg.MaxOpenConns)
 	}
 
-	if cfg.MinConns > 0 {
-		poolCfg.MinConns = cfg.MinConns
+	// nil means "not set". 0 is a valid setting (pgxpool's own default): no
+	// warm floor, connections opened on demand and left to age out.
+	if cfg.MinConns != nil {
+		if *cfg.MinConns < 0 {
+			return fmt.Errorf("dbpool: min_conns must be >= 0, got %d", *cfg.MinConns)
+		}
+		poolCfg.MinConns = *cfg.MinConns
 	} else {
 		poolCfg.MinConns = DefaultMinConns
 	}
@@ -132,6 +145,8 @@ func applyPoolConfig(poolCfg *pgxpool.Config, cfg *models.PostGreSQL) {
 	// Beego ORM uses string interpolation, not prepared statements.
 	// Simple protocol avoids statement cache issues.
 	poolCfg.ConnConfig.DefaultQueryExecMode = pgx.QueryExecModeSimpleProtocol
+
+	return nil
 }
 
 // RegisterWithOrm registers the bridged *sql.DB with Beego ORM.

--- a/src/lib/dbpool/pool_integration_test.go
+++ b/src/lib/dbpool/pool_integration_test.go
@@ -122,7 +122,7 @@ func TestPool_URLOverridesFields(t *testing.T) {
 func TestPool_MaxConnsEnforced(t *testing.T) {
 	cfg := testCfg()
 	cfg.MaxOpenConns = 2
-	cfg.MinConns = 0 // don't pre-create
+	cfg.MinConns = minConns(0) // don't pre-create
 
 	p := mustPool(t, cfg)
 
@@ -146,7 +146,7 @@ func TestPool_MaxConnsEnforced(t *testing.T) {
 
 func TestPool_MinConnsPreWarmed(t *testing.T) {
 	cfg := testCfg()
-	cfg.MinConns = 3
+	cfg.MinConns = minConns(3)
 	cfg.MaxOpenConns = 10
 
 	p := mustPool(t, cfg)
@@ -169,7 +169,7 @@ func TestPool_ConnectTimeoutApplied(t *testing.T) {
 		SSLMode:        "disable",
 		ConnectTimeout: 1 * time.Second,
 		MaxOpenConns:   1,
-		MinConns:       0,
+		MinConns:       minConns(0),
 	}
 
 	// pgxpool is lazy — creation succeeds, first query triggers connect.
@@ -246,7 +246,7 @@ func TestPool_SelfTestCleanup(t *testing.T) {
 func TestPool_ConcurrentQueries(t *testing.T) {
 	cfg := testCfg()
 	cfg.MaxOpenConns = 5
-	cfg.MinConns = 2
+	cfg.MinConns = minConns(2)
 
 	p := mustPool(t, cfg)
 
@@ -279,7 +279,6 @@ func TestPool_ConcurrentQueries(t *testing.T) {
 	assert.LessOrEqual(t, stat.TotalConns(), int32(cfg.MaxOpenConns),
 		"pool should never exceed MaxConns")
 }
-
 
 // ---------------------------------------------------------------------------
 // Option extensibility
@@ -317,7 +316,7 @@ func TestPool_MultipleOptions(t *testing.T) {
 func TestPool_WrongPassword(t *testing.T) {
 	cfg := testCfg()
 	cfg.Password = "definitely-wrong-password"
-	cfg.MinConns = 0
+	cfg.MinConns = minConns(0)
 
 	// pgxpool is lazy — creation succeeds, first query fails.
 	p, err := New(context.Background(), cfg)
@@ -332,7 +331,7 @@ func TestPool_WrongPassword(t *testing.T) {
 func TestPool_WrongDatabase(t *testing.T) {
 	cfg := testCfg()
 	cfg.Database = "nonexistent_db_" + strconv.FormatInt(time.Now().UnixNano(), 36)
-	cfg.MinConns = 0
+	cfg.MinConns = minConns(0)
 
 	p, err := New(context.Background(), cfg)
 	require.NoError(t, err)
@@ -347,7 +346,7 @@ func TestPool_WrongHost(t *testing.T) {
 	cfg := testCfg()
 	cfg.Host = "192.0.2.1" // TEST-NET, unreachable
 	cfg.ConnectTimeout = 1 * time.Second
-	cfg.MinConns = 0
+	cfg.MinConns = minConns(0)
 
 	p, err := New(context.Background(), cfg)
 	require.NoError(t, err)
@@ -485,7 +484,7 @@ func TestPool_RecoveryAfterConnectionKill(t *testing.T) {
 
 	cfg := testCfg()
 	cfg.MaxOpenConns = 2
-	cfg.MinConns = 1
+	cfg.MinConns = minConns(1)
 	cfg.HealthCheckPeriod = 500 * time.Millisecond
 
 	setAppName := func(c *pgxpool.Config) {
@@ -524,7 +523,7 @@ func TestPool_RecoveryAfterConnectionKill(t *testing.T) {
 func TestPool_MaxConnLifetimeEviction(t *testing.T) {
 	cfg := testCfg()
 	cfg.MaxOpenConns = 5
-	cfg.MinConns = 0
+	cfg.MinConns = minConns(0)
 	cfg.ConnMaxLifetime = 1 * time.Second
 	cfg.HealthCheckPeriod = 500 * time.Millisecond
 
@@ -562,7 +561,7 @@ func TestPool_MaxConnLifetimeEviction(t *testing.T) {
 func TestPool_MaxConnIdleTimeEviction(t *testing.T) {
 	cfg := testCfg()
 	cfg.MaxOpenConns = 10
-	cfg.MinConns = 1
+	cfg.MinConns = minConns(1)
 	cfg.ConnMaxIdleTime = 500 * time.Millisecond
 	cfg.HealthCheckPeriod = 500 * time.Millisecond
 
@@ -591,7 +590,7 @@ func TestPool_MaxConnIdleTimeEviction(t *testing.T) {
 	stat2 := p.PgxPool().Stat()
 	assert.LessOrEqual(t, stat2.IdleConns(), stat1.IdleConns(),
 		"idle connections should be reaped after MaxConnIdleTime")
-	assert.GreaterOrEqual(t, stat2.TotalConns(), int32(cfg.MinConns),
+	assert.GreaterOrEqual(t, stat2.TotalConns(), *cfg.MinConns,
 		"pool should never drop below MinConns")
 }
 

--- a/src/lib/dbpool/pool_test.go
+++ b/src/lib/dbpool/pool_test.go
@@ -26,6 +26,8 @@ import (
 	"github.com/goharbor/harbor/src/common/models"
 )
 
+func minConns(v int32) *int32 { return &v }
+
 func TestBuildDSN_FromFields(t *testing.T) {
 	cfg := &models.PostGreSQL{
 		Host:     "db.example.com",
@@ -61,7 +63,7 @@ func TestApplyPoolConfig_ExplicitValues(t *testing.T) {
 		Database:          "test",
 		SSLMode:           "disable",
 		MaxOpenConns:      50,
-		MinConns:          5,
+		MinConns:          minConns(5),
 		ConnMaxLifetime:   30 * time.Minute,
 		ConnMaxIdleTime:   5 * time.Minute,
 		HealthCheckPeriod: 2 * time.Minute,
@@ -72,7 +74,7 @@ func TestApplyPoolConfig_ExplicitValues(t *testing.T) {
 	poolCfg, err := pgxpool.ParseConfig(dsn)
 	require.NoError(t, err)
 
-	applyPoolConfig(poolCfg, cfg)
+	require.NoError(t, applyPoolConfig(poolCfg, cfg))
 
 	assert.Equal(t, int32(50), poolCfg.MaxConns)
 	assert.Equal(t, int32(5), poolCfg.MinConns)
@@ -100,13 +102,62 @@ func TestApplyPoolConfig_ZeroFallbacks(t *testing.T) {
 
 	pgxDefault := poolCfg.MaxConns // pgxpool sets max(4, NumCPU) during ParseConfig
 
-	applyPoolConfig(poolCfg, cfg)
+	require.NoError(t, applyPoolConfig(poolCfg, cfg))
 
 	assert.Equal(t, pgxDefault, poolCfg.MaxConns, "zero MaxOpenConns should keep pgxpool default")
 	assert.Equal(t, int32(DefaultMinConns), poolCfg.MinConns)
 	assert.Equal(t, DefaultMaxConnIdleTime, poolCfg.MaxConnIdleTime)
 	assert.Equal(t, DefaultHealthCheckPeriod, poolCfg.HealthCheckPeriod)
 	assert.Equal(t, DefaultConnectTimeout, poolCfg.ConnConfig.ConnectTimeout)
+}
+
+// An explicitly configured 0 must survive to pgxpool — it is pgxpool's own
+// default and means "keep no warm connections", which is what dense
+// multi-tenant deployments want. Only nil falls back to DefaultMinConns.
+func TestApplyPoolConfig_ExplicitZeroMinConnsHonored(t *testing.T) {
+	cfg := &models.PostGreSQL{
+		Host: "localhost", Port: 5432, Username: "test",
+		Password: "test", Database: "test", SSLMode: "disable",
+		MinConns: minConns(0),
+	}
+
+	poolCfg, err := pgxpool.ParseConfig(BuildDSN(cfg))
+	require.NoError(t, err)
+
+	require.NoError(t, applyPoolConfig(poolCfg, cfg))
+
+	assert.Equal(t, int32(0), poolCfg.MinConns, "explicit 0 must not be coerced to DefaultMinConns")
+}
+
+func TestApplyPoolConfig_NilMinConnsUsesDefault(t *testing.T) {
+	cfg := &models.PostGreSQL{
+		Host: "localhost", Port: 5432, Username: "test",
+		Password: "test", Database: "test", SSLMode: "disable",
+		MinConns: nil,
+	}
+
+	poolCfg, err := pgxpool.ParseConfig(BuildDSN(cfg))
+	require.NoError(t, err)
+
+	require.NoError(t, applyPoolConfig(poolCfg, cfg))
+
+	assert.Equal(t, int32(DefaultMinConns), poolCfg.MinConns)
+}
+
+func TestApplyPoolConfig_NegativeMinConnsRejected(t *testing.T) {
+	cfg := &models.PostGreSQL{
+		Host: "localhost", Port: 5432, Username: "test",
+		Password: "test", Database: "test", SSLMode: "disable",
+		MinConns: minConns(-5),
+	}
+
+	poolCfg, err := pgxpool.ParseConfig(BuildDSN(cfg))
+	require.NoError(t, err)
+
+	err = applyPoolConfig(poolCfg, cfg)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "min_conns must be >= 0")
 }
 
 func TestApplyPoolConfig_ZeroMaxConnsKeepsPgxDefault(t *testing.T) {
@@ -126,7 +177,7 @@ func TestApplyPoolConfig_ZeroMaxConnsKeepsPgxDefault(t *testing.T) {
 
 	pgxDefault := poolCfg.MaxConns // max(4, NumCPU)
 
-	applyPoolConfig(poolCfg, cfg)
+	require.NoError(t, applyPoolConfig(poolCfg, cfg))
 
 	assert.Equal(t, pgxDefault, poolCfg.MaxConns, "zero MaxOpenConns must not override pgxpool default")
 }
@@ -164,12 +215,14 @@ func TestApplyPoolConfig_SimpleProtocolAlwaysSet(t *testing.T) {
 	poolCfg, err := pgxpool.ParseConfig(BuildDSN(cfg))
 	require.NoError(t, err)
 
-	applyPoolConfig(poolCfg, cfg)
+	require.NoError(t, applyPoolConfig(poolCfg, cfg))
 
 	assert.Equal(t, pgx.QueryExecModeSimpleProtocol, poolCfg.ConnConfig.DefaultQueryExecMode,
 		"SimpleProtocol must always be set — Beego ORM relies on it")
 }
 
+// MinConns is excluded here: unlike the others it now fails loudly rather than
+// silently falling back. See TestApplyPoolConfig_NegativeMinConnsRejected.
 func TestApplyPoolConfig_NegativeValuesIgnored(t *testing.T) {
 	cfg := &models.PostGreSQL{
 		Host:              "h",
@@ -179,7 +232,6 @@ func TestApplyPoolConfig_NegativeValuesIgnored(t *testing.T) {
 		Database:          "d",
 		SSLMode:           "disable",
 		MaxOpenConns:      -1,
-		MinConns:          -5,
 		ConnMaxLifetime:   -1 * time.Minute,
 		ConnMaxIdleTime:   -1 * time.Minute,
 		HealthCheckPeriod: -1 * time.Minute,
@@ -190,12 +242,10 @@ func TestApplyPoolConfig_NegativeValuesIgnored(t *testing.T) {
 
 	pgxDefaultMax := poolCfg.MaxConns
 
-	applyPoolConfig(poolCfg, cfg)
+	require.NoError(t, applyPoolConfig(poolCfg, cfg))
 
 	// Negative MaxOpenConns (-1 < 0) should not override pgxpool default
 	assert.Equal(t, pgxDefaultMax, poolCfg.MaxConns, "negative MaxOpenConns must not set MaxConns")
-	// Negative MinConns should fall back to default
-	assert.Equal(t, int32(DefaultMinConns), poolCfg.MinConns, "negative MinConns must fall back to default")
 	// Negative durations should fall back to defaults
 	assert.Equal(t, DefaultMaxConnIdleTime, poolCfg.MaxConnIdleTime)
 	assert.Equal(t, DefaultHealthCheckPeriod, poolCfg.HealthCheckPeriod)

--- a/src/pkg/config/inmemory/manager_test.go
+++ b/src/pkg/config/inmemory/manager_test.go
@@ -19,6 +19,9 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/goharbor/harbor/src/common"
 )
 
 func TestNewInMemoryManager(t *testing.T) {
@@ -32,4 +35,20 @@ func TestNewInMemoryManager(t *testing.T) {
 	assert.Equal(t, "ldaps://ldap.vmware.com", inMemoryManager.Get(ctx, "ldap_url").GetString())
 	assert.Equal(t, 5, inMemoryManager.Get(ctx, "ldap_timeout").GetInt())
 	assert.Equal(t, true, inMemoryManager.Get(ctx, "ldap_verify_cert").GetBool())
+}
+
+// Walks the whole core path — config store -> GetDatabaseCfg -> models.PostGreSQL —
+// to prove POSTGRESQL_MIN_CONNS=0 survives as a configured 0 rather than being
+// re-read as "unset" and coerced back to the default. See harbor-next#564.
+func TestGetDatabaseCfg_MinConns(t *testing.T) {
+	ctx := context.Background()
+
+	mgr := NewInMemoryManager()
+	require.NotNil(t, mgr.GetDatabaseCfg().PostGreSQL.MinConns)
+	assert.Equal(t, int32(2), *mgr.GetDatabaseCfg().PostGreSQL.MinConns, "metadata default")
+
+	require.NoError(t, mgr.UpdateConfig(ctx, map[string]any{common.PostGreSQLMinConns: 0}))
+	minConns := mgr.GetDatabaseCfg().PostGreSQL.MinConns
+	require.NotNil(t, minConns, "an explicit 0 must not read back as unset")
+	assert.Equal(t, int32(0), *minConns)
 }

--- a/src/pkg/config/manager.go
+++ b/src/pkg/config/manager.go
@@ -173,7 +173,7 @@ func (c *CfgManager) GetDatabaseCfg() *models.Database {
 			ConnMaxIdleTime:   c.Get(ctx, common.PostGreSQLConnMaxIdleTime).GetDuration(),
 			HealthCheckPeriod: c.Get(ctx, common.PostGreSQLHealthCheckPeriod).GetDuration(),
 			ConnectTimeout:    c.Get(ctx, common.PostGreSQLConnectTimeout).GetDuration(),
-			MinConns:          int32(c.Get(ctx, common.PostGreSQLMinConns).GetInt()),
+			MinConns:          c.Get(ctx, common.PostGreSQLMinConns).GetOptionalInt32(),
 			URL:               c.Get(ctx, common.PostGreSQLURL).GetString(),
 		},
 	}


### PR DESCRIPTION
## Summary

`database.minConns` could not be set to `0`. The Go config layer treated `0` as "unset" and substituted `DefaultMinConns` (2), so there was no way to run pgxpool without a warm-connection floor. In dense multi-tenant deployments that floor is multiplied across every tenant sharing one PostgreSQL server.

`0` is not a degenerate value — it is pgxpool's own `defaultMinConns`. The pool keeps no warm connections, drains to empty when idle, and opens on demand at acquire time. `MaxConns` still governs the ceiling, so burst behaviour is unchanged. The cost is connection setup latency (TCP + TLS + auth + backend fork) on the first query after an idle gap.

### Why the default was 2

Worth recording, since it looks deliberate and is not. PR #118 (`612a3c5f7`) replaced one metadata line with another in the same hunk:

```go
-{Name: common.PostGreSQLMaxIdleConns, ..., EnvKey: "POSTGRESQL_MAX_IDLE_CONNS", DefaultValue: "2", ...}
+{Name: common.PostGreSQLMinConns,     ..., EnvKey: "POSTGRESQL_MIN_CONNS",     DefaultValue: "2", ...}
```

The `database/sql` knob was a **cap** on idle connections (keep *at most* 2 idle); the pgxpool knob is a **floor** (keep *at least* 2 warm). The number crossed an inverted semantic. The `if x > 0 { } else { default }` guard is the "0 means not set" idiom copied from `MaxOpenConns` directly above it, where 0 genuinely does mean unset for pgxpool.

The default stays 2. It is now overridable.

## Changes

- `models.PostGreSQL.MinConns` becomes `*int32` — nil is "unset", 0 is a configured value.
- `dbpool.applyPoolConfig` honours an explicit 0 and returns an error for a negative value instead of silently falling back. `New` propagates it, so a bad value fails startup rather than quietly changing pool behaviour.
- `ConfigureValue.GetOptionalInt32` returns nil when the key carries no metadata, so a missing key is not read back as a configured 0 (`CfgManager.Get` hands back an empty `ConfigureValue` whose `GetInt` is 0).
- The exporter uses `viper.IsSet`, which distinguishes an unset env var from `HARBOR_DATABASE_MIN_CONNS=0`; `viper.GetInt` collapses both to 0.

## Related Issues

Closes #564

Chart half is on #56 (`fix(chart): Allow database.minConns 0, let exporter.config win over chart env`). Both halves are needed end to end: the chart used to coerce `0` to `2` in its templates independently of this.

## Type of Change

- [x] Bug fix (`fix:`)

## Testing

- [x] Unit tests added/updated

Acceptance criteria from the issue, each asserted directly:

| Criterion | Test |
| --- | --- |
| `MinConns: ptr(0)` → `pgxpool.Config.MinConns == 0` | `TestApplyPoolConfig_ExplicitZeroMinConnsHonored` |
| `MinConns: nil` → 2 | `TestApplyPoolConfig_NilMinConnsUsesDefault` |
| negative rejected with a clear error | `TestApplyPoolConfig_NegativeMinConnsRejected` |
| `POSTGRESQL_MIN_CONNS=0` survives the whole core path | `TestGetDatabaseCfg_MinConns` (config store → `GetDatabaseCfg` → `models.PostGreSQL`) |
| `HARBOR_DATABASE_MIN_CONNS` unset / `""` / `0` / `5` | `TestGetMinConns` |
| an explicit 0 does not read back as unset | `TestConfigureValue_GetOptionalInt32` |

```
go test ./lib/dbpool/... ./lib/config/... ./pkg/config/... ./cmd/exporter/...
ok  github.com/goharbor/harbor/src/lib/dbpool
ok  github.com/goharbor/harbor/src/lib/config/metadata
ok  github.com/goharbor/harbor/src/pkg/config
ok  github.com/goharbor/harbor/src/pkg/config/inmemory
ok  github.com/goharbor/harbor/src/pkg/config/rest
ok  github.com/goharbor/harbor/src/pkg/config/store
ok  github.com/goharbor/harbor/src/cmd/exporter
```

Note for reviewers: five `db`-tagged integration cases set `cfg.MinConns = 0` with a `// don't pre-create` comment, which the old coercion silently turned into 2. They now get what they asked for. `go test -tags db ./lib/dbpool/...` needs a live PostgreSQL and has not been run locally.

## Checklist

- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] Commits are signed off (`git commit -s`)
- [x] No new warnings introduced
