### PR TITLE
fix: Harden Proxy Cache Repository Filter Validation

### DIFF
--- a/src/controller/event/metadata/commonevent/model.go
+++ b/src/controller/event/metadata/commonevent/model.go
@@ -58,6 +58,9 @@ type Metadata struct {
 	ResponseCode int
 	// RequestURL request URL
 	RequestURL string
+	// IsResourceName indicates the request declared, via the X-Is-Resource-Name
+	// header, that name/ID path parameters are resource names
+	IsResourceName bool
 	// IPAddress IP address of the request
 	IPAddress string
 	// ResponseLocation response location

--- a/src/lib/pattern/matcher.go
+++ b/src/lib/pattern/matcher.go
@@ -44,7 +44,7 @@ func ValidateKind(kind string) error {
 	case "", KindRegex, KindDoublestar:
 		return nil
 	default:
-		return errors.Errorf("unsupported repository filter kind %q, must be %q or %q", kind, KindDoublestar, KindRegex)
+		return errors.Errorf("unsupported repository filter kind %q, must be %q, %q, or empty (defaults to %q)", kind, KindDoublestar, KindRegex, KindDoublestar)
 	}
 }
 

--- a/src/lib/pattern/matcher.go
+++ b/src/lib/pattern/matcher.go
@@ -37,6 +37,17 @@ func ValidateRepositoryFilter(filterPattern, kind string) error {
 	return err
 }
 
