### PR TITLE
fix: Make Release Patch Validation Task-Compatible

### DIFF
--- a/taskfile/release-ready.yml
+++ b/taskfile/release-ready.yml
@@ -152,7 +152,10 @@ tasks:
           for index in "${!branches[@]}"; do
             branch="${branches[$index]}"
             branch_ref="${parent_refs[$index]}"
-            IFS=' ' read -r -a branch_parents <<< "$(git -C "${patch_target_dir}" show -s --format='%P' "${branch_ref}")"
+            branch_parents=()
+            for branch_parent in $(git -C "${patch_target_dir}" show -s --format='%P' "${branch_ref}"); do
+              branch_parents+=("${branch_parent}")
+            done
 
             if [ "${#branch_parents[@]}" -eq 0 ]; then
               patches_ready=false


### PR DESCRIPTION
## Summary

- replace the Bash-only `read -a` invocation rejected by Task 3.49.1
- preserve parent validation for both single-parent and merge commits

## Validation

- `PATCHES_TOKEN=*** task-v3.49.1 --taskfile taskfile/release-ready.yml check`
- live five-branch JJ megamerge completed with 79 added and 90 modified files, with no conflicts
- `git diff --check`