### PR TITLE
feat(8gcr-dev): everyone-admin demo + config-write lock to admin

### DIFF
--- a/deploy/flux/8gcr-dev/helmrelease.yaml
+++ b/deploy/flux/8gcr-dev/helmrelease.yaml
@@ -47,6 +47,66 @@ spec:
         nginx.ingress.kubernetes.io/proxy-body-size: "0"
         nginx.ingress.kubernetes.io/ssl-redirect: "true"
         cert-manager.io/cluster-issuer: letsencrypt-prod
+        # Demo-only config lock: every user on this tenant is a system admin
+        # (see the CNPG postInitApplicationSQL trigger below), so the built-in
+        # role check can no longer gate configuration writes. This guard pins
+        # write access to /api/v2.0/configurations to the *username* `admin`.
+        # It asks Harbor who the caller is (works for Basic auth and portal
+        # session cookies alike) and 403s everyone else. Reads are untouched.
+        # kube-dns (10.96.0.10) is the cluster's fixed DNS Service IP; the core
+        # Service is addressed by name so its ClusterIP can change freely.
+        nginx.ingress.kubernetes.io/server-snippet: |
+          location = /api/v2.0/configurations {
+              resolver 10.96.0.10 valid=30s ipv6=off;
+              set $cfg_upstream harbor-harbor-next-core.8gcr-dev-main.svc.cluster.local;
+              access_by_lua_block {
+                  local m = ngx.req.get_method()
+                  if m == "PUT" or m == "POST" or m == "DELETE" or m == "PATCH" then
+                      local http = require "resty.http"
+                      local httpc = http.new()
+                      httpc:set_timeout(3000)
+                      local ok, cerr = httpc:connect("harbor-harbor-next-core.8gcr-dev-main.svc.cluster.local", 80)
+                      if not ok then
+                          ngx.log(ngx.ERR, "cfg-guard connect: ", cerr)
+                          return ngx.exit(403)
+                      end
+                      local res, rerr = httpc:request({
+                          method = "GET",
+                          path = "/api/v2.0/users/current",
+                          headers = {
+                              ["Authorization"] = ngx.var.http_authorization,
+                              ["Cookie"] = ngx.var.http_cookie,
+                              ["Host"] = ngx.var.host,
+                              ["Accept"] = "application/json",
+                          },
+                      })
+                      if not res then
+                          ngx.log(ngx.ERR, "cfg-guard request: ", rerr)
+                          httpc:close()
+                          return ngx.exit(403)
+                      end
+                      local body = res:read_body() or ""
+                      httpc:set_keepalive()
+                      local uname
+                      if res.status == 200 then
+                          uname = string.match(body, '"username"%s*:%s*"([^"]*)"')
+                      end
+                      if uname ~= "admin" then
+                          ngx.status = 403
+                          ngx.header["Content-Type"] = "application/json"
+                          ngx.say('{"errors":[{"code":"FORBIDDEN","message":"configuration changes are restricted to the admin account on this demo"}]}')
+                          return ngx.exit(403)
+                      end
+                  end
+              }
+              proxy_set_header Host $host;
+              proxy_set_header X-Real-IP $remote_addr;
+              proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+              proxy_set_header X-Forwarded-Proto $scheme;
+              proxy_set_header X-Forwarded-Host $host;
+              proxy_http_version 1.1;
+              proxy_pass http://$cfg_upstream:80$request_uri;
+          }
     # ---- Database ----
     # Both CNPG bootstrap (extraManifests below) and Harbor's runtime DB client
     # read the SAME Secret/harbor-db-password. CNPG requires basic-auth type
@@ -171,6 +231,41 @@ spec:
               owner: harbor
               secret:
                 name: harbor-db-password
