### PR TITLE
ci: Use Renumbered Commercial Patch Branches for release-2.15

### DIFF
--- a/taskfile/commercial-patches
+++ b/taskfile/commercial-patches
@@ -1,6 +1,7 @@
 # Ordered commercial patches for Harbor Next release-2.15.
-0001-branding
-0002-sftp-replication
-0003-identity-providers
-0004-pgx-monitoring
-0005-aws-rds-iam-auth
+release-2.15/0001-commercial-feature-gate
+release-2.15/0002-branding
+release-2.15/0003-sftp-replication
+release-2.15/0004-identity-providers
+release-2.15/0005-pgx-monitoring
+release-2.15/0006-aws-rds-iam-auth


### PR DESCRIPTION
Backports the renumbered commercial patch set to `release-2.15`, pointing the manifest at release-scoped branch copies on the patches repository:

`release-2.15/0001-commercial-feature-gate` … `release-2.15/0006-aws-rds-iam-auth` — parented on the current `release-2.15` tip, with `0006-aws-rds-iam-auth` stacked on `0005-pgx-monitoring`. **Excludes** `0007-multi-format-artifacts` and `0008-audit-log-otel` by design.

This also unbreaks Release Ready on this branch: the old-named branches its manifest referenced were deleted when `main` switched to the renumbered set (#673).

As part of this, the feature gate's config validation was decoupled from the audit-log feature (a `RegisterConfigUpdateValidator` hook in `pkg/commercial`; the OTLP guard now registers itself from the audit-log branch) — without that, the gate didn't compile when audit-log is excluded. The updated `0001`/`0008` are also pushed for `main`.

Verified locally on both lines: fresh octopus merges are conflict-free, `go build ./...` passes, affected package tests green.