### PR TITLE
chore: Simplify Commercial Release Images

### DIFF
--- a/.github/scripts/update-release-notes.sh
+++ b/.github/scripts/update-release-notes.sh
@@ -3,6 +3,20 @@ set -euo pipefail
 
 : "${GH_TOKEN:?GH_TOKEN is required}"
 
+github_retry() {
+  local attempt
+  for attempt in 1 2 3 4 5; do
+    if "$@"; then
+      return 0
+    fi
+    if [[ "${attempt}" -eq 5 ]]; then
+      return 1
+    fi
+    echo "GitHub request failed (attempt ${attempt}/5); retrying..." >&2
+    sleep $((attempt * 2))
+  done
+}
+
 preview_pr_number="${RELEASE_NOTES_PREVIEW_PR_NUMBER:-}"
 if [[ -n "${preview_pr_number}" && ! "${TAG_NAME:-}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
   preview_version=$(node -e "const manifest = require('./.release-please-manifest.json'); const version = manifest['.']; if (!version) { throw new Error('missing root release version'); } console.log(version);")
@@ -47,7 +61,7 @@ generated_notes_args=(-f "tag_name=${TAG_NAME}")
 if [[ -n "${preview_pr_number}" ]]; then
   generated_notes_args+=(-f "target_commitish=$(git rev-parse HEAD)")
 fi
-gh api "repos/${GITHUB_REPOSITORY}/releases/generate-notes" \
+github_retry gh api "repos/${GITHUB_REPOSITORY}/releases/generate-notes" \
   "${generated_notes_args[@]}" \
   --jq .body > "${tmp_dir}/generated-notes.md"
 
@@ -60,7 +74,7 @@ node .github/scripts/format-release-notes.mjs \
 if [[ -n "${preview_pr_number}" ]]; then
   release_branch="${GITHUB_REF_NAME:?GITHUB_REF_NAME is required for a release PR preview}"
 else
-  release_branch=$(gh release view "${TAG_NAME}" \
+  release_branch=$(github_retry gh release view "${TAG_NAME}" \
     --repo "${GITHUB_REPOSITORY}" \
     --json targetCommitish \
     --jq .targetCommitish)
@@ -71,35 +85,28 @@ if [[ -z "${release_branch}" ]]; then
   exit 1
 fi
 
-# `gh repo clone` shells out to git without reliably propagating GH_TOKEN as
-# a credential for the private container-registry/8gcr repo in this
-# non-interactive context ("could not read Username for 'https://github.com'").
-# Use a plain `git clone` instead, but via a one-shot GIT_ASKPASS helper
-# rather than embedding the token in the URL — an embedded token is written
-# into the clone's `.git/config` and shows up in the process list (`ps`)
-# for the duration of the clone. The askpass script only ever reads the
-# token from its own environment, never as a command-line argument or URL.
-# Exported (not just prefixed on this one command) because the per-branch
-# `git fetch` loop below against the same private repo needs it too.
+# Fetch only the branches declared by this Harbor branch. The token remains
+# in the environment and never appears in a URL, process argument, or Git
+# config file.
 askpass_script="${tmp_dir}/git-askpass.sh"
 cat > "${askpass_script}" <<'EOF'
 #!/usr/bin/env bash
-echo "${PATCHES_TOKEN}"
+case "$1" in
+  *Username*) printf '%s\n' 'x-access-token' ;;
+  *Password*) printf '%s\n' "${PATCHES_TOKEN}" ;;
+  *) exit 1 ;;
+esac
 EOF
 chmod 700 "${askpass_script}"
-export GIT_ASKPASS="${askpass_script}" PATCHES_TOKEN
+export GIT_ASKPASS="${askpass_script}" GIT_TERMINAL_PROMPT=0 PATCHES_TOKEN
 
-git clone --depth=1 --branch main \
-  "https://x-access-token@github.com/container-registry/8gcr" \
-  "${tmp_dir}/patches-repo"
-
-series="${tmp_dir}/patches-repo/8gcr-ee/patches/series"
+git init --bare "${tmp_dir}/patches-repo"
+patches_remote="https://x-access-token@github.com/container-registry/8gcr"
+series="taskfile/commercial-patches"
 patch_notes="${tmp_dir}/commercial-patches.md"
 
-# 8gcr-ee/patches/series is now a manifest of commercial jj/git branch names
-# (see ADR-0006 in container-registry/8gcr), not a StGit patch-file series.
-# None of the branches carry a commit body, only a one-line subject, so a
-# direct `git log --format=%s` read replaces the old patch-file parsing.
+# The Harbor branch owns the ordered manifest. 8gcr only stores the branch
+# commits, so release notes and image builds always use the same exact list.
 if [[ -f "${series}" ]]; then
   while IFS= read -r branch; do
     branch="${branch%%#*}"
@@ -112,10 +119,15 @@ if [[ -f "${series}" ]]; then
       exit 1
     fi
 
-    git -C "${tmp_dir}/patches-repo" fetch --depth=1 origin \
+    git -C "${tmp_dir}/patches-repo" fetch --depth=1 "${patches_remote}" \
       "${branch}:refs/remotes/origin/${branch}"
     echo "- $(git -C "${tmp_dir}/patches-repo" log -1 --format=%s "refs/remotes/origin/${branch}")" \
       >> "${patch_notes}"
+
+    if git -C "${tmp_dir}/patches-repo" cat-file -e \
+      "refs/remotes/origin/${branch}:dockerfile/grype-scanner.dockerfile" 2>/dev/null; then
+      images+=(grype-scanner snyk-scanner)
+    fi
   done < "${series}"
 fi
 
@@ -143,6 +155,8 @@ fi
   for image in "${images[@]}"; do
     image_name="harbor-${image}"
     [[ "${image}" == "trivy-adapter" ]] && image_name="trivy-adapter"
+    [[ "${image}" == "grype-scanner" ]] && image_name="harbor-grype-adapter"
+    [[ "${image}" == "snyk-scanner" ]] && image_name="harbor-snyk-adapter"
     echo "| \`${image_name}\` | \`${registry}/${image_name}:${TAG_NAME}\` |"
   done
 
@@ -163,13 +177,13 @@ fi
   fi
 } > "${tmp_dir}/release-notes.md"
 
