### PR TITLE
ci: Use Renumbered Commercial Patch Branches

### DIFF
--- a/taskfile/commercial-patches
+++ b/taskfile/commercial-patches
@@ -1,7 +1,9 @@
 # Ordered commercial patches for Harbor Next main.
-0001-branding
-0002-sftp-replication
-0003-identity-providers
-0004-pgx-monitoring
-0005-aws-rds-iam-auth
-0006-multi-format-artifacts
+0001-commercial-feature-gate
+0002-branding
+0003-sftp-replication
+0004-identity-providers
+0005-pgx-monitoring
+0006-aws-rds-iam-auth
+0007-multi-format-artifacts
+0008-audit-log-otel


### PR DESCRIPTION
Switches `taskfile/commercial-patches` to the renumbered commercial branch set led by `0001-commercial-feature-gate`.

All eight branches have been rebased onto current `main`, restructured so they octopus-merge with zero conflicts (per-feature files for `const.go`/`metadatalist.go`/`core/main.go` registration, branding extracted to its own controller/handler files, dependency management consolidated into the feature-gate branch, distinct insertion anchors in `swagger.yaml`/portal config/i18n), and pushed to the patches repository. `0006-aws-rds-iam-auth` stacks on `0005-pgx-monitoring`; the other seven parent directly on `main`.

Verified locally: fresh octopus merge of all eight onto `main` is conflict-free, `go build ./...` passes, and the full patch-touched test suite is green (also fixes a latent `RecordPull` arity mismatch in the gomod registry and missing pull-recording in the PyPI distribution handler inside `0007-multi-format-artifacts`).

The old branch set (`0001-branding` … `0006-multi-format-artifacts`, `0007-audit-log-otel`) will be deleted from the patches repository after this merges.