### PR TITLE
ci: Show Only Release Notes Preview

### DIFF
--- a/.github/scripts/update-release-notes-preview.mjs
+++ b/.github/scripts/update-release-notes-preview.mjs
@@ -1,15 +1,12 @@
 import { readFileSync, writeFileSync } from 'node:fs';
 
-const [bodyPath, notesPath, outputPath] = process.argv.slice(2);
+const [notesPath, outputPath] = process.argv.slice(2);
 
-if (!bodyPath || !notesPath || !outputPath) {
-  throw new Error('usage: update-release-notes-preview.mjs <pr-body> <notes> <output>');
+if (!notesPath || !outputPath) {
+  throw new Error('usage: update-release-notes-preview.mjs <notes> <output>');
 }
 
-const body = readFileSync(bodyPath, 'utf8').trimEnd();
 const notes = readFileSync(notesPath, 'utf8').trim();
 const heading = '## Release Notes Preview';
-const start = body.indexOf(heading);
-const prefix = start === -1 ? body : body.slice(0, start).trimEnd();
 
-writeFileSync(outputPath, `${prefix}\n\n${heading}\n\n${notes}\n`);
+writeFileSync(outputPath, `${heading}\n\n${notes}\n`);

--- a/.github/scripts/update-release-notes.sh
+++ b/.github/scripts/update-release-notes.sh
@@ -200,9 +200,7 @@ fi
 } > "${tmp_dir}/release-notes.md"
 
 if [[ -n "${preview_pr_number}" && "${dry_run}" != "true" ]]; then
-  github_retry gh pr view "${preview_pr_number}" --repo "${GITHUB_REPOSITORY}" --json body --jq .body > "${tmp_dir}/release-pr-body.md"
   node .github/scripts/update-release-notes-preview.mjs \
-    "${tmp_dir}/release-pr-body.md" \
     "${tmp_dir}/release-notes.md" \
     "${tmp_dir}/release-pr-body-with-preview.md"
   github_retry gh pr edit "${preview_pr_number}" \


### PR DESCRIPTION
## Summary

- replace the release-please PR body with the generated release notes preview
- stop preserving release-please’s generated preamble and changelog when refreshing the preview

## Validation

- rendered an exact preview fixture with Node.js and compared the output
- `bash -n .github/scripts/update-release-notes.sh`

`actionlint` was not available locally.