### PR TITLE
upstream: fix: convert robot account ID columns and sequence to bigint (goharbor/harbor#23633)

### DIFF
--- a/api/v2.0/swagger.yaml
+++ b/api/v2.0/swagger.yaml
@@ -6532,6 +6532,7 @@ parameters:
     description: Robot ID
     required: true
     type: integer
+    format: int64
   gcId:
     name: gc_id
     in: path
@@ -8070,6 +8071,7 @@ definitions:
         description: The type of the robot creator, like local(harbor_user) or robot.
       creator_ref:
         type: integer
+        format: int64
         description: The reference of the robot creator, like the id of harbor user.
       creation_time:
         type: string

--- a/make/migrations/postgresql/0182_2.15.7_schema.up.sql
+++ b/make/migrations/postgresql/0182_2.15.7_schema.up.sql
@@ -1,0 +1,7 @@
+/*
+Convert the robot account ID columns to bigint to avoid running out of the int4 range, issue #23091.
+*/
+ALTER TABLE robot ALTER COLUMN id TYPE bigint;
+ALTER TABLE robot ALTER COLUMN creator_ref TYPE bigint;
+ALTER TABLE role_permission ALTER COLUMN role_id TYPE bigint;
+ALTER SEQUENCE robot_id_seq AS bigint MAXVALUE 9007199254740991;

--- a/src/controller/scan/base_controller.go
+++ b/src/controller/scan/base_controller.go
@@ -762,7 +762,7 @@ func scanTaskForArtifacts(task *task.Task, artifactMap map[int64]any) bool {
 	if task == nil {
 		return false
 	}
-	artifactID := int64(task.GetNumFromExtraAttrs(artifactIDKey))
+	artifactID := task.GetInt64FromExtraAttrs(artifactIDKey)
 	if artifactID == 0 {
 		return false
 	}
@@ -1118,14 +1118,7 @@ func (bc *basicController) isAccessory(ctx context.Context, art *ar.Artifact) (b
 }
 
 func getArtifactID(extraAttrs map[string]any) int64 {
-	var artifactID float64
-	if extraAttrs != nil {
-		if v, ok := extraAttrs[artifactIDKey]; ok {
-			artifactID, _ = v.(float64) // int64 Unmarshal to float64
-		}
-	}
-
-	return int64(artifactID)
+	return int64FromExtraAttrs(extraAttrs, artifactIDKey)
 }
 
 func getArtifactTag(extraAttrs map[string]any) string {
@@ -1159,14 +1152,20 @@ func GetReportUUIDs(extraAttrs map[string]any) []string {
 }
 
 func getRobotID(extraAttrs map[string]any) int64 {
-	var trackID float64
-	if extraAttrs != nil {
-		if v, ok := extraAttrs[robotIDKey]; ok {
-			trackID, _ = v.(float64) // int64 Unmarshal to float64
-		}
-	}
+	return int64FromExtraAttrs(extraAttrs, robotIDKey)
+}
 
-	return int64(trackID)
+// int64FromExtraAttrs gets the int64 value specified by key from the extra attributes
+func int64FromExtraAttrs(extraAttrs map[string]any, key string) int64 {
+	if extraAttrs == nil {
+		return 0
+	}
+	v, ok := extraAttrs[key]
+	if !ok || v == nil {
+		return 0
+	}
+	id, _ := task.Int64FromAny(v)
+	return id
 }
 
 func parseOptions(options ...Option) (*Options, error) {

--- a/src/controller/scan/callback_test.go
+++ b/src/controller/scan/callback_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/goharbor/harbor/src/jobservice/job"
 	"github.com/goharbor/harbor/src/lib/orm"
 	"github.com/goharbor/harbor/src/pkg/task"
+	taskdao "github.com/goharbor/harbor/src/pkg/task/dao"
 	artifacttesting "github.com/goharbor/harbor/src/testing/controller/artifact"
 	robottesting "github.com/goharbor/harbor/src/testing/controller/robot"
 	ormtesting "github.com/goharbor/harbor/src/testing/lib/orm"
@@ -171,10 +172,46 @@ func (suite *CallbackTestSuite) TestScanAllCallback() {
 func (suite *CallbackTestSuite) makeExtraAttrs(artifactID, robotID int64) map[string]any {
 	b, _ := json.Marshal(map[string]any{artifactIDKey: artifactID, robotIDKey: robotID})
 
-	extraAttrs := map[string]any{}
-	json.Unmarshal(b, &extraAttrs)
+	daoTask := &taskdao.Task{
+		ExtraAttrs: string(b),
+	}
+	tsk := &task.Task{}
+	tsk.From(daoTask)
 
-	return extraAttrs
+	return tsk.ExtraAttrs
+}
+
+func TestGetRobotID_LargeID(t *testing.T) {
+	largeID := int64(9007199254740993)
+
+	b, _ := json.Marshal(map[string]any{robotIDKey: largeID, artifactIDKey: largeID})
+	daoTask := &taskdao.Task{
+		ExtraAttrs: string(b),
+	}
+	tsk := &task.Task{}
+	tsk.From(daoTask)
+
+	gotRobotID := getRobotID(tsk.ExtraAttrs)
+	if gotRobotID != largeID {
+		t.Errorf("getRobotID() = %d, want %d", gotRobotID, largeID)
+	}
+
+	gotArtifactID := getArtifactID(tsk.ExtraAttrs)
+	if gotArtifactID != largeID {
+		t.Errorf("getArtifactID() = %d, want %d", gotArtifactID, largeID)
+	}
+}
+
+func TestGetRobotID_LegacyFloat64(t *testing.T) {
+	// old data decoded without UseNumber comes in as float64
+	extraAttrs := map[string]any{robotIDKey: float64(12345), artifactIDKey: float64(67890)}
+
+	if got := getRobotID(extraAttrs); got != 12345 {
+		t.Errorf("getRobotID() = %d, want 12345", got)
+	}
+	if got := getArtifactID(extraAttrs); got != 67890 {
+		t.Errorf("getArtifactID() = %d, want 67890", got)
+	}
 }
 
 func TestCallbackTestSuite(t *testing.T) {

--- a/src/controller/scandataexport/execution.go
+++ b/src/controller/scandataexport/execution.go
@@ -185,8 +185,12 @@ func (c *controller) convertToExportExecStatus(ctx context.Context, exec *task.E
 		EndTime:       exec.EndTime,
 	}
 	if pids, ok := exec.ExtraAttrs[export.ProjectIDsAttribute]; ok {
-		for _, pid := range pids.([]any) {
-			execStatus.ProjectIDs = append(execStatus.ProjectIDs, int64(pid.(float64)))
+		if list, ok := pids.([]any); ok {
+			for _, pid := range list {
+				if id, ok := task.Int64FromAny(pid); ok {
+					execStatus.ProjectIDs = append(execStatus.ProjectIDs, id)
+				}
+			}
 		}
 	}
 	if digest, ok := exec.ExtraAttrs[export.DigestKey]; ok {

--- a/src/pkg/task/execution.go
+++ b/src/pkg/task/execution.go
@@ -15,6 +15,7 @@
 package task
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"sync"
@@ -356,7 +357,9 @@ func (e *executionManager) populateExecution(ctx context.Context, execution *dao
 
 	if len(execution.ExtraAttrs) > 0 {
 		extras := map[string]any{}
-		if err := json.Unmarshal([]byte(execution.ExtraAttrs), &extras); err != nil {
+		d := json.NewDecoder(bytes.NewReader([]byte(execution.ExtraAttrs)))
+		d.UseNumber()
+		if err := d.Decode(&extras); err != nil {
 			log.Errorf("failed to unmarshal the extra attributes of execution %d: %v", execution.ID, err)
 		} else {
 			exec.ExtraAttrs = extras

--- a/src/pkg/task/execution_test.go
+++ b/src/pkg/task/execution_test.go
@@ -15,6 +15,8 @@
 package task
 
 import (
+	"encoding/json"
+	"fmt"
 	"testing"
 	"time"
 
@@ -227,6 +229,38 @@ func (e *executionManagerTestSuite) TestGet() {
 	e.Equal(int64(1), exec.Metrics.TaskCount)
 	e.Equal(int64(1), exec.Metrics.SuccessTaskCount)
 	e.execDAO.AssertExpectations(e.T())
+}
+
+func (e *executionManagerTestSuite) TestGet_LargeIDInExtraAttrs() {
+
+	largeID := int64(9007199254740993)
+	extraAttrsJSON := fmt.Sprintf(`{"project_ids": [%d]}`, largeID)
+	e.execDAO.On("Get", mock.Anything, mock.Anything).Return(&dao.Execution{
+		ID:         1,
+		Status:     job.SuccessStatus.String(),
+		ExtraAttrs: extraAttrsJSON,
+	}, nil)
+	e.execDAO.On("GetMetrics", mock.Anything, mock.Anything).Return(&dao.Metrics{}, nil)
+
+	exec, err := e.execMgr.Get(nil, 1)
+	e.Require().Nil(err)
+	e.Require().NotNil(exec.ExtraAttrs)
+
+	pids, ok := exec.ExtraAttrs["project_ids"]
+	e.Require().True(ok)
+	pidList, ok := pids.([]any)
+	e.Require().True(ok)
+	e.Require().Len(pidList, 1)
+
+	// verify that the ID is preserved as exact json.Number
+	num, ok := pidList[0].(json.Number)
+	e.Require().True(ok)
+	e.Equal("9007199254740993", num.String())
+
+	// verify conversion via Int64FromAny
+	id, ok := Int64FromAny(pidList[0])
+	e.Require().True(ok)
+	e.Equal(largeID, id)
 }
 
 func (e *executionManagerTestSuite) TestList() {

--- a/src/pkg/task/model.go
+++ b/src/pkg/task/model.go
@@ -15,7 +15,10 @@
 package task
 
 import (
+	"bytes"
 	"encoding/json"
+	"math"
+	"strconv"
 	"time"
 
 	"github.com/goharbor/harbor/src/jobservice/job"
@@ -104,7 +107,9 @@ func (t *Task) From(task *dao.Task) {
 	t.StatusRevision = task.StatusRevision
 	if len(task.ExtraAttrs) > 0 {
 		extras := map[string]any{}
-		if err := json.Unmarshal([]byte(task.ExtraAttrs), &extras); err != nil {
+		d := json.NewDecoder(bytes.NewReader([]byte(task.ExtraAttrs)))
+		d.UseNumber()
+		if err := d.Decode(&extras); err != nil {
 			log.Errorf("failed to unmarshal the extra attributes of task %d: %v", task.ID, err)
 			return
 		}
@@ -153,11 +158,65 @@ func (t *Task) GetNumFromExtraAttrs(key string) float64 {
 	if !exist {
 		return 0
 	}
-	v, ok := rt.(float64)
-	if !ok {
+	switch v := rt.(type) {
+	case float64:
+		return v
+	case json.Number:
+		f, _ := v.Float64()
+		return f
+	case int64:
+		return float64(v)
+	case int:
+		return float64(v)
+	}
+	return 0
+}
+
+// GetInt64FromExtraAttrs returns the int64 value specified by key
+func (t *Task) GetInt64FromExtraAttrs(key string) int64 {
+	if len(t.ExtraAttrs) == 0 {
 		return 0
 	}
-	return v
+	rt, exist := t.ExtraAttrs[key]
+	if !exist {
+		return 0
+	}
+	i, _ := Int64FromAny(rt)
+	return i
+}
+
+// Int64FromAny converts a JSON-decoded value to int64 without losing
+// precision, returns false if the value cannot be represented as an int64
+func Int64FromAny(value any) (int64, bool) {
+	switch v := value.(type) {
+	case int64:
+		return v, true
+	case int:
+		return int64(v), true
+	case int32:
+		return int64(v), true
+	case json.Number:
+		if i, err := v.Int64(); err == nil {
+			return i, true
+		}
+	case string:
+		if i, err := strconv.ParseInt(v, 10, 64); err == nil {
+			return i, true
+		}
+	case float64:
+		// for values decoded without UseNumber, check bounds and integral round-trip
+		if math.IsNaN(v) || math.IsInf(v, 0) {
+			return 0, false
+		}
+		if v < float64(math.MinInt64) || v >= 9223372036854775808.0 {
+			return 0, false
+		}
+		i := int64(v)
+		if float64(i) == v {
+			return i, true
+		}
+	}
+	return 0, false
 }
 
 // Job is the model represents the requested jobservice job

--- a/src/pkg/task/model_test.go
+++ b/src/pkg/task/model_test.go
@@ -1,0 +1,79 @@
+// Copyright Project Harbor Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package task
+
+import (
+	"encoding/json"
+	"fmt"
+	"math"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/goharbor/harbor/src/pkg/task/dao"
+)
+
+func TestTaskFrom_LargeIDInExtraAttrs(t *testing.T) {
+	largeID := int64(9007199254740993)
+	daoTask := &dao.Task{
+		ExtraAttrs: fmt.Sprintf(`{"robot_id": %d, "artifact_id": %d}`, largeID, largeID),
+	}
+
+	tsk := &Task{}
+	tsk.From(daoTask)
+
+	assert.NotNil(t, tsk.ExtraAttrs)
+
+	// Verify UseNumber preserved exact json.Number
+	robotVal, ok := tsk.ExtraAttrs["robot_id"].(json.Number)
+	assert.True(t, ok)
+	assert.Equal(t, "9007199254740993", robotVal.String())
+
+	// Verify GetInt64FromExtraAttrs extracts exact int64
+	assert.Equal(t, largeID, tsk.GetInt64FromExtraAttrs("robot_id"))
+	assert.Equal(t, largeID, tsk.GetInt64FromExtraAttrs("artifact_id"))
+}
+
+func TestInt64FromAny(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   any
+		wantVal int64
+		wantOk  bool
+	}{
+		{"int64", int64(12345), 12345, true},
+		{"int", int(12345), 12345, true},
+		{"int32", int32(12345), 12345, true},
+		{"json.Number valid", json.Number("9007199254740993"), 9007199254740993, true},
+		{"json.Number invalid", json.Number("abc"), 0, false},
+		{"string valid", "12345", 12345, true},
+		{"string invalid", "invalid", 0, false},
+		{"float64 exact int", float64(12345.0), 12345, true},
+		{"float64 fractional", float64(12.34), 0, false},
+		{"float64 NaN", math.NaN(), 0, false},
+		{"float64 +Inf", math.Inf(1), 0, false},
+		{"float64 -Inf", math.Inf(-1), 0, false},
+		{"float64 out of range positive", 1e20, 0, false},
+		{"float64 out of range negative", -1e20, 0, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotVal, gotOk := Int64FromAny(tt.input)
+			assert.Equal(t, tt.wantOk, gotOk)
+			assert.Equal(t, tt.wantVal, gotVal)
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Backport of #587 to `release-2.15`.

Cherry-picks upstream Harbor commit `95ed8f0ed` from goharbor/harbor#23633: convert robot account ID columns (`robot.id`, `robot.creator_ref`, `role_permission.role_id`) and sequence `robot_id_seq` to `bigint` to prevent ID exhaustion when creating ephemeral robot accounts in CI/CD, cap the sequence at `9007199254740991` (2^53 − 1) so IDs stay exactly representable as JSON numbers, use `json.Decoder.UseNumber()` + `task.Int64FromAny` so numeric IDs above 2^53 don't lose precision in scan callbacks and data exports, and set `format: int64` on `robotId`/`creator_ref` in `swagger.yaml`.

## Backport Notes

- Code diff from #587 (merge commit `4c6306ed7`) applied cleanly (one trivial offset in `swagger.yaml`).
- Migration renumbered for the patch branch: `0190_2.16.0_schema.up.sql` (appended block on `main`) → new file `0182_2.15.7_schema.up.sql`. The `0181` slot stays reserved to mirror `0181_2.15.3_schema.up.sql` on `main` (Y2K38 fix, #23718 backport pending).
- Re-running these `ALTER`s during a later 2.15 → 2.16 upgrade (migration 0190) is harmless.

## Upstream Context

- Upstream PR: goharbor/harbor#23633
- Upstream commit: 95ed8f0eda8b12c01508babc5e27f64c8404464f
- Fixes: goharbor/harbor#23091

## Testing

- `go build ./pkg/task/... ./controller/scan/... ./controller/scandataexport/...` — pass
- `go test ./pkg/task/... ./controller/scan/... ./controller/scandataexport/...` — pass
