### PR TITLE
fix(chart): extraTemplateManifests silently drops every document after the first

### DIFF
--- a/deploy/chart/templates/extraManifests.yaml
+++ b/deploy/chart/templates/extraManifests.yaml
@@ -6,25 +6,48 @@ Extra manifests - escape hatch for any additional resources
 
 {{/* Static manifests - merged with chart labels */}}
 {{- range .Values.extraManifests }}
----
-{{- $manifest := deepCopy . }}
+{{- $docs := list . }}
+{{- if kindIs "string" . }}
+{{- $docs = regexSplit "(?m)^---" . -1 }}
+{{- end }}
+{{- range $doc := $docs }}
+{{- $manifest := $doc }}
+{{- if kindIs "string" $doc }}
+{{- if trim $doc }}
+{{- $manifest = fromYaml $doc }}
+{{- if $manifest.Error }}{{- fail (printf "invalid YAML in manifest: %s" $manifest.Error) }}{{- end }}
+{{- end }}
+{{- end }}
+{{- if and $manifest (kindIs "map" $manifest) $manifest.kind }}
+{{- $manifest = deepCopy $manifest }}
 {{- $userMeta := default dict $manifest.metadata }}
 {{- $userLabels := default dict $userMeta.labels }}
 {{- $mergedLabels := merge $userLabels $labels }}
 {{- $_ := set $userMeta "labels" $mergedLabels }}
 {{- $_ := set $manifest "metadata" $userMeta }}
-{{- toYaml $manifest }}
+---
+{{ toYaml $manifest }}{{ "\n" }}
+{{- end }}
+{{- end }}
 {{- end }}
 
 {{/* Templated manifests - can use .Values, .Release, etc. */}}
 {{- range .Values.extraTemplateManifests }}
----
-{{- $rendered := tpl . $ | fromYaml }}
-{{- $manifest := deepCopy $rendered }}
+{{- $rendered := tpl . $ }}
+{{- range $docStr := regexSplit "(?m)^---" $rendered -1 }}
+{{- if trim $docStr }}
+{{- $manifest := fromYaml $docStr }}
+{{- if $manifest.Error }}{{- $manifest = dict }}{{- end }}
+{{- if and $manifest (kindIs "map" $manifest) $manifest.kind }}
+{{- $manifest = deepCopy $manifest }}
 {{- $userMeta := default dict $manifest.metadata }}
 {{- $userLabels := default dict $userMeta.labels }}
 {{- $mergedLabels := merge $userLabels $labels }}
 {{- $_ := set $userMeta "labels" $mergedLabels }}
 {{- $_ := set $manifest "metadata" $userMeta }}
-{{- toYaml $manifest }}
+---
+{{ toYaml $manifest }}{{ "\n" }}
+{{- end }}
+{{- end }}
+{{- end }}
 {{- end }}

--- a/deploy/chart/tests/extramanifests_test.yaml
+++ b/deploy/chart/tests/extramanifests_test.yaml
@@ -69,3 +69,163 @@ tests:
     asserts:
       - hasDocuments:
           count: 0
+
+  # Regression: multi-document strings in extraTemplateManifests previously
+  # dropped every document after the first --- separator (issue #667).
+  - it: should render all documents from a multi-document extraTemplateManifests entry
+    set:
+      externalURL: https://harbor.example.com
+      database.host: postgres.example.com
+      harborAdminPassword: Harbor12345
+      extraTemplateManifests:
+        - |
+          apiVersion: v1
+          kind: ConfigMap
+          metadata:
+            name: first
+          ---
+          apiVersion: v1
+          kind: ConfigMap
+          metadata:
+            name: second
+    asserts:
+      - hasDocuments:
+          count: 2
+
+  - it: should render first document from a multi-document extraTemplateManifests entry
+    documentIndex: 0
+    set:
+      externalURL: https://harbor.example.com
+      database.host: postgres.example.com
+      harborAdminPassword: Harbor12345
+      extraTemplateManifests:
+        - |
+          apiVersion: v1
+          kind: ConfigMap
+          metadata:
+            name: first
+          ---
+          apiVersion: v1
+          kind: ConfigMap
+          metadata:
+            name: second
+    asserts:
+      - equal:
+          path: metadata.name
+          value: first
+
+  - it: should render second document from a multi-document extraTemplateManifests entry
+    documentIndex: 1
+    set:
+      externalURL: https://harbor.example.com
+      database.host: postgres.example.com
+      harborAdminPassword: Harbor12345
+      extraTemplateManifests:
+        - |
+          apiVersion: v1
+          kind: ConfigMap
+          metadata:
+            name: first
+          ---
+          apiVersion: v1
+          kind: ConfigMap
+          metadata:
+            name: second
+    asserts:
+      - equal:
+          path: metadata.name
+          value: second
+
+  # Regression: multi-document string entries in extraManifests previously
+  # failed with a type error because the static branch always called deepCopy
+  # on the raw string value before checking its kind.
+  - it: should render first document from a multi-document extraManifests string entry
+    documentIndex: 0
+    set:
+      externalURL: https://harbor.example.com
+      database.host: postgres.example.com
+      harborAdminPassword: Harbor12345
+      extraManifests:
+        - |
+          apiVersion: v1
+          kind: ConfigMap
+          metadata:
+            name: alpha
+          ---
+          apiVersion: v1
+          kind: ConfigMap
+          metadata:
+            name: beta
+    asserts:
+      - equal:
+          path: metadata.name
+          value: alpha
+
+  - it: should render second document from a multi-document extraManifests string entry
+    documentIndex: 1
+    set:
+      externalURL: https://harbor.example.com
+      database.host: postgres.example.com
+      harborAdminPassword: Harbor12345
+      extraManifests:
+        - |
+          apiVersion: v1
+          kind: ConfigMap
+          metadata:
+            name: alpha
+          ---
+          apiVersion: v1
+          kind: ConfigMap
+          metadata:
+            name: beta
+    asserts:
+      - equal:
+          path: metadata.name
+          value: beta
+
+  # Regression: tpl() applied to a full multi-document entry that contains
+  # template directives spanning a --- boundary must resolve correctly before
+  # the rendered output is split into individual documents.
+  - it: should interpolate templates in first document of multi-document extraTemplateManifests entries
+    documentIndex: 0
+    set:
+      externalURL: https://harbor.example.com
+      database.host: postgres.example.com
+      harborAdminPassword: Harbor12345
+      extraTemplateManifests:
+        - |
+          apiVersion: v1
+          kind: ConfigMap
+          metadata:
+            name: {{ .Release.Name }}-first
+          ---
+          apiVersion: v1
+          kind: ConfigMap
+          metadata:
+            name: {{ .Release.Name }}-second
+    asserts:
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-first
+
+  - it: should interpolate templates in second document of multi-document extraTemplateManifests entries
+    documentIndex: 1
+    set:
+      externalURL: https://harbor.example.com
+      database.host: postgres.example.com
+      harborAdminPassword: Harbor12345
+      extraTemplateManifests:
+        - |
+          apiVersion: v1
+          kind: ConfigMap
+          metadata:
+            name: {{ .Release.Name }}-first
+          ---
+          apiVersion: v1
+          kind: ConfigMap
+          metadata:
+            name: {{ .Release.Name }}-second
+    asserts:
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-second


### PR DESCRIPTION
Resolves issue #667.

### What this PR does / why we need it
This fixes a bug in deploy/chart/templates/extraManifests.yaml where multi-document YAML strings in extraTemplateManifests were not being properly split and handled correctly.

The changes also:
- Prevent newline chomping issues.
- Support string arrays safely in extraManifests.

Fixes #667.