### PR TITLE
ci: Update ORAS setup for chart publishing

### DIFF
--- a/.github/workflows/publish-chart.yml
+++ b/.github/workflows/publish-chart.yml
@@ -184,9 +184,10 @@ jobs:
             "${REGISTRY_ADDRESS}/${REGISTRY_PROJECT}/charts/harbor-next@${CHART_DIGEST}"
 
       - name: Install oras
-        uses: oras-project/setup-oras@38de303aac69abb66f3e6255b7198bff35f323e3 # v2.0.0
+        uses: oras-project/setup-oras@1d808f7d7f6995cc68b7bf507bfe5c5446e1dc9d # v2.0.1
         with:
-          version: ${{ env.ORAS_VERSION }}
+          # Retry source may be an old release tag with a stale versions.env.
+          version: 1.3.3
 
       - name: Push Artifact Hub repository metadata
         # artifacthub-repo.yml rides next to the chart as an OCI artifact

--- a/.github/workflows/publish-chart.yml
+++ b/.github/workflows/publish-chart.yml
@@ -187,7 +187,7 @@ jobs:
         uses: oras-project/setup-oras@1d808f7d7f6995cc68b7bf507bfe5c5446e1dc9d # v2.0.1
         with:
           # Retry source may be an old release tag with a stale versions.env.
-          version: 1.3.3
+          version: ${{ env.ORAS_VERSION }}
 
       - name: Push Artifact Hub repository metadata
         # artifacthub-repo.yml rides next to the chart as an OCI artifact

--- a/versions.env
+++ b/versions.env
@@ -31,7 +31,7 @@ HELM_DOCS_VERSION=1.14.2
 # renovate: datasource=github-releases depName=artifacthub/hub extractVersion=^v(?<version>.*)$
 AH_VERSION=1.22.0
 # renovate: datasource=github-releases depName=oras-project/oras extractVersion=^v(?<version>.*)$
-ORAS_VERSION=1.3.2
+ORAS_VERSION=1.3.3
 # renovate: datasource=npm depName=ajv-cli
 AJV_CLI_VERSION=5.0.0
 # renovate: datasource=docker depName=node versioning=docker


### PR DESCRIPTION
## Summary

- update `oras-project/setup-oras` from v2.0.0 to v2.0.1 using its full commit SHA
- update ORAS CLI from 1.3.2 to latest stable 1.3.3
- pin 1.3.3 in the retry workflow so publishing an older chart tag does not reload a stale ORAS version from that tag

## Root cause

The chart was packaged, pushed, and signed, but Artifact Hub metadata publication failed before execution because `setup-oras` v2.0.0 did not contain ORAS CLI 1.3.2 in its embedded release catalog. Official `setup-oras` v2.0.1 explicitly adds support for ORAS CLI 1.3.2 and 1.3.3.

## Impact

Manual chart publication retries can install ORAS and finish pushing `artifacthub-repo.yml`. Future workflows also use ORAS CLI 1.3.3.

## Validation

- confirmed setup-oras v2.0.1 embedded catalog contains ORAS CLI 1.3.3
- parsed workflow YAML
- ran `actionlint` v1.7.7
- ran `zizmor` v1.29.0 with no findings for the workflow
- verified repository ORAS version is 1.3.3

Follow-up to #646 and failed run 32204540320.