### PR TITLE
chore: Pin GOTOOLCHAIN For Vendored Trivy Build

### DIFF
--- a/taskfile/build.yml
+++ b/taskfile/build.yml
@@ -10,6 +10,10 @@ vars:
   GCFLAGS_DEBUG: "all=-N -l"
   VERSION_LDFLAGS: '-X github.com/goharbor/harbor/src/pkg/version.GitCommit={{.GIT_COMMIT}} -X github.com/goharbor/harbor/src/pkg/version.ReleaseVersion={{.VERSION}}'
   PLATFORMS: '{{.PLATFORMS | default .CI_PLATFORMS}}'
+  # Go version pinned in src/go.mod, reused to pin GOTOOLCHAIN for
+  # vendored-source builds (Trivy) so they don't pick up a newer local `go`.
+  GO_VERSION_PIN:
+    sh: awk '/^go /{print $2}' src/go.mod
 
 tasks:
   all-binaries:
@@ -198,7 +202,7 @@ tasks:
         cd "$TRIVY_DIR"
         go mod edit -require github.com/containerd/containerd/v2@v2.3.2
         go mod tidy -e
-        GOEXPERIMENT=jsonv2 CGO_ENABLED=0 GOOS={{.GOOS}} GOARCH={{.GOARCH}} go build -trimpath -o "{{.ROOT_DIR}}/bin/{{.PLATFORM}}/trivy" ./cmd/trivy
+        GOTOOLCHAIN=go{{.GO_VERSION_PIN}} GOEXPERIMENT=jsonv2 CGO_ENABLED=0 GOOS={{.GOOS}} GOARCH={{.GOARCH}} go build -trimpath -o "{{.ROOT_DIR}}/bin/{{.PLATFORM}}/trivy" ./cmd/trivy
 
   binary:trivy-adapter:*:
     desc: "Build harbor-scanner-trivy binary (cross-compiled from source)"


### PR DESCRIPTION
## Problem

`task build:binary:trivy:*` clones `aquasecurity/trivy` from source and
builds it with whatever `go` is on PATH. Trivy uses the still-experimental
`encoding/json/v2` API (`GOEXPERIMENT=jsonv2`), whose surface isn't stable
across Go point releases — go1.27 dropped `json.SkipFunc`, which Trivy
v0.71.2 depends on. A newer local Go toolchain than CI's fails with:

```
# github.com/aquasecurity/trivy/pkg/x/json
pkg/x/json/json.go:109:16: undefined: json.SkipFunc
```

even though release-2.15 itself builds fine on that newer version, since
CI pins Go via `go-version-file: src/go.mod` (go1.26.5) while a local
`task release-images-local` run just uses whatever `go` is on the host.

## Fix

Pin `GOTOOLCHAIN` for the Trivy build to the Go version release-2.15
itself targets (read from `src/go.mod`), so it always builds with a
known-compatible toolchain regardless of the host's `go`.

## Verification

```
task build:binary:trivy:linux-amd64   # was failing locally, now succeeds
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)