### PR TITLE
chore: Qualify Trivy Base Image

### DIFF
--- a/dockerfile/trivy-adapter.dockerfile
+++ b/dockerfile/trivy-adapter.dockerfile
@@ -7,7 +7,7 @@ ARG ALPINE_VERSION=MISSING-BUILD-ARG
 
 FROM alpine:${ALPINE_VERSION} AS certs
 
-FROM aquasec/trivy:${TRIVY_BASE_IMAGE_VERSION}
+FROM docker.io/aquasec/trivy:${TRIVY_BASE_IMAGE_VERSION}
 COPY --from=certs /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 ARG TARGETARCH
 COPY bin/linux-${TARGETARCH}/lprobe /lprobe


### PR DESCRIPTION
## Summary

- Qualify the Trivy base image with the `docker.io` registry.

## Why

This avoids unqualified image-name resolution and makes the intended Docker Hub source explicit.

## Impact

There is no image version or runtime behavior change; only the registry source is made explicit.

## Validation

- Confirmed the commit changes only `dockerfile/trivy-adapter.dockerfile`.
- No tests run (image reference-only change).
