### PR TITLE
ci: Install envsubst for Helm chart publishing

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -275,6 +275,9 @@ jobs:
         with:
           version: ${{ env.HELM_VERSION }}
 
+      - name: Install envsubst
+        run: command -v envsubst || (sudo apt-get update && sudo apt-get install -y gettext-base)
+
       - name: Install cosign
         uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
 


### PR DESCRIPTION
## Summary

- install `envsubst` before the Helm chart publishing job sets up cosign
- reuse the existing `gettext-base` setup used by the image signing workflows

## Root cause

The self-hosted release runner does not include `envsubst`. `sigstore/cosign-installer` v4.1.2 invokes it while expanding the install directory, causing the Helm chart publishing job to exit with code 127 before cosign is installed.

## Impact

Helm chart releases can proceed through cosign installation on minimal self-hosted runners.

## Validation

- parsed `.github/workflows/release-please.yml` with PyYAML
- ran `actionlint` v1.7.7 against the workflow
- checked the install command with `bash -n`