### PR TITLE
ci: Filter CodeQL Reflected-XSS False Positive in Response Recorder

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -54,3 +54,28 @@ jobs:
         uses: github/codeql-action/analyze@f205ea1c3313d32999d8d6a48b4f6530d4437b38 # v4.37.4
         with:
           category: "/language:${{ matrix.language }}"
+          output: sarif-results
+          # The go results are filtered below before upload; failure-only keeps
+          # diagnostics visible on the tool status page if the analysis fails.
+          upload: ${{ matrix.language == 'go' && 'failure-only' || 'always' }}
+
+      # go/reflected-xss at src/lib/response_recorder.go is a false positive:
+      # CodeQL over-approximates the logger's io.Writer dispatch and assumes
+      # log output can reach the HTTP response recorder, but core loggers only
+      # ever write to stdout, log files, or syslog. Drop that single result
+      # before upload; all other alerts pass through unchanged.
+      - name: Filter false positives
+        if: matrix.language == 'go'
+        uses: advanced-security/filter-sarif@2da736ff05ef065cb2894ac6892e47b5eac2c3c0 # v1.1
+        with:
+          patterns: |
+            -src/lib/response_recorder.go:go/reflected-xss
+          input: sarif-results/go.sarif
+          output: sarif-results/go.sarif
+
+      - name: Upload filtered SARIF
+        if: matrix.language == 'go'
+        uses: github/codeql-action/upload-sarif@f205ea1c3313d32999d8d6a48b4f6530d4437b38 # v4.37.4
+        with:
+          sarif_file: sarif-results/go.sarif
+          category: "/language:go"


### PR DESCRIPTION
## Summary

Resolves CodeQL alert [#228](https://github.com/container-registry/harbor-next/security/code-scanning/228) — `go/reflected-xss` (high) at `src/lib/response_recorder.go:38` — which has been open on `main` since 2026-07-24 and keeps failing the **CodeQL** check on unrelated PRs (most recently #659).

## Why it is a false positive

The SARIF taint paths all follow the same shape:

```
user input (OIDC redirect_url query, login principal, UAA token URL)
  → log.Errorf / log.Debugf
  → Logger.output() → l.out.Write(formatted line)      src/lib/log/logger.go
  → ResponseRecorder.Write                             src/lib/response_recorder.go:38
```

The last hop only exists because CodeQL over-approximates the `io.Writer` interface dispatch on `l.out` to every `Write([]byte)` implementation in the codebase, including the HTTP `ResponseRecorder`. In reality core loggers only ever write to stdout, job log files, or syslog — a log line can never reach an HTTP response.

## Why it fails unrelated PRs

GitHub attributes an open alert to a PR when the PR's diff intersects any location on the alert's taint path. The paths run through logging/middleware code, so any PR touching that area (e.g. #659, which edits `src/server/middleware/log/log.go`) gets the month-old alert pinned on it as "1 new alert".

## Fix

Standard GitHub-documented suppression for CodeQL false positives: defer the go SARIF upload (`upload: failure-only` + `output:`), drop the single file+rule result with [`advanced-security/filter-sarif`](https://github.com/advanced-security/filter-sarif) (pinned to v1.1 SHA), then upload via `upload-sarif` with the same category.

- Scope is exactly `src/lib/response_recorder.go` × `go/reflected-xss`; all other alerts — including the open `go/unvalidated-url-redirection` and all JS alerts — pass through unchanged.
- Once this merges, the next scheduled/push scan on `main` no longer reports the result, and GitHub closes alert #228 automatically.
- The JS leg keeps its direct upload path, untouched.

## Verification

- Workflow YAML validated locally.
- `filter-sarif` pattern semantics per its README: minus-only patterns exclude the named result, everything else is included by default.
- SARIF filename `go.sarif` matches the CodeQL language name used by the analyze step.