### PR TITLE
ci: Publish Multi-Format Artifact Images

### DIFF
--- a/.github/workflows/publish-images.yml
+++ b/.github/workflows/publish-images.yml
@@ -23,6 +23,10 @@ on:
         required: false
         type: string
         default: 8gcr
+      patches_series:
+        required: false
+        type: string
+        default: 8gcr-ee/patches/series
     secrets:
       REGISTRY_PASSWORD:
         required: true
@@ -35,7 +39,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        component: [core, jobservice, registryctl, exporter, portal, registry, trivy-adapter]
+        component: [core, jobservice, registryctl, exporter, portal, registry, trivy-adapter, grype-scanner, snyk-scanner]
         platform:
           - linux/amd64
           - linux/arm64
@@ -52,11 +56,12 @@ jobs:
         run: |
           platform=${{ matrix.platform }}
           echo "PLATFORM_PAIR=${platform//\//-}" >> "$GITHUB_ENV"
-          if [ "${{ matrix.component }}" = "trivy-adapter" ]; then
-            echo "image_name=trivy-adapter" >> "$GITHUB_OUTPUT"
-          else
-            echo "image_name=harbor-${{ matrix.component }}" >> "$GITHUB_OUTPUT"
-          fi
+          case "${{ matrix.component }}" in
+            trivy-adapter) echo "image_name=trivy-adapter" >> "$GITHUB_OUTPUT" ;;
+            grype-scanner) echo "image_name=harbor-grype-adapter" >> "$GITHUB_OUTPUT" ;;
+            snyk-scanner) echo "image_name=harbor-snyk-adapter" >> "$GITHUB_OUTPUT" ;;
+            *) echo "image_name=harbor-${{ matrix.component }}" >> "$GITHUB_OUTPUT" ;;
+          esac
           if [ -n "$BUILDX_HOST" ]; then
             echo "BUILDX_HOST=$BUILDX_HOST" >> "$GITHUB_ENV"
           fi
@@ -64,6 +69,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ inputs.checkout_ref }}
+          fetch-depth: 0
           persist-credentials: false
 
       - name: Install Task
@@ -109,6 +115,7 @@ jobs:
       - name: Apply commercial patches
         env:
           PATCHES_TOKEN: ${{ steps.app-token.outputs.token }}
+          PATCHES_SERIES: ${{ inputs.patches_series }}
         run: task --taskfile taskfile/release-ready.yml apply-commercial-patches
 
       - name: Load versions
@@ -176,6 +183,10 @@ jobs:
             TRIVY_VERSION=${{ env.TRIVY_VERSION }}
             TRIVY_COMMIT=${{ env.TRIVY_COMMIT }}
             HARBOR_SCANNER_TRIVY_VERSION=${{ env.HARBOR_SCANNER_TRIVY_VERSION }}
+            NODE_VERSION=${{ env.NODE_VERSION }}
+            SNYK_CLI_VERSION=${{ env.SNYK_CLI_VERSION }}
+            GRYPE_VERSION=${{ env.GRYPE_VERSION }}
+            SYFT_VERSION=${{ env.SYFT_VERSION }}
           tags: ${{ env.REGISTRY_ADDRESS }}/${{ env.REGISTRY_PROJECT }}/${{ steps.prepare.outputs.image_name }}
           outputs: type=image,push-by-digest=true,name-canonical=true,push=true
 
@@ -198,7 +209,7 @@ jobs:
     needs: [build]
     strategy:
       matrix:
-        component: [core, jobservice, registryctl, exporter, portal, registry, trivy-adapter]
+        component: [core, jobservice, registryctl, exporter, portal, registry, trivy-adapter, grype-scanner, snyk-scanner]
     runs-on: ${{ vars.RUNNER || 'ubuntu-latest' }}
     permissions:
       contents: read
@@ -210,11 +221,12 @@ jobs:
       - name: Prepare BuildKit
         id: prepare
         run: |
-          if [ "${{ matrix.component }}" = "trivy-adapter" ]; then
-            echo "image_name=trivy-adapter" >> "$GITHUB_OUTPUT"
-          else
-            echo "image_name=harbor-${{ matrix.component }}" >> "$GITHUB_OUTPUT"
-          fi
+          case "${{ matrix.component }}" in
+            trivy-adapter) echo "image_name=trivy-adapter" >> "$GITHUB_OUTPUT" ;;
+            grype-scanner) echo "image_name=harbor-grype-adapter" >> "$GITHUB_OUTPUT" ;;
+            snyk-scanner) echo "image_name=harbor-snyk-adapter" >> "$GITHUB_OUTPUT" ;;
+            *) echo "image_name=harbor-${{ matrix.component }}" >> "$GITHUB_OUTPUT" ;;
+          esac
           if [ -n "$BUILDX_HOST" ]; then
             echo "BUILDX_HOST=$BUILDX_HOST" >> "$GITHUB_ENV"
           fi
@@ -275,11 +287,13 @@ jobs:
 
       - name: Sign images
         run: |
-          for image in core jobservice registryctl exporter portal registry trivy-adapter; do
-            image_name="harbor-${image}"
-            if [ "${image}" = "trivy-adapter" ]; then
-              image_name="trivy-adapter"
-            fi
+          for image in core jobservice registryctl exporter portal registry trivy-adapter grype-scanner snyk-scanner; do
+            case "${image}" in
+              trivy-adapter) image_name="trivy-adapter" ;;
+              grype-scanner) image_name="harbor-grype-adapter" ;;
+              snyk-scanner) image_name="harbor-snyk-adapter" ;;
+              *) image_name="harbor-${image}" ;;
+            esac
 
             cosign sign --yes \
               "${REGISTRY_ADDRESS}/${REGISTRY_PROJECT}/${image_name}:${IMAGE_TAG}"


### PR DESCRIPTION
## Summary

- fetch full history before the JJ commercial megamerge
- allow callers to select a version-specific 8gcr patch manifest
- publish, merge, and sign the new Grype and Snyk scanner images
- pass the scanner tool versions required by their Dockerfiles

Main/2.16 uses the default six-patch `8gcr-ee/patches/series`. Release 2.15 can select `8gcr-ee/patches/series-release-2.15`.

## Validation

- `actionlint .github/workflows/publish-images.yml`
- conflict-free JJ merge of `next/main` plus patches 0001-0006
- merged `go mod tidy -diff` is empty
- compiled every merged Go package
- built the merged Angular production bundle
- built `harbor-grype-adapter` and `harbor-snyk-adapter` locally with Podman