### PR TITLE
fix: Show Ellipsis For Truncated Tags In Artifact List

### DIFF
--- a/src/portal/src/app/base/project/repository/artifact/artifact-list-page/artifact-list/artifact-list-tab/artifact-list-tab.component.html
+++ b/src/portal/src/app/base/project/repository/artifact/artifact-list-page/artifact-list/artifact-list-tab/artifact-list-tab.component.html
@@ -334,11 +334,12 @@
                                     </span>
 
                                     <span
+                                        class="tag-cell-count"
                                         *ngIf="
                                             artifact?.tags?.length > 1 &&
                                             isEllipsisActive(tagsSpan)
                                         "
-                                        >({{ artifact?.tagNumber }} )</span
+                                        >({{ artifact?.tagNumber }})</span
                                     >
                                     <app-pull-command
                                         *ngIf="artifact?.tags?.length > 0"

--- a/src/portal/src/app/base/project/repository/artifact/artifact-list-page/artifact-list/artifact-list-tab/artifact-list-tab.component.scss
+++ b/src/portal/src/app/base/project/repository/artifact/artifact-list-page/artifact-list/artifact-list-tab/artifact-list-tab.component.scss
@@ -214,6 +214,15 @@
   flex: 1 1 auto;
   width: auto;
   min-width: 0;
+  // .truncated makes the span a flex container, where text-overflow has no
+  // effect; block restores the ellipsis.
+  display: block;
+}
+
+.tag-cell-count {
+  flex-shrink: 0;
+  white-space: nowrap;
+  margin-left: 2px;
 }
 
 .tag-copy-command {

--- a/src/portal/src/app/base/project/repository/artifact/artifact-list-page/artifact-list/artifact-list-tab/artifact-list-tab.component.scss
+++ b/src/portal/src/app/base/project/repository/artifact/artifact-list-page/artifact-list/artifact-list-tab/artifact-list-tab.component.scss
@@ -216,8 +216,10 @@
   min-width: 0;
 
   // .truncated makes the span a flex container, where text-overflow has no
-  // effect; block restores the ellipsis.
+  // effect; block restores the ellipsis. height: auto drops .truncated's
+  // fixed 25px box so the parent flexbox recenters the 20px line box.
   display: block;
+  height: auto;
 }
 
 .tag-cell-count {

--- a/src/portal/src/app/base/project/repository/artifact/artifact-list-page/artifact-list/artifact-list-tab/artifact-list-tab.component.scss
+++ b/src/portal/src/app/base/project/repository/artifact/artifact-list-page/artifact-list/artifact-list-tab/artifact-list-tab.component.scss
@@ -214,6 +214,7 @@
   flex: 1 1 auto;
   width: auto;
   min-width: 0;
+
   // .truncated makes the span a flex container, where text-overflow has no
   // effect; block restores the ellipsis.
   display: block;


### PR DESCRIPTION
## Summary

Fork-native replacement for #553 (upstream goharbor/harbor#23607, issue goharbor/harbor#23110).

Our tag cell already uses a flex layout (`.tag-cell-content`, added with the pull-command button), so the actual overlap bug from goharbor/harbor#23110 does not reproduce here. What does remain is its root cause: `.truncated` makes the tag span a **flex container**, and `text-overflow: ellipsis` has no effect on flex containers — long tag lists hard-clip mid-character with no `…`, and the count badge sits flush against the text: `v2.13.1-rc(30 )`.

This applies the same remedy as upstream's fix without replacing our cell markup (which would have deleted `app-pull-command`):

- `display: block` on `.tag-cell-text` → restores the ellipsis
- new `.tag-cell-count` class on the count badge → `flex-shrink: 0`, `white-space: nowrap`, `margin-left: 2px`
- drop the stray space inside the badge (`(30 )` → `(30)`), matching upstream

Rendered result: `v2.13.1… (30) ⧉`.

## Verification

Reproduced all variants (upstream pre-fix, our current, upstream fix, this fix) in a static page with the exact DOM + component CSS and the real `isEllipsisActive` condition (`offsetWidth < scrollWidth`), rendered headless at three cell widths:

| Variant | Result |
|---|---|
| upstream pre-fix | hard clip, no ellipsis (degrades to the #23110 overlap in the datagrid) |
| harbor-next main | no overlap, but hard clip, no ellipsis, badge flush against text |
| upstream fix (#553) | clean ellipsis + spaced badge, but deletes our pull-command button |
| **this PR** | clean ellipsis + spaced badge, pull-command intact |

Closes #553.