-if [[ -n "${preview_pr_number}" ]]; then
-  gh pr view "${preview_pr_number}" --repo "${GITHUB_REPOSITORY}" --json body --jq .body > "${tmp_dir}/release-pr-body.md"
+if [[ -n "${preview_pr_number}" && "${dry_run}" != "true" ]]; then
+  github_retry gh pr view "${preview_pr_number}" --repo "${GITHUB_REPOSITORY}" --json body --jq .body > "${tmp_dir}/release-pr-body.md"
   node .github/scripts/update-release-notes-preview.mjs \
     "${tmp_dir}/release-pr-body.md" \
     "${tmp_dir}/release-notes.md" \
     "${tmp_dir}/release-pr-body-with-preview.md"
-  gh pr edit "${preview_pr_number}" \
+  github_retry gh pr edit "${preview_pr_number}" \
     --repo "${GITHUB_REPOSITORY}" \
     --body-file "${tmp_dir}/release-pr-body-with-preview.md"
   exit 0
@@ -183,6 +197,6 @@ elif [[ "${dry_run}" == "true" ]]; then
   exit 0
 fi
 
-gh release edit "${TAG_NAME}" \
+github_retry gh release edit "${TAG_NAME}" \
   --repo "${GITHUB_REPOSITORY}" \
   --notes-file "${tmp_dir}/release-notes.md"

--- a/.github/workflows/publish-images.yml
+++ b/.github/workflows/publish-images.yml
@@ -23,10 +23,10 @@ on:
         required: false
         type: string
         default: 8gcr
-      patches_series:
+      registry_username:
         required: false
         type: string
-        default: 8gcr-ee/patches/series
+        default: ""
     secrets:
       REGISTRY_PASSWORD:
         required: true
@@ -49,7 +49,7 @@ jobs:
     env:
       REGISTRY_ADDRESS: ${{ inputs.registry_address }}
       REGISTRY_PROJECT: ${{ inputs.registry_project }}
-      VERSION: ${{ inputs.version }}
+      RELEASE_VERSION: ${{ inputs.version }}
     steps:
       - name: Prepare
         id: prepare
@@ -103,6 +103,13 @@ jobs:
 
           jj --version
 
+      # Root Taskfile evaluation reads Go cache paths, even for apply-patches.
+      - name: Setup Go
+        uses: ./.github/actions/setup-go-cached
+        with:
+          go-version-file: src/go.mod
+          go-sum-path: src/go.sum
+
       - name: Generate GitHub App token
         id: app-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
@@ -115,17 +122,10 @@ jobs:
       - name: Apply commercial patches
         env:
           PATCHES_TOKEN: ${{ steps.app-token.outputs.token }}
-          PATCHES_SERIES: ${{ inputs.patches_series }}
-        run: task --taskfile taskfile/release-ready.yml apply-commercial-patches
+        run: task apply-patches
 
       - name: Load versions
         run: grep -E '^[A-Z_]+=' versions.env >> "$GITHUB_ENV"
-
-      - name: Setup Go
-        uses: ./.github/actions/setup-go-cached
-        with:
-          go-version-file: src/go.mod
-          go-sum-path: src/go.sum
 
       - name: Generate API code
         if: ${{ contains(fromJSON('["core","jobservice","registryctl","exporter","registry","trivy-adapter"]'), matrix.component) }}
@@ -162,7 +162,7 @@ jobs:
         uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
         with:
           registry: ${{ env.REGISTRY_ADDRESS }}
-          username: ${{ vars.REGISTRY_USERNAME }}
+          username: ${{ inputs.registry_username || vars.REGISTRY_USERNAME }}
           password: ${{ secrets.REGISTRY_PASSWORD }}
 
       - name: Build and push by digest
@@ -242,7 +242,7 @@ jobs:
         uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
         with:
           registry: ${{ env.REGISTRY_ADDRESS }}
-          username: ${{ vars.REGISTRY_USERNAME }}
+          username: ${{ inputs.registry_username || vars.REGISTRY_USERNAME }}
           password: ${{ secrets.REGISTRY_PASSWORD }}
 
       - uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
@@ -282,7 +282,7 @@ jobs:
         uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
         with:
           registry: ${{ env.REGISTRY_ADDRESS }}
-          username: ${{ vars.REGISTRY_USERNAME }}
+          username: ${{ inputs.registry_username || vars.REGISTRY_USERNAME }}
           password: ${{ secrets.REGISTRY_PASSWORD }}
 
       - name: Sign images

--- a/.github/workflows/release-notes-engine.yml
+++ b/.github/workflows/release-notes-engine.yml
@@ -5,7 +5,7 @@ on:
     inputs:
       tag_name:
         description: Existing release tag to update
-        required: true
+        required: false
         type: string
       checkout_ref:
         description: Ref containing the changelog to render
@@ -30,7 +30,7 @@ concurrency:
 
 jobs:
   update:
-    name: Recreate ${{ inputs.tag_name || github.ref_name }} Release Notes
+    name: Recreate ${{ inputs.tag_name || 'Release Preview' }} Notes
     runs-on: ${{ vars.RUNNER || 'ubuntu-latest' }}
     timeout-minutes: 15
     env:

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -112,7 +112,6 @@ jobs:
       pull-requests: write
     uses: ./.github/workflows/release-notes-engine.yml
     with:
-      tag_name: v${{ needs.release-please.outputs.version }}
       checkout_ref: ${{ fromJSON(needs.release-please.outputs.prs)[0].headBranchName }}
       preview_pr_number: ${{ fromJSON(needs.release-please.outputs.prs)[0].number }}
     secrets:

--- a/.github/workflows/release-ready.yml
+++ b/.github/workflows/release-ready.yml
@@ -20,9 +20,8 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
-          # Full history: the jj merge in taskfile/release-ready.yml needs
-          # the merge base with the commercial branches; a shallow checkout
-          # hides it and every branch-touched file becomes a spurious conflict.
+          # release-ready clones this checkout by commit to validate patches
+          # without mutating the workflow's source tree.
           fetch-depth: 0
 
       - uses: ./.github/actions/setup-task
@@ -55,6 +54,13 @@ jobs:
 
           jj --version
 
