### PR TITLE
chore: Fix Build Core Binary From Package Directory, Not Single File

### DIFF
--- a/devenv/air.core.toml
+++ b/devenv/air.core.toml
@@ -8,7 +8,7 @@ tmp_dir = "tmp"
 [build]
   # Fast build by default. Set DEBUG=true to enable Delve step-through debugging:
   #   docker compose exec core env DEBUG=true air -c devenv/air.core.toml
-  cmd = "cd src && CGO_ENABLED=0 GOMODCACHE=/go/pkg/mod /usr/local/go/bin/go build ${DEBUG:+-gcflags=all='-N -l'} -trimpath -o ../tmp/core ./core/main.go"
+  cmd = "cd src && CGO_ENABLED=0 GOMODCACHE=/go/pkg/mod /usr/local/go/bin/go build ${DEBUG:+-gcflags=all='-N -l'} -trimpath -o ../tmp/core ./core/"
 
   bin = "tmp/core"
   args_bin = []

--- a/taskfile/build.yml
+++ b/taskfile/build.yml
@@ -77,7 +77,7 @@ tasks:
       - task: _go-build
         vars:
           PLATFORM: '{{index .MATCH 0}}'
-          MAIN_PATH: ./core/main.go
+          MAIN_PATH: ./core/
           OUTPUT_NAME: core
 
   binary:jobservice:*:


### PR DESCRIPTION
## Problem

`task build:binary:core:*` invokes `go build` on a single file
(`./core/main.go`) rather than the package directory. Go's single-file
build mode only compiles the named file and silently ignores sibling
files in the same package.

This is invisible on a bare checkout, where `main.go` is the only file
in `src/core/`. It breaks the moment a commercial patch adds a second
file to that package — specifically `src/core/commercial.go`, which the
`0001-commercial-feature-gate` patch on `8gcr` adds to declare
`commercialShutdownHooks` (a hook slice `main.go` appends to and reads,
by design, so no two commercial patches need to touch `main.go`'s
`gracefulShutdown` call directly).

Running `task release-images-local` against `release-2.15` after
applying the declared commercial patches fails with:

```
core/main.go:197:36: undefined: commercialShutdownHooks
core/main.go:271:44: undefined: commercialShutdownHooks
```

## Fix

Point `MAIN_PATH` at the package directory (`./core/`) instead of the
single file, so `go build` picks up every `.go` file in
`src/core/` (currently `main.go`, `commercial.go`, and the excluded
`main_test.go`). No other binary target in this Taskfile has more than
one file in its main package, so this is the only one affected.

## Verification

```
task apply-patches
task build:binary:core:linux-amd64   # was failing, now succeeds
task build:all-binaries PLATFORMS=linux/amd64  # full binary set builds clean
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)