+              # Demo-only: auto-promote every newly registered user to system
+              # admin (mirrors demo.goharbor.io). Harbor owns the schema and
+              # creates `harbor_user` during its own migrations, which run long
+              # after initdb — so we cannot CREATE TRIGGER here directly. Instead
+              # we install a one-shot DDL event trigger (superuser context) that
+              # fires when Harbor first creates `harbor_user`, then installs the
+              # BEFORE INSERT row trigger. `anonymous` (Harbor's internal
+              # unauthenticated principal) is excluded. Config writes are still
+              # fenced to the real `admin` account by the ingress server-snippet
+              # above. Scope is this tenant's CNPG cluster only — NOT baked into
+              # the shared 8gcr/harbor-core image, which other tenants also pull.
+              postInitApplicationSQL:
+                - |
+                  CREATE OR REPLACE FUNCTION demo_install_promote_admin() RETURNS event_trigger
+                  LANGUAGE plpgsql AS $$
+                  BEGIN
+                    IF to_regclass('public.harbor_user') IS NOT NULL
+                       AND NOT EXISTS (SELECT 1 FROM pg_trigger WHERE tgname = 'trg_demo_promote_new_user_to_admin') THEN
+                      CREATE OR REPLACE FUNCTION demo_promote_new_user_to_admin() RETURNS trigger
+                      LANGUAGE plpgsql AS $body$
+                      BEGIN
+                        IF NEW.username IS DISTINCT FROM 'anonymous' THEN
+                          NEW.sysadmin_flag := true;
+                        END IF;
+                        RETURN NEW;
+                      END;
+                      $body$;
+                      EXECUTE 'CREATE TRIGGER trg_demo_promote_new_user_to_admin BEFORE INSERT ON harbor_user FOR EACH ROW EXECUTE FUNCTION demo_promote_new_user_to_admin()';
+                    END IF;
+                  END;
+                  $$;
+                - |
+                  CREATE EVENT TRIGGER demo_install_promote_admin_evt
+                    ON ddl_command_end WHEN TAG IN ('CREATE TABLE')
+                    EXECUTE FUNCTION demo_install_promote_admin();
       - apiVersion: apps/v1
         kind: Deployment
         metadata:

--- a/deploy/flux/8gcr-dev/ingress-packages.yaml
+++ b/deploy/flux/8gcr-dev/ingress-packages.yaml
@@ -4,7 +4,7 @@
 # to core, and everything else to the portal. Core serves the package registries
 # on their own prefixes, so without these rules an `npm install` or a `mvn` build
 # lands on the Angular app and gets 200 text/html back, which npm reports as a
-# JSON parse error and Maven as an unparseable POM.
+# JSON parse error and Maven as an unparsable POM.
 #
 # A separate Ingress rather than a chart change, so it ships with this bundle.
 # ingress-nginx merges rules per host and prefers the longer path, so the chart's


### PR DESCRIPTION
Makes two demo behaviours on the **8gcr-dev-main** tenant (`8gcr.container-registry.dev`) permanent, entirely within this Flux overlay. **Nothing here touches the shared `8gcr/harbor-core` image**, so other tenants pulling that image (e.g. `215-next`) are unaffected.

### 1. Everyone-admin (like demo.goharbor.io)
`CNPG postInitApplicationSQL` installs a DDL **event trigger**. Harbor creates `harbor_user` during its own migrations (long after initdb), so we can't `CREATE TRIGGER` at bootstrap directly; the event trigger fires on that `CREATE TABLE` and installs a `BEFORE INSERT` row trigger that sets `sysadmin_flag = true` for every new user, **excluding** the internal `anonymous` principal. Rebuild-safe.

### 2. Config-write lock to the `admin` username
Once everyone is admin, Harbor's role check can no longer gate configuration changes. An nginx `server-snippet` intercepts `PUT/POST/DELETE/PATCH /api/v2.0/configurations`, asks Harbor `/api/v2.0/users/current` who the caller is (works for **Basic auth and portal session cookies**), and returns **403** unless the username is exactly `admin`. Reads are untouched. The core Service is addressed **by name** (resolved via kube-dns `10.96.0.10`, a fixed cluster IP) so its ClusterIP is never hardcoded.

## Verified live against 8gcr.container-registry.dev

| Caller | `PUT /configurations` | `GET /configurations` |
|---|---|---|
| `admin` (basic auth) | 200 forwarded | 200 |
| `admin` (portal session) | 200 forwarded | 200 |
| any other user | **403** | 200 |
| anonymous | **403** | 401 |

Auto-promote confirmed: an ordinary API-created user came out `sysadmin_flag=t`.

## Notes
- The **current** live DB already has the row trigger applied by hand; `postInitApplicationSQL` only runs on a fresh CNPG bootstrap, so this PR is the source-of-truth for future rebuilds. Adding it to the existing Cluster is a no-op (CNPG only runs it at bootstrap).
- This is a demo. Do not port either behaviour to a production tenant or into the Harbor image.

## Release Notes

The 8gcr development demo now automatically grants system-administrator access to newly registered users while restricting configuration changes to the built-in admin account.