### PR TITLE
ci: Install Envsubst Before Cosign

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -353,6 +353,9 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Install envsubst
+        run: command -v envsubst || (sudo apt-get update && sudo apt-get install -y gettext-base)
+
       - name: Install cosign
         uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
 


### PR DESCRIPTION
## What changed

- Install `gettext-base` before the cosign installer in the release signing job.

## Why

Cosign installer v4.1.2 expands its install directory with `envsubst`. The minimal self-hosted release runner does not provide that command, so the v2.15.6 release workflow failed before image signing began.

This matches the prerequisite setup already used by the signing jobs on `main`.

## Validation

- `actionlint .github/workflows/release-please.yml`
- Confirmed `next/main` installs `envsubst` in `.github/workflows/publish-images.yml` before cosign.
