### PR TITLE
fix: Carry X-Is-Resource-Name Header Into Audit Metadata

### DIFF
--- a/src/controller/event/metadata/commonevent/model.go
+++ b/src/controller/event/metadata/commonevent/model.go
@@ -58,6 +58,9 @@ type Metadata struct {
 	ResponseCode int
 	// RequestURL request URL
 	RequestURL string
+	// IsResourceName indicates the request declared, via the X-Is-Resource-Name
+	// header, that name/ID path parameters are resource names
+	IsResourceName bool
 	// IPAddress IP address of the request
 	IPAddress string
 	// ResponseLocation response location

--- a/src/lib/pattern/matcher.go
+++ b/src/lib/pattern/matcher.go
@@ -44,7 +44,7 @@ func ValidateKind(kind string) error {
 	case "", KindRegex, KindDoublestar:
 		return nil
 	default:
-		return errors.Errorf("unsupported repository filter kind %q, must be %q or %q", kind, KindDoublestar, KindRegex)
+		return errors.Errorf("unsupported repository filter kind %q, must be %q, %q, or empty (defaults to %q)", kind, KindDoublestar, KindRegex, KindDoublestar)
 	}
 }
 

--- a/src/pkg/auditext/event/project/project.go
+++ b/src/pkg/auditext/event/project/project.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"fmt"
 	"net/http"
-	"net/url"
 	"regexp"
 	"strconv"
 	"time"
@@ -68,7 +67,7 @@ func (r *resolver) Resolve(ce *commonevent.Metadata, evt *event.Event) error {
 		ctx = orm.Clone(ctx)
 	}
 
-	proj, err := getProject(ctx, projStr, isResourceName(ce.RequestURL))
+	proj, err := getProject(ctx, projStr, ce.IsResourceName)
 	if err != nil {
 		return fmt.Errorf("failed to get project: %v", err)
 	}
@@ -115,17 +114,10 @@ func getProjectNameOrID(url string) string {
 	return ""
 }
 
-// isResourceName reports whether the request URL carries x_is_resource_name=true,
-// which forces the path segment to be treated as a project name even when it is
-// all digits — mirroring parseProjectNameOrID in the API handlers.
-func isResourceName(requestURL string) bool {
-	u, err := url.Parse(requestURL)
-	if err != nil {
-		return false
-	}
-	return u.Query().Get("x_is_resource_name") == "true"
-}
-
+// getProject resolves the path segment to a project. isName comes from the
+// X-Is-Resource-Name header and forces the segment to be treated as a project
+// name even when it is all digits — mirroring parseProjectNameOrID in the API
+// handlers.
 func getProject(ctx context.Context, str string, isName bool) (*models.Project, error) {
 	var projectNameOrID any = str
 	if !isName {

--- a/src/pkg/auditext/event/project/project_test.go
+++ b/src/pkg/auditext/event/project/project_test.go
@@ -138,13 +138,14 @@ func TestProjectEventResolver_Resolve(t *testing.T) {
 		assert.True(t, data.IsSuccessful)
 	})
 
-	t.Run("Resolve all-digit project name with x_is_resource_name", func(t *testing.T) {
+	t.Run("Resolve all-digit project name with X-Is-Resource-Name", func(t *testing.T) {
 		ce := &commonevent.Metadata{
-			Ctx:           context.Background(),
-			Username:      "admin",
-			RequestURL:    "/api/v2.0/projects/123?x_is_resource_name=true",
-			RequestMethod: "PUT",
-			ResponseCode:  http.StatusOK,
+			Ctx:            context.Background(),
+			Username:       "admin",
+			RequestURL:     "/api/v2.0/projects/123",
+			RequestMethod:  "PUT",
+			ResponseCode:   http.StatusOK,
+			IsResourceName: true,
 		}
 		evt := &event.Event{}
 		err := r.Resolve(ce, evt)

--- a/src/server/middleware/log/log.go
+++ b/src/server/middleware/log/log.go
@@ -17,6 +17,7 @@ package log //nolint:revive
 import (
 	"io"
 	"net/http"
+	"strconv"
 
 	"github.com/goharbor/harbor/src/common/security"
 	"github.com/goharbor/harbor/src/controller/event/metadata/commonevent"
@@ -45,11 +46,13 @@ func Middleware() func(http.Handler) http.Handler {
 			r = r.WithContext(ctx)
 		}
 
+		isResourceName, _ := strconv.ParseBool(r.Header.Get("X-Is-Resource-Name"))
 		e := &commonevent.Metadata{
-			Ctx:           r.Context(),
-			Username:      "unknown",
-			RequestMethod: r.Method,
-			RequestURL:    r.URL.String(),
+			Ctx:            r.Context(),
+			Username:       "unknown",
+			RequestMethod:  r.Method,
+			RequestURL:     r.URL.String(),
+			IsResourceName: isResourceName,
 		}
 		if matched, resName := e.PreCheckMetadata(); matched {
 			lib.NopCloseRequest(r)


### PR DESCRIPTION
Follow-up to #588, addressing cubic review findings surfaced on the 2.15 backport (#654) — the same code is on `main`, so it needs the fix here too.

- **P1**: `X-Is-Resource-Name` is a header parameter (see `api/v2.0/swagger.yaml`), not a query parameter, so the project audit resolver's `isResourceName(ce.RequestURL)` could never see it and still resolved all-digit project names as project IDs. The log middleware now captures the header into `commonevent.Metadata.IsResourceName` and the resolver uses that. (The removed query check read `x_is_resource_name`, a parameter the API never accepts.)
- **P3**: `pattern.ValidateKind` error message now lists empty as an accepted value (doublestar default), matching its actual behavior.

Same change applied to the upstream PR (goharbor/harbor#23762, second commit) and stacked on the 2.15 backport (#654).