+// ValidateKind validates the repository filter kind. Empty kind is valid and
+// means the doublestar default.
+func ValidateKind(kind string) error {
+	switch kind {
+	case "", KindRegex, KindDoublestar:
+		return nil
+	default:
+		return errors.Errorf("unsupported repository filter kind %q, must be %q or %q", kind, KindDoublestar, KindRegex)
+	}
+}
+
 // Match returns true if the value matches the pattern according to the kind.
 // Empty pattern matches all (returns true).
 func Match(value, filterPattern, kind string) (bool, error) {
@@ -46,6 +57,12 @@ func Match(value, filterPattern, kind string) (bool, error) {
 	}
 	switch kind {
 	case KindRegex:
+		// Compile the bare pattern first: a group-imbalanced pattern such as
+		// `foo)|(bar` fails alone but compiles inside the ^(?:...)$ wrapper,
+		// where the top-level alternation silently destroys the anchoring.
+		if _, err := regexp.Compile(filterPattern); err != nil {
+			return false, err
+		}
 		re, err := regexp.Compile("^(?:" + filterPattern + ")$")
 		if err != nil {
 			return false, err
@@ -61,6 +78,10 @@ func Match(value, filterPattern, kind string) (bool, error) {
 	}
 }
 
+// validateDoublestarPattern is a port of doValidatePattern from
+// github.com/bmatcuk/doublestar/v4; the v1 dependency in go.mod has no
+// ValidatePattern. Keep it in sync with the library's grammar if the
+// dependency is ever bumped.
 func validateDoublestarPattern(s string) bool {
 	altDepth := 0
 	l := len(s)

--- a/src/lib/pattern/matcher_test.go
+++ b/src/lib/pattern/matcher_test.go
@@ -81,6 +81,12 @@ func TestValidateRepositoryFilter(t *testing.T) {
 			kind:          "invalid_kind",
 			expectErr:     true,
 		},
+		{
+			name:          "group-imbalanced regex that only compiles when wrapped",
+			filterPattern: "foo)|(bar",
+			kind:          KindRegex,
+			expectErr:     true,
+		},
 	}
 
 	for _, tc := range cases {
@@ -93,6 +99,13 @@ func TestValidateRepositoryFilter(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestValidateKind(t *testing.T) {
+	for _, kind := range []string{"", KindRegex, KindDoublestar} {
+		assert.NoError(t, ValidateKind(kind), "kind %q should be valid", kind)
+	}
+	assert.Error(t, ValidateKind("glob"))
 }
 
 func TestMatch(t *testing.T) {
@@ -207,6 +220,13 @@ func TestMatch(t *testing.T) {
 			value:         "library/nginx",
 			filterPattern: "library/**",
 			kind:          "invalid_kind",
+			expectErr:     true,
+		},
+		{
+			name:          "group-imbalanced regex does not break anchoring",
+			value:         "library/foobar",
+			filterPattern: "foo)|(bar",
+			kind:          KindRegex,
 			expectErr:     true,
 		},
 	}

--- a/src/pkg/auditext/event/project/project.go
+++ b/src/pkg/auditext/event/project/project.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"fmt"
 	"net/http"
-	"net/url"
 	"regexp"
 	"strconv"
 	"time"
@@ -68,7 +67,7 @@ func (r *resolver) Resolve(ce *commonevent.Metadata, evt *event.Event) error {
 		ctx = orm.Clone(ctx)
 	}
 
-	proj, err := getProject(ctx, projStr, isResourceName(ce.RequestURL))
+	proj, err := getProject(ctx, projStr, ce.IsResourceName)
 	if err != nil {
 		return fmt.Errorf("failed to get project: %v", err)
 	}
@@ -115,17 +114,10 @@ func getProjectNameOrID(url string) string {
 	return ""
 }
 
-// isResourceName reports whether the request URL carries x_is_resource_name=true,
-// which forces the path segment to be treated as a project name even when it is
-// all digits — mirroring parseProjectNameOrID in the API handlers.
-func isResourceName(requestURL string) bool {
-	u, err := url.Parse(requestURL)
-	if err != nil {
-		return false
-	}
-	return u.Query().Get("x_is_resource_name") == "true"
-}
-
+// getProject resolves the path segment to a project. isName comes from the
+// X-Is-Resource-Name header and forces the segment to be treated as a project
+// name even when it is all digits — mirroring parseProjectNameOrID in the API
+// handlers.
 func getProject(ctx context.Context, str string, isName bool) (*models.Project, error) {
 	var projectNameOrID any = str
 	if !isName {

--- a/src/pkg/auditext/event/project/project.go
+++ b/src/pkg/auditext/event/project/project.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"net/url"
 	"regexp"
 	"strconv"
 	"time"
@@ -32,17 +33,25 @@ import (
 	"github.com/goharbor/harbor/src/pkg/project/models"
 )
 
+// Each URL shape is declared once and used for both resolver registration and
+// project-name extraction, so the two can never drift apart.
+const (
+	projectPattern        = `^/api/v2\.0/projects/([^/?]+)(?:\?.*)?$`
+	projectMetaPattern    = `^/api/v2\.0/projects/([^/?]+)/metadatas/(?:\?.*)?$`
+	projectMetaKeyPattern = `^/api/v2\.0/projects/([^/?]+)/metadatas/([^/?]+)(?:\?.*)?$`
+)
+
 var (
-	projectReg        = regexp.MustCompile(`^/api/v2.0/projects/([^/?]+)(?:\?.*)?$`)
-	projectMetaReg    = regexp.MustCompile(`^/api/v2.0/projects/([^/?]+)/metadatas/(?:\?.*)?$`)
-	projectMetaKeyReg = regexp.MustCompile(`^/api/v2.0/projects/([^/?]+)/metadatas/([^/?]+)(?:\?.*)?$`)
+	projectReg        = regexp.MustCompile(projectPattern)
+	projectMetaReg    = regexp.MustCompile(projectMetaPattern)
+	projectMetaKeyReg = regexp.MustCompile(projectMetaKeyPattern)
 )
 
 func init() {
 	var projectEventResolver = &resolver{}
-	commonevent.RegisterResolver(`^/api/v2.0/projects/[^/?]+(?:\?.*)?$`, projectEventResolver)
-	commonevent.RegisterResolver(`^/api/v2.0/projects/[^/?]+/metadatas/(?:\?.*)?$`, projectEventResolver)
-	commonevent.RegisterResolver(`^/api/v2.0/projects/[^/?]+/metadatas/[^/?]+(?:\?.*)?$`, projectEventResolver)
+	commonevent.RegisterResolver(projectPattern, projectEventResolver)
+	commonevent.RegisterResolver(projectMetaPattern, projectEventResolver)
+	commonevent.RegisterResolver(projectMetaKeyPattern, projectEventResolver)
 }
 
 type resolver struct {
@@ -59,7 +68,7 @@ func (r *resolver) Resolve(ce *commonevent.Metadata, evt *event.Event) error {
 		ctx = orm.Clone(ctx)
 	}
 
-	proj, err := getProject(ctx, projStr)
+	proj, err := getProject(ctx, projStr, isResourceName(ce.RequestURL))
 	if err != nil {
 		return fmt.Errorf("failed to get project: %v", err)
 	}
@@ -106,13 +115,23 @@ func getProjectNameOrID(url string) string {
 	return ""
 }
 
-func getProject(ctx context.Context, str string) (*models.Project, error) {
-	var projectNameOrID any
-	v, err := strconv.ParseInt(str, 10, 64)
+// isResourceName reports whether the request URL carries x_is_resource_name=true,
+// which forces the path segment to be treated as a project name even when it is
+// all digits — mirroring parseProjectNameOrID in the API handlers.
+func isResourceName(requestURL string) bool {
+	u, err := url.Parse(requestURL)
 	if err != nil {
-		projectNameOrID = str
-	} else {
-		projectNameOrID = v
+		return false
+	}
+	return u.Query().Get("x_is_resource_name") == "true"
+}
+
+func getProject(ctx context.Context, str string, isName bool) (*models.Project, error) {
+	var projectNameOrID any = str
+	if !isName {
+		if v, err := strconv.ParseInt(str, 10, 64); err == nil {
+			projectNameOrID = v
+		}
 	}
 	return project.Ctl.Get(ctx, projectNameOrID)
 }

--- a/src/pkg/auditext/event/project/project_test.go
+++ b/src/pkg/auditext/event/project/project_test.go
@@ -88,6 +88,7 @@ func TestProjectEventResolver_Resolve(t *testing.T) {
 
 	mockCtrl.On("Get", mock.Anything, int64(123)).Return(proj, nil)
 	mockCtrl.On("Get", mock.Anything, "test-proj").Return(proj, nil)
+	mockCtrl.On("Get", mock.Anything, "123").Return(proj, nil)
 
 	r := &resolver{}
 
@@ -135,5 +136,24 @@ func TestProjectEventResolver_Resolve(t *testing.T) {
 		assert.Equal(t, int64(123), data.ProjectID)
 		assert.Equal(t, "update project: test-proj", data.OperationDescription)
 		assert.True(t, data.IsSuccessful)
+	})
+
+	t.Run("Resolve all-digit project name with x_is_resource_name", func(t *testing.T) {
+		ce := &commonevent.Metadata{
+			Ctx:           context.Background(),
+			Username:      "admin",
+			RequestURL:    "/api/v2.0/projects/123?x_is_resource_name=true",
+			RequestMethod: "PUT",
+			ResponseCode:  http.StatusOK,
+		}
+		evt := &event.Event{}
+		err := r.Resolve(ce, evt)
+		assert.NoError(t, err)
+
+		data, ok := evt.Data.(*model.CommonEvent)
+		assert.True(t, ok)
+		assert.Equal(t, "test-proj", data.ResourceName)
+		// The segment must be resolved as a project *name*, not ID 123.
+		mockCtrl.AssertCalled(t, "Get", mock.Anything, "123")
 	})
 }

--- a/src/pkg/auditext/event/project/project_test.go
+++ b/src/pkg/auditext/event/project/project_test.go
@@ -138,13 +138,14 @@ func TestProjectEventResolver_Resolve(t *testing.T) {
 		assert.True(t, data.IsSuccessful)
 	})
 
-	t.Run("Resolve all-digit project name with x_is_resource_name", func(t *testing.T) {
+	t.Run("Resolve all-digit project name with X-Is-Resource-Name", func(t *testing.T) {
 		ce := &commonevent.Metadata{
-			Ctx:           context.Background(),
-			Username:      "admin",
-			RequestURL:    "/api/v2.0/projects/123?x_is_resource_name=true",
-			RequestMethod: "PUT",
-			ResponseCode:  http.StatusOK,
+			Ctx:            context.Background(),
+			Username:       "admin",
+			RequestURL:     "/api/v2.0/projects/123",
+			RequestMethod:  "PUT",
+			ResponseCode:   http.StatusOK,
+			IsResourceName: true,
 		}
 		evt := &event.Event{}
 		err := r.Resolve(ce, evt)

--- a/src/server/middleware/log/log.go
+++ b/src/server/middleware/log/log.go
@@ -17,6 +17,7 @@ package log //nolint:revive
 import (
 	"io"
 	"net/http"
+	"strconv"
 
 	"github.com/goharbor/harbor/src/common/security"
 	"github.com/goharbor/harbor/src/controller/event/metadata/commonevent"
@@ -45,11 +46,13 @@ func Middleware() func(http.Handler) http.Handler {
 			r = r.WithContext(ctx)
 		}
 
+		isResourceName, _ := strconv.ParseBool(r.Header.Get("X-Is-Resource-Name"))
 		e := &commonevent.Metadata{
-			Ctx:           r.Context(),
-			Username:      "unknown",
-			RequestMethod: r.Method,
-			RequestURL:    r.URL.String(),
+			Ctx:            r.Context(),
+			Username:       "unknown",
+			RequestMethod:  r.Method,
+			RequestURL:     r.URL.String(),
+			IsResourceName: isResourceName,
 		}
 		if matched, resName := e.PreCheckMetadata(); matched {
 			lib.NopCloseRequest(r)

--- a/src/server/middleware/repoproxy/proxy_test.go
+++ b/src/server/middleware/repoproxy/proxy_test.go
@@ -266,6 +266,13 @@ func TestMatchRepositoryFilter(t *testing.T) {
 			want:          false,
 		},
 		{
+			name:          "group-imbalanced regex treated as no match, not unanchored",
+			repository:    "library/foobar",
+			filterPattern: "foo)|(bar",
+			filterKind:    "regex",
+			want:          false,
+		},
+		{
 			name:          "doublestar exact match",
 			repository:    "library/nginx",
 			filterPattern: "library/nginx",

--- a/src/server/v2.0/handler/project.go
+++ b/src/server/v2.0/handler/project.go
@@ -861,9 +861,8 @@ func validateProxyCacheRepositoryFilter(metadata *models.ProjectMetadata) error 
 		return nil
 	}
 
-	if filterKind != pattern.KindRegex && filterKind != pattern.KindDoublestar {
-		return errors.BadRequestError(nil).
-			WithMessagef("metadata.proxy_cache_filter_kind should be %q or %q, but got: %q", pattern.KindDoublestar, pattern.KindRegex, filterKind)
+	if err := pattern.ValidateKind(filterKind); err != nil {
+		return errors.BadRequestError(nil).WithMessagef("metadata.proxy_cache_filter_kind: %v", err)
 	}
 
 	if err := pattern.ValidateRepositoryFilter(filterPattern, filterKind); err != nil {

--- a/src/server/v2.0/handler/project_metadata.go
+++ b/src/server/v2.0/handler/project_metadata.go
@@ -90,16 +90,14 @@ func (p *projectMetadataAPI) DeleteProjectMetadata(ctx context.Context, params o
 		return p.SendError(ctx, err)
 	}
 	if params.MetaName == proModels.ProMetaProxyCacheFilterKind {
-		if p.ctl != nil {
-			existing, err := p.ctl.Get(ctx, project.ProjectID, proModels.ProMetaProxyCacheFilterPattern)
-			if err != nil {
-				return p.SendError(ctx, err)
-			}
-			if patVal, ok := existing[proModels.ProMetaProxyCacheFilterPattern]; ok && patVal != "" {
-				return p.SendError(ctx, errors.New(nil).WithCode(errors.BadRequestCode).
-					WithMessagef("cannot delete %s when %s is not empty, please clear the pattern first",
-						proModels.ProMetaProxyCacheFilterKind, proModels.ProMetaProxyCacheFilterPattern))
-			}
+		existing, err := p.ctl.Get(ctx, project.ProjectID, proModels.ProMetaProxyCacheFilterPattern)
+		if err != nil {
+			return p.SendError(ctx, err)
+		}
+		if patVal, ok := existing[proModels.ProMetaProxyCacheFilterPattern]; ok && patVal != "" {
+			return p.SendError(ctx, errors.New(nil).WithCode(errors.BadRequestCode).
+				WithMessagef("cannot delete %s when %s is not empty, please clear the pattern first",
+					proModels.ProMetaProxyCacheFilterKind, proModels.ProMetaProxyCacheFilterPattern))
 		}
 	}
 	if err = p.ctl.Delete(ctx, project.ProjectID, params.MetaName); err != nil {
@@ -191,27 +189,18 @@ func (p *projectMetadataAPI) validate(ctx context.Context, projectID int64, meta
 		}
 		metas[proModels.ProMetaMaxUpstreamConn] = strconv.FormatInt(v, 10)
 	case proModels.ProMetaProxyCacheFilterPattern:
-		if p.proCtl != nil {
-			pro, err := p.proCtl.Get(ctx, projectID)
-			if err != nil {
-				return nil, err
-			}
-			if !pro.IsProxy() {
-				return nil, errors.New(nil).WithCode(errors.BadRequestCode).WithMessage("can not update the normal project with proxy cache filter metadata")
-			}
+		if err := p.requireProxyProject(ctx, projectID); err != nil {
+			return nil, err
 		}
-		// plain pattern string; empty means match all — no further validation needed at metadata level
-		kind := pattern.KindDoublestar
-		if k, ok := metas[proModels.ProMetaProxyCacheFilterKind]; ok && k != "" {
+		// The API accepts one key per request, so the effective kind is
+		// whatever is already stored; empty means the doublestar default.
+		var kind string
+		existing, err := p.ctl.Get(ctx, projectID, proModels.ProMetaProxyCacheFilterKind)
+		if err != nil {
+			return nil, err
+		}
+		if k, ok := existing[proModels.ProMetaProxyCacheFilterKind]; ok {
 			kind = k
-		} else if p.ctl != nil {
-			existing, err := p.ctl.Get(ctx, projectID, proModels.ProMetaProxyCacheFilterKind)
-			if err != nil {
-				return nil, err
-			}
-			if k, ok := existing[proModels.ProMetaProxyCacheFilterKind]; ok && k != "" {
-				kind = k
-			}
 		}
 		if err := pattern.ValidateRepositoryFilter(value, kind); err != nil {
 			return nil, errors.New(nil).WithCode(errors.BadRequestCode).
@@ -219,41 +208,23 @@ func (p *projectMetadataAPI) validate(ctx context.Context, projectID int64, meta
 		}
 		metas[proModels.ProMetaProxyCacheFilterPattern] = value
 	case proModels.ProMetaProxyCacheFilterKind:
-		if p.proCtl != nil {
-			pro, err := p.proCtl.Get(ctx, projectID)
-			if err != nil {
-				return nil, err
-			}
-			if !pro.IsProxy() {
-				return nil, errors.New(nil).WithCode(errors.BadRequestCode).WithMessage("can not update the normal project with proxy cache filter metadata")
-			}
+		if err := p.requireProxyProject(ctx, projectID); err != nil {
+			return nil, err
 		}
-		// must be "doublestar" or "regex" when specified
-		if value != "" && value != pattern.KindRegex && value != pattern.KindDoublestar {
+		if err := pattern.ValidateKind(value); err != nil {
 			return nil, errors.New(nil).WithCode(errors.BadRequestCode).
-				WithMessagef("invalid proxy_cache_filter_kind: %q, must be %q or %q", value, pattern.KindDoublestar, pattern.KindRegex)
+				WithMessagef("invalid proxy_cache_filter_kind: %v", err)
 		}
-		var pat string
-		hasPat := false
-		if patVal, ok := metas[proModels.ProMetaProxyCacheFilterPattern]; ok {
-			pat = patVal
-			hasPat = true
-		} else if p.ctl != nil {
-			if existing, err := p.ctl.Get(ctx, projectID, proModels.ProMetaProxyCacheFilterPattern); err == nil {
-				if patVal, ok := existing[proModels.ProMetaProxyCacheFilterPattern]; ok {
-					pat = patVal
-					hasPat = true
-				}
-			}
+		// The new kind must keep the stored pattern (the only possible source,
+		// since the API accepts one key per request) compilable.
+		existing, err := p.ctl.Get(ctx, projectID, proModels.ProMetaProxyCacheFilterPattern)
+		if err != nil {
+			return nil, err
 		}
-		if hasPat && pat != "" {
-			kind := value
-			if kind == "" {
-				kind = pattern.KindDoublestar
-			}
-			if err := pattern.ValidateRepositoryFilter(pat, kind); err != nil {
+		if pat, ok := existing[proModels.ProMetaProxyCacheFilterPattern]; ok && pat != "" {
+			if err := pattern.ValidateRepositoryFilter(pat, value); err != nil {
 				return nil, errors.New(nil).WithCode(errors.BadRequestCode).
-					WithMessagef("existing proxy_cache_filter_pattern %q is invalid for new kind %q: %v", pat, kind, err)
+					WithMessagef("existing proxy_cache_filter_pattern %q is invalid for new kind %q: %v", pat, value, err)
 			}
 		}
 		metas[proModels.ProMetaProxyCacheFilterKind] = value
@@ -261,4 +232,17 @@ func (p *projectMetadataAPI) validate(ctx context.Context, projectID int64, meta
 		return nil, errors.New(nil).WithCode(errors.BadRequestCode).WithMessagef("invalid key: %s", key)
 	}
 	return metas, nil
+}
+
+// requireProxyProject rejects proxy-cache-filter metadata changes on projects
+// that are not proxy cache projects.
+func (p *projectMetadataAPI) requireProxyProject(ctx context.Context, projectID int64) error {
+	pro, err := p.proCtl.Get(ctx, projectID)
+	if err != nil {
+		return err
+	}
+	if !pro.IsProxy() {
+		return errors.New(nil).WithCode(errors.BadRequestCode).WithMessage("can not update the normal project with proxy cache filter metadata")
+	}
+	return nil
 }

--- a/src/server/v2.0/handler/project_metadata_test.go
+++ b/src/server/v2.0/handler/project_metadata_test.go
@@ -31,7 +31,7 @@ import (
 
 type fakeMetadataController struct {
 	metadata.Controller
-	getFunc func(ctx context.Context, projectID int64, meta ...string) (map[string]string, error)
+	getFunc    func(ctx context.Context, projectID int64, meta ...string) (map[string]string, error)
 	deleteFunc func(ctx context.Context, projectID int64, meta ...string) error
 }
 


### PR DESCRIPTION
Backport of the second commit from #588 (`ef3f62694` on `main`) to `release-2.15`. Applied clean, no conflicts.

Fixes from the review of the filter feature: regex anchoring escape via group-imbalanced patterns, swallowed store error on kind change (could fail-close all pulls), inconsistent empty-kind handling between write paths (now shared `pattern.ValidateKind`), audit resolver name/ID ambiguity for all-digit project names, plus cleanups (dead lookups, nil-guards, duplicated regexes/guards). Also submitted upstream as goharbor/harbor#23762.

**Stacked on #653** — its base is the #653 branch so it shows only its own commit. After #653 merges, retarget this PR to `release-2.15` before merging.

Verified on the stacked state: `go build ./...` and unit tests for `lib/pattern`, `auditext/event/project`, `repoproxy`, `v2.0/handler` green.