+      # Root Taskfile evaluation reads Go cache paths.
+      - name: Setup Go
+        uses: ./.github/actions/setup-go-cached
+        with:
+          go-version-file: src/go.mod
+          go-sum-path: src/go.sum
+
       - name: Generate GitHub App token
         id: app-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
@@ -67,4 +73,4 @@ jobs:
       - name: Verify release patches apply
         env:
           PATCHES_TOKEN: ${{ steps.app-token.outputs.token }}
-        run: task --taskfile taskfile/release-ready.yml check
+        run: task release-ready

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,6 +10,8 @@ task test:quick   # API lint + unit tests
 task test:ci      # Full CI pipeline
 task images       # Build/push Docker images
 task dev:up       # Local dev with hot reload
+task apply-patches # Apply branches listed in taskfile/commercial-patches with jj
+task release-ready # Verify those patches against a clean clone
 ```
 
 Go test/build need generated API first: `task build:gen-apis`.
@@ -33,7 +35,7 @@ Go test/build need generated API first: `task build:gen-apis`.
 
 `main` uses `always-bump-minor`; `VERSION` on `main` tracks the next development release while `.release-please-manifest.json` tracks the published release. `release-X.Y` branches use patch-only versioning. `ci:`, `build:`, `chore:`, `test:` are hidden from release notes.
 
-**exclude-paths:** changes touching only `.github/`, `docs/`, or `tests/` don't bump version. Use `ci:` for CI-only changes.
+**exclude-paths:** changes touching only `.github/`, `docs/`, `tests/`, or `taskfile/` don't bump version. Use `ci:` for CI-only changes.
 
 ## Registry
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,9 +10,16 @@ task test:quick   # API lint + unit tests
 task test:ci      # Full CI pipeline
 task images       # Build/push Docker images
 task dev:up       # Local dev with hot reload
+task apply-patches # Apply branches listed in taskfile/commercial-patches with jj
+task release-ready # Verify those patches against a clean clone
 ```
 
 Go test/build need generated API first: `task build:gen-apis`.
+
+For an unsigned local release build and push, authenticate the container
+engine first, then run `task release-images-local RELEASE_VERSION=X.Y.Z
+IMAGE_TAG=<tag>`. It defaults to `8gears.container-registry.com/8gcr-pr` and
+builds both `linux/amd64` and `linux/arm64`.
 
 ## PRs
 
@@ -27,7 +34,7 @@ Go test/build need generated API first: `task build:gen-apis`.
 
 `main` uses `always-bump-minor`; `VERSION` on `main` tracks the next development release while `.release-please-manifest.json` tracks the published release. `release-X.Y` branches use patch-only versioning. `ci:`, `build:`, `chore:`, `test:` are hidden from release notes.
 
-**exclude-paths:** changes touching only `.github/`, `docs/`, or `tests/` don't bump version — use `ci:` for CI-only changes.
+**exclude-paths:** changes touching only `.github/`, `docs/`, `tests/`, or `taskfile/` don't bump version — use `ci:` for CI-only changes.
 
 ## Registry
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -24,8 +24,8 @@ flowchart LR
   harborMain["container-registry/harbor-next\nharbor-next/main"]
   harborRelease["container-registry/harbor-next\nharbor-next/release-X.Y"]
   harborTag["container-registry/harbor-next\nvX.Y.Z tag + GitHub Release"]
-  gcrMain["container-registry/8gcr\n8gcr/main"]
-  gcrPatches["container-registry/8gcr\ncommercial patches"]
+  patchManifest["harbor-next branch\ntaskfile/commercial-patches"]
+  gcrPatches["container-registry/8gcr\ndeclared patch branches"]
   images["8gears.container-registry.com/8gcr\nrelease images"]
 
   upstream -->|selected fixes as upstream: commits| harborMain
@@ -33,8 +33,8 @@ flowchart LR
   harborTag -->|new vX.Y.0 creates| harborRelease
   harborMain -->|/backport vX.Y| harborRelease
   harborRelease -->|maintenance release-please PR merged| harborTag
