### PR TITLE
ci: Harden Release Notes Branch Validation And Ref Derivation

### DIFF
--- a/.github/scripts/update-release-notes.sh
+++ b/.github/scripts/update-release-notes.sh
@@ -83,6 +83,10 @@ node .github/scripts/format-release-notes.mjs \
 
 if [[ -n "${preview_pr_number}" ]]; then
   release_branch="${GITHUB_REF_NAME:?GITHUB_REF_NAME is required for a release PR preview}"
+elif [[ "${GITHUB_REF_TYPE:-}" == "branch" && -n "${GITHUB_REF_NAME:-}" ]]; then
+  # push-triggered path only. Tag-triggered runs (manual recreate on a
+  # tag ref) have GITHUB_REF_NAME=<tag>, not a branch, so fall through.
+  release_branch="${GITHUB_REF_NAME}"
 else
   release_branch=$(github_retry gh release view "${TAG_NAME}" \
     --repo "${GITHUB_REPOSITORY}" \
@@ -124,7 +128,7 @@ if [[ -f "${series}" ]]; then
     branch="${branch%"${branch##*[![:space:]]}"}"
     [[ -z "${branch}" ]] && continue
 
-    if [[ "${branch}" == */* || "${branch}" == *..* ]]; then
+    if ! git check-ref-format --branch "${branch}" >/dev/null 2>&1; then
       echo "Invalid commercial branch name in series: ${branch}" >&2
       exit 1
     fi


### PR DESCRIPTION
Ports two fixes from [#691](https://github.com/container-registry/harbor-next/pull/691) (`release-2.15`) to main's copy of `.github/scripts/update-release-notes.sh`.

## 1. Branch name validation

The commercial-patch-branch validation rejected any name containing `/`:

```sh
if [[ "${branch}" == */* || "${branch}" == *..* ]]; then
```

`release-2.15`'s manifest uses hierarchical names
(`release-2.15/0001-commercial-feature-gate`) and this broke every
release-notes run there. main's own manifest doesn't use hierarchical
names today, so this isn't currently broken here — but it's the same
script, and validating with `git check-ref-format --branch` (matching
`taskfile/release-ready.yml`'s own validation) is strictly more correct
and won't reject anything that currently passes.

## 2. Release-branch derivation

`release_branch` for the cosign-verify snippet came from `gh release
view --json targetCommitish`, which is unreliable for
release-please-created releases — confirmed directly on `release-2.15`'s
v2.15.7 release, where it returned a raw commit SHA instead of a branch
name, producing a `--certificate-identity` that never matched the actual
signing certificate (verify always failed). `GITHUB_REF_NAME` is the real
branch name and is already available in the job that runs this script.

## What's intentionally *not* changed here

On `release-2.15`, cosign runs in an inline `sign` job in
`release-please.yml`, so its `--certificate-identity` workflow path
needed fixing from `publish-images.yml` to `release-please.yml`. On
`main`, cosign signing runs *inside* `publish-images.yml` itself
(invoked via `workflow_call` from `release-please.yml`), so
`publish-images.yml` is already the correct workflow path here — left
unchanged. There's no main-line release yet to verify this against
directly (all releases so far are on `release-2.15`), but this follows
directly from where `cosign sign` actually executes in
`.github/workflows/publish-images.yml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)