### PR TITLE
ci: Fetch Full History for Release Patch Validation

### DIFF
--- a/.github/workflows/release-ready.yml
+++ b/.github/workflows/release-ready.yml
@@ -20,6 +20,10 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
+          # Full history: the jj merge in taskfile/release-ready.yml needs
+          # the merge base with the commercial branches; a shallow checkout
+          # hides it and every branch-touched file becomes a spurious conflict.
+          fetch-depth: 0
 
       - uses: ./.github/actions/setup-task
         with:

--- a/taskfile/release-ready.yml
+++ b/taskfile/release-ready.yml
@@ -112,18 +112,16 @@ tasks:
           exit 1
         fi
 
-        # Shallow-fetch each branch directly into the target worktree. depth=10
-        # comfortably covers a direct 8gcr-main child (depth 1) or a branch
-        # stacked one level deep (e.g. 0005 on 0004, depth 2) without pulling
-        # full history. Resolve to a raw SHA before handing off to jj — jj
-        # only exposes refs/remotes/<name>/* as revsets for remotes it has
-        # registered via `jj git remote`; "patches" is just a fetch-refspec
-        # destination, not a real remote, so jj can't resolve the ref path
-        # itself even though the commit is present. The SHA always works.
+        # Full-history fetch: jj doesn't support shallow histories — graft
+        # boundaries break merge-base discovery and turn the merge into
+        # spurious conflicts. Cost is only the 8gcr-side commits since the
+        # branches share their history with this checkout. Resolve to a raw
+        # SHA for jj: "patches" is a fetch-refspec destination, not a
+        # registered remote, so jj can't resolve the ref path itself.
         parent_refs=()
         for branch in "${branches[@]}"; do
           echo "Fetching commercial branch: ${branch}"
-          git -C "${patch_target_dir}" fetch --depth=10 "${remote_url}" \
+          git -C "${patch_target_dir}" fetch "${remote_url}" \
             "${branch}:refs/remotes/patches/${branch}"
           parent_refs+=("$(git -C "${patch_target_dir}" rev-parse "refs/remotes/patches/${branch}")")
         done


### PR DESCRIPTION
## Summary

"Validate Release Patches" fails on `main` as soon as any commit lands after the 8gcr-main sync point (first seen on 8862b52, the #613 merge): the jj octopus merge reports **137 spurious 2-sided conflicts** across every file the commercial branches touch.

Root cause: the job's shallow checkout (default `fetch-depth: 1`) plus `--depth=10` branch fetches hide the merge base between HEAD and the commercial branches. jj sees unrelated histories, so every branch-side change becomes an add/add conflict. The job only ever passed when HEAD happened to *be* the sync point — then the merge base is HEAD itself and no ancestor walk is needed.

Fix:
- `fetch-depth: 0` on the workflow checkout.
- Unshallow the per-branch fetches in `apply-commercial-patches` (jj does not support shallow histories; the branches share nearly all history with the checkout, so the incremental cost is only the 8gcr-side commits).

## Related Issues

Follow-up to #612.

## Type of Change

- [x] CI/CD

## Testing

- [x] Reproduced CI's exact failure locally: shallow clone at 8862b52 + depth-10 branch fetch + `jj new` octopus → 137 conflicts, matching the failing run's log.
- [x] Same merge with full history on both sides → **zero conflicts**.
- [ ] Live `workflow_dispatch` of Release Ready on this branch (HEAD is a child of 8862b52, i.e. drifted from the sync point — exactly the failing condition; passing proves the fix).

## Checklist

- [x] Conventional-commit title
- [x] DCO sign-off
- [x] No new warnings