-  harborMain -->|upstream-sync dispatch| gcrMain
-  gcrMain --> gcrPatches
+  harborMain -->|owns ordered patch list| patchManifest
+  patchManifest -->|selects exact branches| gcrPatches
   harborTag -->|release workflow source| images
   gcrPatches -->|applied at release runtime| images
 ```
@@ -44,7 +44,8 @@ Rules:
 - `upstream/main` is the upstream Harbor source.
 - `harbor-next/main` is active Harbor Next development.
 - `harbor-next/release-X.Y` is a maintenance branch for patch releases.
-- `8gcr/main` provides the commercial patch series used at release runtime.
+- Each Harbor Next branch owns its ordered commercial patch list in `taskfile/commercial-patches`.
+- The release fetches only those named branches from `8gcr`; it never reads or imports `8gcr/main`.
 - Release images are built by checking out the Harbor Next release source, applying 8gcr patches during the workflow run, and building images from that patched working tree.
 
 ## Branch Movement
@@ -93,7 +94,7 @@ sequenceDiagram
   Maintainer->>GitHub: Squash-merge release PR
   GitHub->>Actions: Push starts Release Please workflow again
   RP->>GitHub: Create vX.Y.Z tag and GitHub Release
-  Actions->>GCR: Clone 8gcr patch series
+  Actions->>GCR: Fetch Harbor-declared patch branches
   Actions->>Actions: Apply patches to Harbor Next release source
   Actions->>Registry: Build and push release images
   Actions->>Cosign: Sign release images
@@ -131,6 +132,7 @@ Release-please ignores changes that only touch:
 - `.github/`
 - `docs/`
 - `tests/`
+- `taskfile/`
 
 Use `ci:` for workflow-only changes.
 
@@ -198,7 +200,9 @@ Each release publishes `linux/amd64` and `linux/arm64` images:
 
 Default registry path: `8gears.container-registry.com/8gcr`.
 
-At release runtime, the workflow clones `container-registry/8gcr`, reads the patch list from `8gcr-ee/patches/series`, applies those patches on top of the checked-out Harbor Next release source, and builds the images. Those images contain the commercial features from the patch series.
+At release runtime, the workflow reads `taskfile/commercial-patches` from the checked-out Harbor Next branch, fetches only those branches from `container-registry/8gcr`, applies their declared commit deltas, and builds the images. The workflow never fetches `8gcr/main` or an 8gcr-owned series file.
+
+Use `task apply-patches` to apply that manifest to a clean checkout and `task release-ready` to validate it against a disposable clean clone. For a local unsigned build and push to the PR registry project (`8gcr-pr` by default), authenticate the container engine and run `task release-images-local RELEASE_VERSION=X.Y.Z IMAGE_TAG=<tag>`; the local task verifies both published architectures after pushing. Main and maintenance-release workflows publish to `8gcr`.
 
 ## Release Notes
 

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -12,8 +12,9 @@ dotenv:
 vars:
   GIT_COMMIT:
     sh: git rev-parse --short=8 HEAD || echo "unknown"
-  VERSION:
+  DEFAULT_VERSION:
     sh: cat VERSION 2>/dev/null | tr -d '\n' || echo "dev"
+  VERSION: '{{.RELEASE_VERSION | default .DEFAULT_VERSION}}'
   TIMESTAMP:
     sh: date -u +%Y%m%d%H%M%S
 
@@ -56,6 +57,8 @@ includes:
     taskfile: ./taskfile/docs.yml
   release-ready:
     taskfile: ./taskfile/release-ready.yml
+  release-images-local:
+    taskfile: ./taskfile/release-images-local.yml
   release-notes:
     taskfile: ./taskfile/release-notes.yml
 
@@ -112,6 +115,16 @@ tasks:
     desc: "Verify release patches apply cleanly"
     cmds:
       - task: release-ready:check
+
+  apply-patches:
+    desc: "Apply the commercial patches declared by this Harbor branch"
+    cmds:
+      - task: release-ready:apply-patches
+
+  release-images-local:
+    desc: "Apply commercial patches, build multi-arch images, push them, and verify the manifests"
+    cmds:
+      - task: release-images-local:run
 
   release-notes:
     desc: "Recreate a GitHub release's notes from its tagged changelog"

--- a/release-please-config-maintenance.json
+++ b/release-please-config-maintenance.json
@@ -5,7 +5,7 @@
   "release-type": "simple",
   "versioning": "always-bump-patch",
   "include-v-in-tag": true,
-  "exclude-paths": [".github", "docs", "tests"],
+  "exclude-paths": [".github", "docs", "tests", "taskfile"],
   "changelog-sections": [
     {"type": "feat",     "section": "Features"},
     {"type": "fix",      "section": "Bug Fixes"},

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -7,7 +7,7 @@
   "versioning": "always-bump-minor",
   "always-update": true,
   "include-v-in-tag": true,
-  "exclude-paths": [".github", "docs", "tests"],
+  "exclude-paths": [".github", "docs", "tests", "taskfile"],
   "changelog-sections": [
     {"type": "feat",     "section": "Features"},
     {"type": "fix",      "section": "Bug Fixes"},

--- a/taskfile/commercial-patches
+++ b/taskfile/commercial-patches
@@ -1,0 +1,7 @@
+# Ordered commercial patches for Harbor Next main.
+0001-branding
+0002-sftp-replication
+0003-identity-providers
+0004-pgx-monitoring
+0005-aws-rds-iam-auth
+0006-multi-format-artifacts

--- a/taskfile/image.yml
+++ b/taskfile/image.yml
@@ -2,13 +2,13 @@
 #
 # CI-aware: local builds native arch only, CI builds all platforms
 # PUSH=false forces native arch (--load requires single platform)
-# TAG defaults to VERSION; override to publish under a different tag
+# IMAGE_TAG defaults to VERSION; override to publish under a different tag
 # (e.g. a feature-branch build) without touching the VERSION file.
 #
 # Usage:
 #   task image:core                         # CI: multi-arch push, local: native push
 #   task image:core PUSH=false              # load locally (native arch)
-#   task image:core TAG=my-feature          # push under a custom tag
+#   task image:core IMAGE_TAG=my-feature    # push under a custom tag
 #   task image:all-images                   # all images
 
 version: '3'
@@ -22,7 +22,7 @@ includes:
 vars:
   PUSH: '{{.PUSH | default "true"}}'
   PLATFORMS: '{{.PLATFORMS | default (ternary (printf "linux/%s" ARCH) .CI_PLATFORMS (eq .PUSH "false"))}}'
-  TAG: '{{.TAG | default .VERSION}}'
+  IMAGE_TAG: '{{.IMAGE_TAG | default (.TAG | default .VERSION)}}'
 
 tasks:
   all-images:
@@ -68,7 +68,7 @@ tasks:
     vars:
       OUTPUT: '{{ternary "--push" "--load" (eq .PUSH "true")}}'
       TAG_PREFIX: '{{ternary (printf "%s/%s/" .REGISTRY_ADDRESS .REGISTRY_PROJECT) "" (eq .PUSH "true")}}'
-      FULL_TAG: '{{.TAG_PREFIX}}{{.IMAGE_NAME}}:{{.TAG}}'
+      FULL_TAG: '{{.TAG_PREFIX}}{{.IMAGE_NAME}}:{{.IMAGE_TAG}}'
     preconditions:
       - sh: '{{if and (ne .PUSH "true") (contains "," .PLATFORMS)}}exit 1{{end}}'
         msg: "PUSH=false requires single platform (--load limitation)"
@@ -108,6 +108,15 @@ tasks:
       vars: [IMAGE_NAME, DOCKERFILE, FULL_TAG]
     cmds:
       - >-
+        {{if contains "," .PLATFORMS}}
+        podman build
+        --platform {{.PLATFORMS}}
+        --manifest {{.FULL_TAG}}
+        --build-arg ALPINE_VERSION={{.ALPINE_VERSION}}
+        {{.BUILD_ARGS}}
+        -f dockerfile/{{.DOCKERFILE}}
+        .
+        {{else}}
         podman build
         --platform {{.PLATFORMS}}
         --build-arg ALPINE_VERSION={{.ALPINE_VERSION}}
@@ -115,7 +124,45 @@ tasks:
         -t {{.FULL_TAG}}
         -f dockerfile/{{.DOCKERFILE}}
         .
-      - '{{if eq .PUSH "true"}}podman push {{.FULL_TAG}}{{end}}'
+        {{end}}
+      - >-
+        {{if and (eq .PUSH "true") (contains "," .PLATFORMS)}}
+        podman manifest push --all {{.FULL_TAG}} docker://{{.FULL_TAG}}
+        {{else if eq .PUSH "true"}}
+        podman push {{.FULL_TAG}}
+        {{end}}
+
+  verify-release-images:
+    desc: "Verify every pushed release image contains amd64 and arm64 manifests"
+    preconditions:
+      - sh: command -v skopeo >/dev/null 2>&1
+        msg: "skopeo is required to verify pushed image manifests"
+      - sh: command -v jq >/dev/null 2>&1
+        msg: "jq is required to verify pushed image manifests"
+    cmds:
+      - |
+        images="harbor-core harbor-jobservice harbor-registryctl harbor-exporter harbor-portal harbor-registry trivy-adapter"
+        if [ -f dockerfile/grype-scanner.dockerfile ]; then
+          images="${images} harbor-grype-adapter"
+        fi
+        if [ -f dockerfile/snyk-scanner.dockerfile ]; then
+          images="${images} harbor-snyk-adapter"
+        fi
+
+        for image in ${images}; do
+          reference="{{.REGISTRY_ADDRESS}}/{{.REGISTRY_PROJECT}}/${image}:{{.IMAGE_TAG}}"
+          platforms=$(skopeo inspect --raw "docker://${reference}" \
+            | jq -r '.manifests[]?.platform | "\(.os)/\(.architecture)"')
+          printf '%s\n' "${platforms}" | grep -Fqx 'linux/amd64' || {
+            echo "Missing linux/amd64 manifest: ${reference}" >&2
+            exit 1
+          }
+          printf '%s\n' "${platforms}" | grep -Fqx 'linux/arm64' || {
+            echo "Missing linux/arm64 manifest: ${reference}" >&2
+            exit 1
+          }
+          echo "Verified ${reference}"
+        done
 
   _build-binaries:
     internal: true

--- a/taskfile/release-images-local.yml
+++ b/taskfile/release-images-local.yml
@@ -1,0 +1,39 @@
+version: '3'
+
+vars:
+  PATCHES_CLONE_URL: '{{.PATCHES_CLONE_URL | default "git@github.com:container-registry/8gcr.git"}}'
+  LOCAL_REGISTRY_ADDRESS: '{{.LOCAL_REGISTRY_ADDRESS | default "8gears.container-registry.com"}}'
+  LOCAL_REGISTRY_PROJECT: '{{.LOCAL_REGISTRY_PROJECT | default "8gcr-pr"}}'
+  LOCAL_PLATFORMS: '{{.LOCAL_PLATFORMS | default "linux/amd64,linux/arm64"}}'
+
+tasks:
+  run:
+    desc: "Build and push unsigned local release images, then verify both architectures"
+    requires:
+      vars: [RELEASE_VERSION, IMAGE_TAG]
+    preconditions:
+      - sh: command -v task >/dev/null 2>&1
+        msg: "Task is required"
+      - sh: command -v jj >/dev/null 2>&1
+        msg: "jj (Jujutsu) is required"
+      - sh: command -v skopeo >/dev/null 2>&1
+        msg: "skopeo is required for final manifest verification"
+      - sh: command -v jq >/dev/null 2>&1
+        msg: "jq is required for final manifest verification"
+    cmds:
+      - task apply-patches PATCHES_CLONE_URL="{{.PATCHES_CLONE_URL}}"
+      # Start a new Task process after patching so patch-provided image tasks
+      # (such as commercial scanner images) are loaded from the patched tree.
+      - >-
+        task image:all-images
+        RELEASE_VERSION="{{.RELEASE_VERSION}}"
+        IMAGE_TAG="{{.IMAGE_TAG}}"
+        REGISTRY_ADDRESS="{{.LOCAL_REGISTRY_ADDRESS}}"
+        REGISTRY_PROJECT="{{.LOCAL_REGISTRY_PROJECT}}"
+        PLATFORMS="{{.LOCAL_PLATFORMS}}"
+        PUSH=true
+      - >-
+        task image:verify-release-images
+        IMAGE_TAG="{{.IMAGE_TAG}}"
+        REGISTRY_ADDRESS="{{.LOCAL_REGISTRY_ADDRESS}}"
+        REGISTRY_PROJECT="{{.LOCAL_REGISTRY_PROJECT}}"

--- a/taskfile/release-ready.yml
+++ b/taskfile/release-ready.yml
@@ -2,225 +2,212 @@ version: '3'
 
 vars:
   PATCHES_REPO: '{{.PATCHES_REPO | default "github.com/container-registry/8gcr"}}'
-  PATCHES_SERIES: '{{.PATCHES_SERIES | default "8gcr-ee/patches/series"}}'
-  RELEASE_READY_TMP_DIR: '{{.RELEASE_READY_TMP_DIR | default ".opencode/tmp/release-ready"}}'
-  RELEASE_PATCHES_TMP_DIR: '{{.RELEASE_PATCHES_TMP_DIR | default ".opencode/tmp/release-patches"}}'
+  PATCHES_CLONE_URL: '{{.PATCHES_CLONE_URL | default "git@github.com:container-registry/8gcr.git"}}'
+  PATCHES_SERIES: '{{.PATCHES_SERIES | default (printf "%s/taskfile/commercial-patches" .ROOT_DIR)}}'
+  PATCH_AUTH_DIR: '{{.PATCH_AUTH_DIR | default ".opencode/tmp/patch-auth"}}'
+  RELEASE_READY_DIR: '{{.RELEASE_READY_DIR | default ".opencode/tmp/release-ready"}}'
+  PATCHES_REMOTE_URL:
+    sh: |
+      if [ -n "${PATCHES_TOKEN:-}" ]; then
+        printf '%s' 'https://x-access-token@{{.PATCHES_REPO}}'
+      else
+        printf '%s' '{{.PATCHES_CLONE_URL}}'
+      fi
+  PATCH_BRANCHES:
+    sh: |
+      awk '
+        { sub(/#.*/, ""); gsub(/^[[:space:]]+|[[:space:]]+$/, "") }
+        NF && seen[$0]++ { print "Duplicate commercial patch branch: " $0 > "/dev/stderr"; exit 1 }
+        NF { print }
+      ' '{{.PATCHES_SERIES}}'
 
 tasks:
-  check:
-    desc: "Verify commercial branches merge cleanly onto the current worktree"
-    dir: ..
+  apply-patches:
+    desc: "Apply Harbor's declared commercial patches via jj"
     preconditions:
       - sh: command -v git >/dev/null 2>&1
         msg: "git is required"
       - sh: command -v jj >/dev/null 2>&1
         msg: "jj (Jujutsu) is required"
-      - sh: command -v task >/dev/null 2>&1
-        msg: "Task is required"
+      - sh: test -f '{{.PATCHES_SERIES}}'
+        msg: "commercial patch manifest not found: {{.PATCHES_SERIES}}"
+      - sh: test -z "$(if [ -d .jj ]; then jj diff --summary; else git status --porcelain; fi)"
+        msg: "applying release patches requires a clean worktree"
+    cmds:
+      - task: _validate-series
+      - task: _clean-auth
+      - defer: { task: _clean-auth }
+      - task: _configure-auth
+      - task: _fetch-patches
+      - task: _validate-patches
+      - task: _import-patches
+      - task: _duplicate-patches
+      - task: _verify-patches
+
+  check:
+    desc: "Verify the declared commercial patches apply to a clean clone"
+    vars:
+      REPO_ROOT:
+        sh: pwd -P
+      GIT_REPO_DIR:
+        sh: git rev-parse --path-format=absolute --git-common-dir
+      CHECKOUT_REF:
+        sh: jj log -r @ --no-graph -T commit_id 2>/dev/null || git rev-parse HEAD
+      CHECKOUT_DIR: '{{.REPO_ROOT}}/{{.RELEASE_READY_DIR}}/worktree'
+      CHECKOUT_AUTH_DIR: '{{.REPO_ROOT}}/{{.RELEASE_READY_DIR}}/auth'
+    cmds:
+      - task: _clean-checkout
+      - defer: { task: _clean-checkout }
+      - task: _clone-checkout
+        vars:
+          GIT_REPO_DIR: '{{.GIT_REPO_DIR}}'
+          CHECKOUT_DIR: '{{.CHECKOUT_DIR}}'
+          CHECKOUT_REF: '{{.CHECKOUT_REF}}'
+      - >-
+        task --dir '{{.CHECKOUT_DIR}}' apply-patches
+        PATCH_AUTH_DIR='{{.CHECKOUT_AUTH_DIR}}'
+        PATCHES_SERIES='{{.PATCHES_SERIES}}'
+      - echo "Release-ready patch validation succeeded."
+
+  _validate-series:
+    internal: true
+    requires:
+      vars: [PATCH_BRANCHES]
+    env:
+      DECLARED_PATCH_BRANCHES: '{{.PATCH_BRANCHES}}'
     cmds:
       - |
-        repo_root=$(pwd -P)
-        git_repo_dir=$(git -C "${repo_root}" rev-parse --path-format=absolute --git-common-dir)
-        if [ -d "${repo_root}/.jj" ]; then
-          checkout_ref=$(jj -R "${repo_root}" log -r @ --no-graph -T commit_id)
-        else
-          checkout_ref=$(git -C "${repo_root}" rev-parse HEAD)
-        fi
-        tmp_root="${repo_root}/{{.RELEASE_READY_TMP_DIR}}"
-        worktree_dir="${tmp_root}/worktree"
-        patches_repo_dir="${tmp_root}/patches-repo"
+        while IFS= read -r branch; do
+          git check-ref-format --branch "${branch}" >/dev/null
+        done <<< "${DECLARED_PATCH_BRANCHES}"
 
-        cleanup() {
-          rm -rf "${tmp_root}"
-        }
+  _clean-auth:
+    internal: true
+    cmd: rm -rf '{{.PATCH_AUTH_DIR}}'
 
-        cleanup
-        trap cleanup EXIT
+  _configure-auth:
+    internal: true
+    cmds:
+      - mkdir -p '{{.PATCH_AUTH_DIR}}'
+      - >-
+        printf '%s\n'
+        '#!/usr/bin/env bash'
+        'case "$1" in'
+        "  *Username*) printf '%s\\n' 'x-access-token' ;;"
+        "  *Password*) printf '%s\\n' \"\${PATCHES_TOKEN}\" ;;"
+        '  *) exit 1 ;;'
+        'esac'
+        > '{{.PATCH_AUTH_DIR}}/git-askpass'
+      - chmod 700 '{{.PATCH_AUTH_DIR}}/git-askpass'
 
-        mkdir -p "${tmp_root}"
-        # A real clone, not `git worktree add` — jj refuses to colocate
-        # inside a linked git worktree ("Cannot create a colocated jj repo
-        # inside a Git worktree"), since worktrees share their main repo's
-        # .git and jj colocation is tied to that. A clone is an independent
-        # repo apply-commercial-patches can freely `jj git init --colocate`.
-        git clone --local "${git_repo_dir}" "${worktree_dir}"
-        git -C "${worktree_dir}" checkout -B release-ready-check "${checkout_ref}"
-
-        task --taskfile "${repo_root}/taskfile/release-ready.yml" apply-commercial-patches \
-          RELEASE_PATCH_TARGET_DIR="${worktree_dir}" \
-          PATCHES_REPO="{{.PATCHES_REPO}}" \
-          PATCHES_SERIES="{{.PATCHES_SERIES}}" \
-          RELEASE_PATCHES_TMP_DIR="${patches_repo_dir}"
-
-        echo "Release-ready branch merge validation succeeded."
-
-  apply-commercial-patches:
-    desc: "Octopus-merge the commercial branches into the current worktree via jj"
-    dir: ..
-    preconditions:
-      - sh: command -v git >/dev/null 2>&1
-        msg: "git is required"
-      - sh: command -v jj >/dev/null 2>&1
-        msg: "jj (Jujutsu) is required. Install the jj command before applying release branches."
-      - sh: test -z "$(git -C '{{.RELEASE_PATCH_TARGET_DIR | default "."}}' status --porcelain)"
-        msg: "release branch merge requires a clean worktree"
+  _fetch-patches:
+    internal: true
+    env:
+      GIT_ASKPASS: '{{.PATCH_AUTH_DIR}}/git-askpass'
+      GIT_TERMINAL_PROMPT: '0'
+      PATCHES_FETCH_URL: '{{.PATCHES_REMOTE_URL}}'
+      DECLARED_PATCH_BRANCHES: '{{.PATCH_BRANCHES}}'
     cmds:
       - |
-        patch_target_dir="{{.RELEASE_PATCH_TARGET_DIR | default "."}}"
-        if [ "${patch_target_dir#/}" = "${patch_target_dir}" ]; then
-          patch_target_dir="$(pwd -P)/${patch_target_dir}"
-        fi
-
-        # The branch manifest ({{.PATCHES_SERIES}}) is sourced from the cloned
-        # PATCHES_REPO, not the local tree — this task also runs from repos
-        # (e.g. harbor-next) that don't carry 8gcr-ee/ at all. The manifest
-        # content itself isn't secret, only the branch content is, but it
-        # stays co-located with the branches for a single source of truth.
-        patches_repo_dir="{{.RELEASE_PATCHES_TMP_DIR}}"
-        if [ "${patches_repo_dir#/}" = "${patches_repo_dir}" ]; then
-          patches_repo_dir="$(pwd -P)/${patches_repo_dir}"
-        fi
-        series_file="${patches_repo_dir}/{{.PATCHES_SERIES}}"
-
-        cleanup_patches_repo() {
-          rm -rf "${patches_repo_dir}"
-        }
-        cleanup_patches_repo
-        trap cleanup_patches_repo EXIT
-        mkdir -p "$(dirname "${patches_repo_dir}")"
-
-        if [ -n "${PATCHES_CLONE_URL:-}" ]; then
-          remote_url="${PATCHES_CLONE_URL}"
-        else
-          if [ -z "${PATCHES_TOKEN:-}" ]; then
-            echo "PATCHES_TOKEN is required unless PATCHES_CLONE_URL is set." >&2
-            exit 1
-          fi
-          remote_url="https://x-access-token:${PATCHES_TOKEN}@{{.PATCHES_REPO}}"
-        fi
-
-        git clone --depth=1 "${remote_url}" "${patches_repo_dir}"
-
-        if [ ! -f "${series_file}" ]; then
-          echo "Branch manifest not found: ${series_file}" >&2
-          exit 1
-        fi
-
-        branches=()
-        while IFS= read -r branch || [ -n "${branch}" ]; do
-          branch=$(printf '%s' "${branch}" | sed 's/#.*//' | xargs)
-          [ -z "${branch}" ] && continue
-          branches+=("${branch}")
-        done < "${series_file}"
-
-        if [ "${#branches[@]}" -eq 0 ]; then
-          echo "Branch manifest is empty: ${series_file}" >&2
-          exit 1
-        fi
-
-        # Fetch the complete patch snapshot in one transaction. jj doesn't
-        # support shallow histories, and fetching branches one at a time can
-        # mix generations when the refs are force-rebased concurrently.
-        # "patches" is a fetch-refspec destination, not a registered jj
-        # remote, so resolve the imported refs to raw SHAs below.
         refspecs=()
-        for branch in "${branches[@]}"; do
-          refspecs+=("+${branch}:refs/remotes/patches/${branch}")
-        done
+        while IFS= read -r branch; do
+          refspecs+=("+refs/heads/${branch}:refs/remotes/patches/${branch}")
+        done <<< "${DECLARED_PATCH_BRANCHES}"
+        git fetch --no-tags "${PATCHES_FETCH_URL}" "${refspecs[@]}"
 
-        # A commercial branch is one patch commit based on the target's
-        # Harbor Next history, or on another branch in this declared series
-        # (0005 is intentionally stacked on 0004). Reject extra 8gcr/main lineage:
-        # jj can merge that history without a conflict when it is shallow,
-        # but the result silently imports unrelated repository changes. The
-        # producer sync runs in another repository, so briefly retry while a
-        # new patch generation is being force-pushed.
-        target_commit=$(git -C "${patch_target_dir}" rev-parse HEAD)
-        sync_attempts=${PATCH_SYNC_ATTEMPTS:-36}
-        sync_delay_seconds=${PATCH_SYNC_DELAY_SECONDS:-5}
-        for ((attempt = 1; attempt <= sync_attempts; attempt++)); do
-          git -C "${patch_target_dir}" fetch --no-tags "${remote_url}" "${refspecs[@]}"
+  _validate-patches:
+    internal: true
+    env:
+      DECLARED_PATCH_BRANCHES: '{{.PATCH_BRANCHES}}'
+    cmds:
+      - |
+        base=$(git rev-parse HEAD)
+        patch_commits=()
+        while IFS= read -r branch; do
+          patch_commits+=("$(git rev-parse "refs/remotes/patches/${branch}^{commit}")")
+        done <<< "${DECLARED_PATCH_BRANCHES}"
 
-          parent_refs=()
-          for branch in "${branches[@]}"; do
-            parent_refs+=("$(git -C "${patch_target_dir}" rev-parse "refs/remotes/patches/${branch}")")
-          done
-
-          patches_ready=true
-          invalid_branch=""
-          invalid_parent=""
-          for index in "${!branches[@]}"; do
-            branch="${branches[$index]}"
-            branch_ref="${parent_refs[$index]}"
-            branch_parents=()
-            for branch_parent in $(git -C "${patch_target_dir}" show -s --format='%P' "${branch_ref}"); do
-              branch_parents+=("${branch_parent}")
-            done
-
-            if [ "${#branch_parents[@]}" -eq 0 ]; then
-              patches_ready=false
-              invalid_branch="${branch}"
-              invalid_parent="<none>"
-              break
-            fi
-
-            for branch_parent in "${branch_parents[@]}"; do
-              if git -C "${patch_target_dir}" merge-base --is-ancestor "${branch_parent}" "${target_commit}"; then
-                continue
-              fi
-
-              parent_is_patch=false
-              for patch_ref in "${parent_refs[@]}"; do
-                if [ "${branch_parent}" = "${patch_ref}" ]; then
-                  parent_is_patch=true
-                  break
-                fi
-              done
-              if [ "${parent_is_patch}" = true ]; then
-                continue
-              fi
-
-              patches_ready=false
-              invalid_branch="${branch}"
-              invalid_parent="${branch_parent}"
-              break
-            done
-            if [ "${patches_ready}" = false ]; then
-              break
-            fi
-          done
-
-          if [ "${patches_ready}" = true ]; then
-            break
-          fi
-          if [ "${attempt}" -eq "${sync_attempts}" ]; then
-            echo "::error::Commercial branch ${invalid_branch} is not based on the target Harbor Next history or another declared patch branch" >&2
-            echo "Unexpected parent: ${invalid_parent}" >&2
-            echo "Rebase the patch series onto the current next/main before publishing images." >&2
+        while IFS= read -r branch; do
+          ref="refs/remotes/patches/${branch}"
+          parents=$(git show -s --format='%P' "${ref}")
+          if [ "$(wc -w <<< "${parents}")" -ne 1 ]; then
+            echo "commercial patch branch must point to one non-merge commit: ${branch}" >&2
             exit 1
           fi
 
-          echo "Patch branches are still syncing to next/main (attempt ${attempt}/${sync_attempts}); retrying in ${sync_delay_seconds}s..."
-          sleep "${sync_delay_seconds}"
-        done
+          parent=${parents}
+          valid_parent=false
+          if git merge-base --is-ancestor "${parent}" "${base}"; then
+            valid_parent=true
+          else
+            for patch_commit in "${patch_commits[@]}"; do
+              if [ "${parent}" = "${patch_commit}" ]; then
+                valid_parent=true
+                break
+              fi
+            done
+          fi
 
-        if [ ! -d "${patch_target_dir}/.jj" ]; then
-          (cd "${patch_target_dir}" && jj git init --colocate >/dev/null)
-        fi
+          if [ "${valid_parent}" != true ]; then
+            echo "commercial patch branch is not based on the target or another declared patch: ${branch}" >&2
+            exit 1
+          fi
+        done <<< "${DECLARED_PATCH_BRANCHES}"
 
-        (cd "${patch_target_dir}" && jj new @ "${parent_refs[@]}" -m "release merge: ${branches[*]}")
+  _import-patches:
+    internal: true
+    cmds:
+      - task: _init-jj
+      - jj git import >/dev/null
 
-        # `jj new` moves the working copy TO the new merge commit — @ IS
-        # the merge itself here, not a child of it. Checking @- (the old
-        # parent) would never see a conflict since no single parent branch
-        # is conflicted on its own, only their combination is.
-        if (cd "${patch_target_dir}" && jj log -r '@ & conflicts()' -T 'commit_id' --no-graph 2>/dev/null | grep -q .); then
-          echo "::error::Commercial branches did not merge cleanly" >&2
-          echo "Conflicted paths:" >&2
-          (cd "${patch_target_dir}" && jj resolve --list) >&2 || true
-          echo "Resolve locally with: task jj:restack (see .claude/skills/jj-megamerge/SKILL.md)" >&2
-          exit 1
-        fi
+  _init-jj:
+    internal: true
+    status:
+      - test -d .jj
+    cmd: jj git init --colocate >/dev/null
 
-        echo "Merged commercial branches:"
-        printf '  %s\n' "${branches[@]}"
+  _duplicate-patches:
+    internal: true
+    env:
+      DECLARED_PATCH_BRANCHES: '{{.PATCH_BRANCHES}}'
+    status:
+      - |
+        patch_revset=$(printf '%s\n' "${DECLARED_PATCH_BRANCHES}" | while IFS= read -r branch; do
+          git rev-parse "refs/remotes/patches/${branch}^{commit}"
+        done | paste -sd '|' -)
+        patchset_id=$(printf '%s' "${patch_revset}" | git hash-object --stdin)
+        test "$(jj log -r @ --no-graph -T 'description.first_line()')" = "release patches ${patchset_id}"
+    cmds:
+      - |
+        patch_revset=$(printf '%s\n' "${DECLARED_PATCH_BRANCHES}" | while IFS= read -r branch; do
+          git rev-parse "refs/remotes/patches/${branch}^{commit}"
+        done | paste -sd '|' -)
+        patchset_id=$(printf '%s' "${patch_revset}" | git hash-object --stdin)
+        base=$(jj log -r @ --no-graph -T commit_id)
+        jj duplicate "(${patch_revset})" --onto @
+        jj new "heads(${base}::) ~ ${base}" -m "release patches ${patchset_id}"
+
+  _verify-patches:
+    internal: true
+    env:
+      DECLARED_PATCH_BRANCHES: '{{.PATCH_BRANCHES}}'
+    preconditions:
+      - sh: test -z "$(jj log -r '::@ & conflicts()' --no-graph -T commit_id)"
+        msg: "commercial patches did not apply cleanly; run 'jj resolve --list'"
+    cmds:
+      - echo "Applied commercial patches from {{.PATCHES_SERIES}}:"
+      - |
+        while IFS= read -r branch; do
+          echo "  ${branch}"
+        done <<< "${DECLARED_PATCH_BRANCHES}"
+
+  _clean-checkout:
+    internal: true
+    cmd: rm -rf '{{.RELEASE_READY_DIR}}'
+
+  _clone-checkout:
+    internal: true
+    cmds:
+      - mkdir -p '{{.RELEASE_READY_DIR}}'
+      - git clone --local '{{.GIT_REPO_DIR}}' '{{.CHECKOUT_DIR}}'
+      - git -C '{{.CHECKOUT_DIR}}' checkout -B release-ready-check '{{.CHECKOUT_REF}}'


### PR DESCRIPTION
## Summary

- make each Harbor branch own `taskfile/commercial-patches`
- replace the monolithic patch command with composable `task apply-patches` tasks
- separate `RELEASE_VERSION` from `IMAGE_TAG`
- add unsigned multi-arch `task release-images-local` builds and manifest verification
- route PR/local validation images to `8gcr-pr` and main/maintenance releases to `8gcr`
- stop reading or importing `8gcr/main`
- exclude `taskfile/**`-only commits from release-please version bumps
- repair release-note preview version derivation and retry transient GitHub API failures

## Validation

- `task release-ready` (six commercial patches)
- release-note normal and derived-preview dry runs
- reusable release-note workflow dry run: https://github.com/container-registry/harbor-next/actions/runs/32055844920
- Taskfile, workflow, shell syntax, and image-task dry-run validation

## CI status

Two unit-test shards failed before tests because runner DNS could not resolve `dind.github-runners.svc`; remaining checks are queued/running.