### PR TITLE
upstream: Proxy the referrer API to upstream registry with paging and local merge (goharbor/harbor#23237)

### DIFF
--- a/api/v2.0/swagger.yaml
+++ b/api/v2.0/swagger.yaml
@@ -7546,6 +7546,10 @@ definitions:
         type: string
         description: 'Matching mode for proxy_cache_filter_pattern: "doublestar" (default, glob-style with ** support) or "regex". Only has value when the current project is a proxy cache project.'
         x-nullable: true
+      proxy_referrer_api:
+        type: string
+        description: 'Whether the proxy cache project should handle API referrer requests. The valid values are "true", "false".'
+        x-nullable: true
   ProjectSummary:
     type: object
     properties:

--- a/api/v2.0/swagger.yaml
+++ b/api/v2.0/swagger.yaml
@@ -7548,7 +7548,7 @@ definitions:
         x-nullable: true
       proxy_referrer_api:
         type: string
-        description: 'Whether the proxy cache project should handle API referrer requests. The valid values are "true", "false".'
+        description: 'Whether the proxy cache project should proxy OCI 1.1 referrer API requests to the upstream registry. The valid values are "true", "false".'
         x-nullable: true
   ProjectSummary:
     type: object

--- a/make/migrations/postgresql/0182_2.15.8_schema.up.sql
+++ b/make/migrations/postgresql/0182_2.15.8_schema.up.sql
@@ -1,0 +1,1 @@
+ALTER TABLE artifact_accessory ADD COLUMN IF NOT EXISTS source varchar(50) DEFAULT 'local';

--- a/src/controller/proxy/controller.go
+++ b/src/controller/proxy/controller.go
@@ -163,7 +163,7 @@ func (c *controller) UseLocalManifest(ctx context.Context, art lib.ArtifactInfo,
 		return true, nil, nil
 	}
 
-	remoteRepo := getRemoteRepo(art)
+	remoteRepo := GetRemoteRepo(art)
 	exist, desc, err := remote.ManifestExist(remoteRepo, getReference(art)) // HEAD
 	if err != nil {
 		if errors.IsRateLimitError(err) && a != nil { // if rate limit, use local if it exists, otherwise return error
@@ -218,7 +218,7 @@ func manifestListContentTypeKey(rep string, art lib.ArtifactInfo) string {
 
 func (c *controller) ProxyManifest(ctx context.Context, art lib.ArtifactInfo, remote RemoteInterface) (distribution.Manifest, error) {
 	var man distribution.Manifest
-	remoteRepo := getRemoteRepo(art)
+	remoteRepo := GetRemoteRepo(art)
 	ref := getReference(art)
 	man, dig, err := remote.Manifest(remoteRepo, ref)
 	if err != nil {
@@ -283,13 +283,13 @@ func (c *controller) sendManifestPullEvent(ctx context.Context, art lib.Artifact
 }
 
 func (c *controller) HeadManifest(_ context.Context, art lib.ArtifactInfo, remote RemoteInterface) (bool, *distribution.Descriptor, error) {
-	remoteRepo := getRemoteRepo(art)
+	remoteRepo := GetRemoteRepo(art)
 	ref := getReference(art)
 	return remote.ManifestExist(remoteRepo, ref)
 }
 
 func (c *controller) ProxyBlob(ctx context.Context, p *proModels.Project, art lib.ArtifactInfo) (int64, io.ReadCloser, error) {
-	remoteRepo := getRemoteRepo(art)
+	remoteRepo := GetRemoteRepo(art)
 	log.Debugf("The blob doesn't exist, proxy the request to the target server, url:%v", remoteRepo)
 	rHelper, err := NewRemoteHelper(ctx, p.RegistryID, WithSpeed(p.ProxyCacheSpeed()))
 	if err != nil {
@@ -335,8 +335,8 @@ func (c *controller) waitAndPushManifest(ctx context.Context, remoteRepo string,
 	h.CacheContent(ctx, remoteRepo, man, art, r, contType)
 }
 
-// getRemoteRepo get the remote repository name, used in proxy cache
-func getRemoteRepo(art lib.ArtifactInfo) string {
+// GetRemoteRepo get the remote repository name, used in proxy cache
+func GetRemoteRepo(art lib.ArtifactInfo) string {
 	return strings.TrimPrefix(art.Repository, art.ProjectName+"/")
 }
 

--- a/src/controller/proxy/controller_test.go
+++ b/src/controller/proxy/controller_test.go
@@ -220,7 +220,7 @@ func TestProxyCacheRemoteRepo(t *testing.T) {
 	}
 	for _, tt := range cases {
 		t.Run(tt.name, func(t *testing.T) {
-			got := getRemoteRepo(tt.in)
+			got := GetRemoteRepo(tt.in)
 			if got != tt.want {
 				t.Errorf(`(%v) = %v; want "%v"`, tt.in, got, tt.want)
 			}

--- a/src/pkg/accessory/dao/model.go
+++ b/src/pkg/accessory/dao/model.go
@@ -32,6 +32,7 @@ type Accessory struct {
 	SubjectArtifactRepo   string    `orm:"column(subject_artifact_repo)" json:"subject_artifact_repo"`
 	SubjectArtifactDigest string    `orm:"column(subject_artifact_digest)" json:"subject_artifact_digest"`
 	Type                  string    `orm:"column(type)" json:"type"`
+	Source                string    `orm:"column(source)" json:"source"`
 	Size                  int64     `orm:"column(size)" json:"size"`
 	Digest                string    `orm:"column(digest)" json:"digest"`
 	CreationTime          time.Time `orm:"column(creation_time);auto_now_add" json:"creation_time"`

--- a/src/pkg/accessory/manager.go
+++ b/src/pkg/accessory/manager.go
@@ -107,6 +107,7 @@ func (m *manager) Get(ctx context.Context, id int64) (model.Accessory, error) {
 		Digest:            acc.Digest,
 		CreatTime:         acc.CreationTime,
 		Icon:              m.GetIcon(acc.Type),
+		Source:            acc.Source,
 	})
 }
 
@@ -131,6 +132,7 @@ func (m *manager) List(ctx context.Context, query *q.Query) ([]model.Accessory, 
 			Digest:            accD.Digest,
 			CreatTime:         accD.CreationTime,
 			Icon:              m.GetIcon(accD.Type),
+			Source:            accD.Source,
 		})
 		if err != nil {
 			return nil, errors.New(err).WithCode(errors.BadRequestCode)
@@ -149,6 +151,7 @@ func (m *manager) Create(ctx context.Context, accessory model.AccessoryData) (in
 		Size:                  accessory.Size,
 		Digest:                accessory.Digest,
 		Type:                  accessory.Type,
+		Source:                accessory.Source,
 	}
 	return m.dao.Create(ctx, acc)
 }

--- a/src/pkg/accessory/model/accessory.go
+++ b/src/pkg/accessory/model/accessory.go
@@ -95,6 +95,7 @@ type AccessoryData struct {
 	Type              string    `json:"type"`
 	Size              int64     `json:"size"`
 	Digest            string    `json:"digest"`
+	Source            string    `json:"source"`
 	CreatTime         time.Time `json:"creation_time"`
 	Icon              string    `json:"icon"`
 }

--- a/src/pkg/accessory/model/accessory.go
+++ b/src/pkg/accessory/model/accessory.go
@@ -83,21 +83,28 @@ const (
 	// TypeInTotoAttestation identifies an attestation that carries an
 	// application/vnd.in-toto+json payload.
 	TypeInTotoAttestation = "attestation.intoto"
+
+	// TypeLocalReferrer identifies local referrer
+	TypeLocalReferrer = "local"
+
+	// TypeProxyReferrer identifies proxy referrer
+	TypeProxyReferrer = "proxy"
 )
 
 // AccessoryData ...
 type AccessoryData struct {
-	ID                int64     `json:"id"`
-	ArtifactID        int64     `json:"artifact_id"`
-	SubArtifactID     int64     `json:"subject_artifact_id"`
-	SubArtifactRepo   string    `json:"subject_artifact_repo"`
-	SubArtifactDigest string    `json:"subject_artifact_digest"`
-	Type              string    `json:"type"`
-	Size              int64     `json:"size"`
-	Digest            string    `json:"digest"`
-	Source            string    `json:"source"`
-	CreatTime         time.Time `json:"creation_time"`
-	Icon              string    `json:"icon"`
+	ID                int64  `json:"id"`
+	ArtifactID        int64  `json:"artifact_id"`
+	SubArtifactID     int64  `json:"subject_artifact_id"`
+	SubArtifactRepo   string `json:"subject_artifact_repo"`
+	SubArtifactDigest string `json:"subject_artifact_digest"`
+	// Type identifies the type of the accessory, it can be TypeLocalReferrer, TypeProxyReferrer
+	Type      string    `json:"type"`
+	Size      int64     `json:"size"`
+	Digest    string    `json:"digest"`
+	Source    string    `json:"source"`
+	CreatTime time.Time `json:"creation_time"`
+	Icon      string    `json:"icon"`
 }
 
 // Accessory Independent, but linked to an existing subject artifact, which enabling the extensibility of an OCI artifact

--- a/src/pkg/project/models/pro_meta.go
+++ b/src/pkg/project/models/pro_meta.go
@@ -28,5 +28,6 @@ const (
 	ProMetaMaxUpstreamConn           = "max_upstream_conn"
 	ProMetaProxyCacheFilterPattern   = "proxy_cache_filter_pattern" // plain string pattern for proxy cache repository filter
 	ProMetaProxyCacheFilterKind      = "proxy_cache_filter_kind"    // "doublestar" (default) or "regex"
+	ProMetaProxyReferrerAPI          = "proxy_referrer_api"
 	ProMetaProxyCacheLocalOnNotFound = "proxy_cache_local_on_not_found"
 )

--- a/src/pkg/project/models/project.go
+++ b/src/pkg/project/models/project.go
@@ -184,6 +184,15 @@ func (p *Project) MaxUpstreamConnection() int {
 	return int(cnt)
 }
 
+// ProxyReferrerAPI
+func (p *Project) ProxyReferrerAPI() bool {
+	enable, exist := p.GetMetadata(ProMetaProxyReferrerAPI)
+	if !exist {
+		return false
+	}
+	return isTrue(enable)
+}
+
 // ProxyCacheLocalOnNotFound returns true if images should be served from local cache when removed from upstream
 func (p *Project) ProxyCacheLocalOnNotFound() bool {
 	val, exist := p.GetMetadata(ProMetaProxyCacheLocalOnNotFound)

--- a/src/portal/src/app/base/left-side-nav/projects/create-project/create-project.component.html
+++ b/src/portal/src/app/base/left-side-nav/projects/create-project/create-project.component.html
@@ -433,6 +433,37 @@
                         name="proxy_cache_local_on_not_found" />
                 </clr-checkbox-wrapper>
             </clr-checkbox-container>
+            <div
+                class="clr-checkbox-container mt-05"
+                [style.visibility]="
+                    isSystemAdmin && enableProxyCache ? 'visible' : 'hidden'
+                ">
+                <clr-checkbox-wrapper>
+                    <input
+                        id="proxy-referrer-api"
+                        type="checkbox"
+                        clrCheckbox
+                        [(ngModel)]="project.metadata.proxy_referrer_api"
+                        name="proxy-referrer-api" />
+                    <label for="proxy-referrer-api">
+                        {{ 'PROJECT.PROXY_REFERRER_API_LABEL' | translate }}
+                        <clr-tooltip>
+                            <clr-icon
+                                clrTooltipTrigger
+                                shape="info-circle"
+                                size="24"></clr-icon>
+                            <clr-tooltip-content
+                                clrPosition="top-right"
+                                clrSize="lg"
+                                *clrIfOpen>
+                                <span>{{
+                                    'PROJECT.PROXY_REFERRER_API_TIP' | translate
+                                }}</span>
+                            </clr-tooltip-content>
+                        </clr-tooltip>
+                    </label>
+                </clr-checkbox-wrapper>
+            </div>
         </form>
     </div>
     <div class="modal-footer">

--- a/src/portal/src/app/base/left-side-nav/projects/create-project/create-project.component.ts
+++ b/src/portal/src/app/base/left-side-nav/projects/create-project/create-project.component.ts
@@ -420,6 +420,9 @@ export class CreateProjectComponent
                 .proxy_cache_local_on_not_found
                 ? 'true'
                 : 'false',
+            proxy_referrer_api: this.project.metadata.proxy_referrer_api
+                ? 'true'
+                : 'false',
         };
         if (
             this.enableProxyCache &&
@@ -481,6 +484,7 @@ export class CreateProjectComponent
         this.speedLimit = -1;
         this.project.metadata.max_upstream_conn = -1;
         this.project.metadata.proxy_cache_local_on_not_found = false;
+        this.project.metadata.proxy_referrer_api = false;
         this.project.metadata.proxy_cache_filter_pattern = '';
         this.project.metadata.proxy_cache_filter_kind =
             REPOSITORY_FILTER_KIND_DOUBLESTAR;

--- a/src/portal/src/app/base/project/project-config/project-policy-config/project-policy-config.component.html
+++ b/src/portal/src/app/base/project/project-config/project-policy-config/project-policy-config.component.html
@@ -183,6 +183,34 @@
                     </clr-control-error>
                 </div>
             </div>
+            <div class="row-inline ml-2" clrInline>
+                <clr-checkbox-wrapper class="ml-1">
+                    <input
+                        id="proxy_referrer_api"
+                        type="checkbox"
+                        clrCheckbox
+                        [(ngModel)]="projectPolicy.ProxyReferrerAPI"
+                        name="proxy_referrer_api"
+                        [disabled]="!allowUpdateProxyCacheConfiguration" />
+                    <label for="proxy_referrer_api">
+                        {{ 'PROJECT.PROXY_REFERRER_API_LABEL' | translate }}
+                        <clr-tooltip>
+                            <clr-icon
+                                clrTooltipTrigger
+                                shape="info-circle"
+                                size="24"></clr-icon>
+                            <clr-tooltip-content
+                                clrPosition="top-left"
+                                clrSize="lg"
+                                *clrIfOpen>
+                                <span>{{
+                                    'PROJECT.PROXY_REFERRER_API_TIP' | translate
+                                }}</span>
+                            </clr-tooltip-content>
+                        </clr-tooltip>
+                    </label>
+                </clr-checkbox-wrapper>
+            </div>
         </div>
         <clr-checkbox-container
             *ngIf="isSystemAdmin && projectPolicy.ProxyCacheEnabled">

--- a/src/portal/src/app/base/project/project-config/project-policy-config/project-policy-config.component.ts
+++ b/src/portal/src/app/base/project/project-config/project-policy-config/project-policy-config.component.ts
@@ -61,6 +61,7 @@ export class ProjectPolicy {
     ProxySpeedKb?: number | null;
     MaxUpstreamConn?: number | null;
     ProxyCacheLocalOnNotFound?: boolean;
+    ProxyReferrerAPI?: boolean;
     ProxyCacheFilterPattern?: string | null;
     ProxyCacheFilterKind?: string | null;
 
@@ -77,6 +78,7 @@ export class ProjectPolicy {
         this.ProxySpeedKb = -1;
         this.MaxUpstreamConn = -1;
         this.ProxyCacheLocalOnNotFound = false;
+        this.ProxyReferrerAPI = false;
         this.ProxyCacheFilterPattern = null;
         this.ProxyCacheFilterKind = 'doublestar';
     }
@@ -102,6 +104,8 @@ export class ProjectPolicy {
             : -1;
         this.ProxyCacheLocalOnNotFound =
             pro.metadata.proxy_cache_local_on_not_found === 'true';
+        this.ProxyReferrerAPI =
+            pro.metadata.proxy_referrer_api === 'true' ? true : false;
         this.ProxyCacheFilterPattern =
             pro.metadata.proxy_cache_filter_pattern || null;
         this.ProxyCacheFilterKind =

--- a/src/portal/src/app/base/project/project-config/project-policy-config/project.ts
+++ b/src/portal/src/app/base/project/project-config/project-policy-config/project.ts
@@ -40,6 +40,7 @@ export class Project {
         proxy_cache_filter_pattern?: string | null;
         proxy_cache_filter_kind?: string | null;
         proxy_cache_local_on_not_found?: string | boolean;
+        proxy_referrer_api?: string | boolean;
     };
     cve_allowlist?: object;
     constructor() {

--- a/src/portal/src/app/base/project/project.ts
+++ b/src/portal/src/app/base/project/project.ts
@@ -38,6 +38,7 @@ export class Project {
         bandwidth: number;
         max_upstream_conn: number;
         proxy_cache_local_on_not_found?: string | boolean;
+        proxy_referrer_api?: string | boolean;
         proxy_cache_filter_pattern?: string;
         proxy_cache_filter_kind?: string;
     };
@@ -45,6 +46,7 @@ export class Project {
         this.metadata = <any>{};
         this.metadata.public = false;
         this.metadata.max_upstream_conn = -1;
+        this.metadata.proxy_referrer_api = false;
         this.metadata.proxy_cache_filter_pattern = '';
         this.metadata.proxy_cache_filter_kind =
             REPOSITORY_FILTER_KIND_DOUBLESTAR;

--- a/src/portal/src/app/shared/services/project.service.ts
+++ b/src/portal/src/app/shared/services/project.service.ts
@@ -174,6 +174,9 @@ export class ProjectDefaultService extends ProjectService {
                     : '-1',
             proxy_cache_local_on_not_found:
                 projectPolicy.ProxyCacheLocalOnNotFound ? 'true' : 'false',
+            proxy_referrer_api: projectPolicy.ProxyReferrerAPI
+                ? 'true'
+                : 'false',
         };
         if (
             projectPolicy.ProxyCacheFilterPattern !== undefined &&

--- a/src/portal/src/i18n/lang/en-us-lang.json
+++ b/src/portal/src/i18n/lang/en-us-lang.json
@@ -249,6 +249,8 @@
         "PROXY_CACHE_MAX_UPSTREAM_CONN_PLACEHOLDER": "Please enter -1 or an integer greater than 0.",
         "PROXY_CACHE_LOCAL_ON_NOT_FOUND": "Serve stale content when upstream is unavailable",
         "PROXY_CACHE_LOCAL_ON_NOT_FOUND_TOOLTIP": "Enable this to allow this project to keep serving cached content even if the artifact is not found in the upstream registry or the upstream registry is unavailable. This can lead to stale content being served if the upstream registry is unavailable.",
+        "PROXY_REFERRER_API_TIP": "Enable this to proxy OCI 1.1 referrer API requests to the upstream registry.",
+        "PROXY_REFERRER_API_LABEL": "Enable proxy for referrer API",
         "REPOSITORY_FILTER": "Repository filter",
         "REPOSITORY_FILTER_TOOLTIP": "Optional filter to limit which repositories are cached from the upstream registry. 'Doublestar' (default) uses glob-style patterns with ** support (e.g. library/**). 'Regex' uses regular expression patterns, the pattern must match the full repository path (e.g. ^library/.*). Only applies to the current proxy cache projects.",
         "REPOSITORY_FILTER_PLACEHOLDER": "e.g. library/**",

--- a/src/portal/src/i18n/lang/fr-fr-lang.json
+++ b/src/portal/src/i18n/lang/fr-fr-lang.json
@@ -250,6 +250,8 @@
         "PROXY_CACHE_MAX_UPSTREAM_CONN_PLACEHOLDER": "Veuillez entrer -1 ou un entier supérieur à 0.",
         "PROXY_CACHE_LOCAL_ON_NOT_FOUND": "Servir le contenu mis en cache lorsque le registre amont est indisponible",
         "PROXY_CACHE_LOCAL_ON_NOT_FOUND_TOOLTIP": "Activez cette option pour permettre à ce projet de continuer à servir le contenu mis en cache même si l'artefact n'est pas trouvé dans le registre amont ou si le registre amont est indisponible. Cela peut entraîner la diffusion de contenu obsolète si le registre amont est indisponible.",
+        "PROXY_REFERRER_API_TIP": "Cochez cette case pour activer le proxy des requêtes de l'API referrer OCI 1.1 vers le registre en amont.",
+        "PROXY_REFERRER_API_LABEL": "Activer le proxy pour l'API referrer",
         "REPOSITORY_FILTER": "Filtre de dépôt",
         "REPOSITORY_FILTER_TOOLTIP": "Filtre optionnel pour limiter les dépôts mis en cache depuis le registre amont. 'Doublestar' (par défaut) utilise des motifs glob avec support ** (ex. library/**). 'Regex' utilise des expressions régulières, le motif doit correspondre au chemin complet du dépôt (ex. ^library/.*). S'applique uniquement aux projets de cache proxy actuels.",
         "REPOSITORY_FILTER_PLACEHOLDER": "ex. library/**",

--- a/src/server/middleware/repoproxy/proxy.go
+++ b/src/server/middleware/repoproxy/proxy.go
@@ -15,13 +15,21 @@
 package repoproxy
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 	"os"
+	"slices"
+	"strconv"
 	"strings"
 	"time"
+
+	"github.com/opencontainers/go-digest"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 
 	"github.com/goharbor/harbor/src/common/security"
 	"github.com/goharbor/harbor/src/common/security/proxycachesecret"
@@ -30,13 +38,18 @@ import (
 	"github.com/goharbor/harbor/src/controller/proxy"
 	"github.com/goharbor/harbor/src/controller/registry"
 	"github.com/goharbor/harbor/src/lib"
+	libCache "github.com/goharbor/harbor/src/lib/cache"
 	"github.com/goharbor/harbor/src/lib/config"
 	"github.com/goharbor/harbor/src/lib/errors"
 	httpLib "github.com/goharbor/harbor/src/lib/http"
 	"github.com/goharbor/harbor/src/lib/log"
 	"github.com/goharbor/harbor/src/lib/orm"
 	"github.com/goharbor/harbor/src/lib/pattern"
+	"github.com/goharbor/harbor/src/lib/q"
 	"github.com/goharbor/harbor/src/lib/redis"
+	"github.com/goharbor/harbor/src/pkg"
+	"github.com/goharbor/harbor/src/pkg/accessory"
+	accModel "github.com/goharbor/harbor/src/pkg/accessory/model"
 	proModels "github.com/goharbor/harbor/src/pkg/project/models"
 	"github.com/goharbor/harbor/src/pkg/proxy/connection"
 	"github.com/goharbor/harbor/src/pkg/reg/model"
@@ -51,7 +64,16 @@ const (
 	ensureTagInterval              = 10 * time.Second
 	ensureTagMaxRetry              = 60
 	upstreamRegistryLimitOnProject = "UPSTREAM_REGISTRY_LIMIT_ON_PROJECT" // if UPSTREAM_REGISTRY_LIMIT_ON_PROJECT is true, the upstream registry connection is based on project level, by default it is artifact level
+	referrerCacheTTL               = 7 * 24 * time.Hour
+	link                           = "Link"
+	xTotalCount                    = "X-Total-Count"
 )
+
+var proxyHeaderNames = []string{
+	contentType,
+	link,
+	xTotalCount,
+}
 
 var tooManyRequestsError = errors.New("too many requests to upstream registry").WithCode(errors.RateLimitCode)
 
@@ -159,7 +181,6 @@ func serveBlob(w http.ResponseWriter, reader io.Reader, size int64, dig string) 
 	// caller append an error body to the blob stream; returning nil instead leaves
 	// the response short of Content-Length so clients and caches reject it.
 	log.Errorf("failed to stream blob %s after %d of %d bytes: %v", dig, written, size, err)
-
 	return nil
 }
 
@@ -201,7 +222,7 @@ func defaultLibrary(ctx context.Context, registryID int64, a lib.ArtifactInfo) (
 		return false, "", err
 	}
 	if reg.Type != model.RegistryTypeDockerHub {
-		return false, "", err
+		return false, "", nil
 	}
 	name := strings.TrimPrefix(a.Repository, a.ProjectName+"/")
 	if strings.Contains(name, "/") {
@@ -507,4 +528,264 @@ func ensureTagWithRetry(ctx context.Context, te tagEnsurer, art lib.ArtifactInfo
 		}
 		log.Debugf("Failed to ensure tag %+v , error %v", art, err)
 	}
+}
+
+func ProxyReferrerMiddleware() func(http.Handler) http.Handler {
+	return middleware.New(func(w http.ResponseWriter, r *http.Request, next http.Handler) {
+		ctx := r.Context()
+		art := lib.GetArtifactInfo(ctx)
+		p, err := project.Ctl.GetByName(ctx, art.ProjectName)
+		if err != nil {
+			httpLib.SendError(w, err)
+			return
+		}
+		if !p.IsProxy() {
+			next.ServeHTTP(w, r)
+			return
+		}
+
+		if !p.ProxyReferrerAPI() {
+			log.Debug("the proxy referrer API is not enabled for current project, fallback to local registry")
+			next.ServeHTTP(w, r)
+			return
+		}
+
+		log.Debug("current project is a harbor proxy cache project, will proxy the referrer API to the upstream")
+		remote, err := proxy.NewRemoteHelper(r.Context(), p.RegistryID, proxy.WithSpeed(p.ProxyCacheSpeed()))
+		if err != nil {
+			log.Errorf("failed to proxy the referrer API to upstream, error %v, fallback to local registry", err)
+			next.ServeHTTP(w, r)
+			return
+		}
+		// for any error, fallback to local registry
+		if proxyErr := proxyReferrerGet(r, w, art, remote, p.RegistryID); proxyErr != nil {
+			log.Errorf("failed to proxy the referrer API to upstream, error %v, fallback to local registry", proxyErr)
+			next.ServeHTTP(w, r)
+		}
+	})
+}
+
+// referrerCache defines the cache structure for referrer index
+type referrerCache struct {
+	Content []byte              `json:"content"`
+	Header  map[string][]string `json:"header"`
+}
+
+// writeProxyHeaders writes proxy-allowed headers from headerMap to response writer
+func writeProxyHeaders(w http.ResponseWriter, headerMap map[string][]string) {
+	for k, v := range headerMap {
+		if slices.Contains(proxyHeaderNames, k) {
+			for _, hv := range v {
+				w.Header().Add(k, hv)
+			}
+		}
+	}
+}
+
+// referrerCacheKey generates cache key for referrer index
+func referrerCacheKey(requestURI string) string {
+	return fmt.Sprintf("{referrer_cache}:%s", requestURI)
+}
+
+// hasNextLink checks whether the Link header in headerMap contains a rel="next" entry,
+// indicating that there are more pages of results from the upstream.
+func hasNextLink(headerMap map[string][]string) bool {
+	linkValues, ok := headerMap[link]
+	if !ok || len(linkValues) == 0 {
+		return false
+	}
+	for _, lv := range linkValues {
+		links := lib.ParseLinks(lv)
+		for _, l := range links {
+			if l.Rel == "next" {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// rewritePaginationLinks rewrites any Link pagination headers to reference the local Harbor proxy-cache path instead of the upstream remote path.
+func rewritePaginationLinks(headerMap map[string][]string, art lib.ArtifactInfo) {
+	linkValues, ok := headerMap[link]
+	if !ok || len(linkValues) == 0 {
+		return
+	}
+
+	remoteRepo := proxy.GetRemoteRepo(art)
+	localRepo := art.Repository
+
+	remotePathPrefix := "/v2/" + remoteRepo + "/referrers/"
+	localPathPrefix := "/v2/" + localRepo + "/referrers/"
+
+	var rewrittenLinkValues []string
+	for _, lv := range linkValues {
+		links := lib.ParseLinks(lv)
+		for _, l := range links {
+			u, err := url.Parse(l.URL)
+			if err != nil {
+				log.Warningf("failed to parse pagination link URL %s: %v", l.URL, err)
+				continue
+			}
+			// Rewrite the path prefix and clear scheme/host to ensure a relative Link
+			if strings.HasPrefix(u.Path, remotePathPrefix) {
+				u.Path = localPathPrefix + strings.TrimPrefix(u.Path, remotePathPrefix)
+				u.Scheme = ""
+				u.Host = ""
+				l.URL = u.String()
+			}
+		}
+		rewrittenLinkValues = append(rewrittenLinkValues, links.String())
+	}
+	headerMap[link] = rewrittenLinkValues
+}
+
+// getLocalReferrers queries the local accessory table for accessories with source "local"
+// and builds OCI descriptors from the corresponding artifacts.
+func getLocalReferrers(ctx context.Context, art lib.ArtifactInfo, artifactType string) []ocispec.Descriptor {
+	query := q.New(q.KeyWords{
+		"SubjectArtifactDigest": art.Reference,
+		"SubjectArtifactRepo":   art.Repository,
+		"Source":                accModel.TypeLocalReferrer,
+	})
+	accs, err := accessory.Mgr.List(ctx, query)
+	if err != nil {
+		log.Warningf("failed to list local accessories for %s@%s: %v", art.Repository, art.Reference, err)
+		return nil
+	}
+	if len(accs) == 0 {
+		return nil
+	}
+
+	var descs []ocispec.Descriptor
+	for _, acc := range accs {
+		accData := acc.GetData()
+		accArt, err := pkg.ArtifactMgr.GetByDigest(ctx, art.Repository, accData.Digest)
+		if err != nil {
+			log.Warningf("failed to get artifact for local accessory %s: %v", accData.Digest, err)
+			continue
+		}
+		if artifactType != "" && accArt.ArtifactType != artifactType {
+			continue
+		}
+		desc := ocispec.Descriptor{
+			MediaType:    accArt.ManifestMediaType,
+			Size:         accArt.Size,
+			Digest:       digest.Digest(accArt.Digest),
+			Annotations:  accArt.Annotations,
+			ArtifactType: accArt.ArtifactType,
+		}
+		descs = append(descs, desc)
+	}
+	return descs
+}
+
+func serveCachedReferrers(ctx context.Context, w http.ResponseWriter, key string) error {
+	c := libCache.Default()
+	if c == nil {
+		return fmt.Errorf("the global cache is not initialized")
+	}
+	cachedContent := referrerCache{}
+	err := c.Fetch(ctx, key, &cachedContent)
+	if err != nil {
+		log.Debugf("failed to get referrer index from cache, key: %s, error: %v", key, err)
+		return fmt.Errorf("failed to get referrer index from cache")
+	}
+	if len(cachedContent.Content) == 0 {
+		log.Debugf("no cached referrer index found in cache, key: %s", key)
+		return fmt.Errorf("the upstream registry is unhealthy or no cached referrer index found")
+	}
+
+	log.Debugf("referrer index found in cache, key: %s", key)
+	writeProxyHeaders(w, cachedContent.Header)
+	w.WriteHeader(http.StatusOK)
+	_, err = io.Copy(w, bytes.NewReader(cachedContent.Content)) // return cached content if registry is unhealthy
+	if err != nil {
+		// just log the error, as the response has been written
+		log.Errorf("failed to copy response body from cache, %v", err)
+	}
+	return nil
+}
+
+func proxyReferrerGet(r *http.Request, w http.ResponseWriter, art lib.ArtifactInfo, remote proxy.RemoteInterface, registryID int64) error {
+	c := libCache.Default()
+	if c == nil {
+		return fmt.Errorf("the global cache is not initialized")
+	}
+	ctx := r.Context()
+	// get registry status
+	reg, err := registry.Ctl.Get(ctx, registryID)
+	if err != nil {
+		return err
+	}
+	key := referrerCacheKey(r.RequestURI)
+	// if registry is unhealthy, try to get from cache
+	if reg.Status != model.Healthy {
+		return serveCachedReferrers(ctx, w, key)
+	}
+
+	index, headerMap, err := remote.ListReferrers(proxy.GetRemoteRepo(art), art.Reference, r.URL.RawQuery)
+	// if upstream return 404, return not found error
+	if errors.IsNotFoundErr(err) {
+		httpLib.SendError(w, err)
+		return nil
+	}
+
+	if err != nil {
+		return err
+	}
+
+	// Rewrite upstream pagination links before caching or writing headers
+	rewritePaginationLinks(headerMap, art)
+
+	// append local referrers (source=local) only on the last page of remote results
+	isLastPage := !hasNextLink(headerMap)
+	var localDescs []ocispec.Descriptor
+	if isLastPage {
+		artifactTypeFilter := r.URL.Query().Get("artifactType")
+		localDescs = getLocalReferrers(ctx, art, artifactTypeFilter)
+		if len(localDescs) > 0 {
+			log.Debugf("appending %d local referrer(s) to remote referrer index for %s@%s", len(localDescs), art.Repository, art.Reference)
+			index.Manifests = append(index.Manifests, localDescs...)
+		}
+	}
+
+	// Preserve the upstream total and add the number of merged local descriptors
+	upstreamTotal := 0
+	hasUpstreamTotal := false
+	if len(headerMap[xTotalCount]) > 0 {
+		if total, err := strconv.Atoi(headerMap[xTotalCount][0]); err == nil {
+			upstreamTotal = total
+			hasUpstreamTotal = true
+		}
+	}
+	if !hasUpstreamTotal {
+		// Fallback to the number of remote manifests in the response
+		upstreamTotal = len(index.Manifests) - len(localDescs)
+	}
+	headerMap[xTotalCount] = []string{strconv.Itoa(upstreamTotal + len(localDescs))}
+
+	// Marshal before touching the response so we can still return an error on failure.
+	b, err := json.Marshal(index)
+	if err != nil {
+		return err
+	}
+	cacheContent := referrerCache{
+		Content: b,
+		Header:  headerMap,
+	}
+	log.Debugf("save referrer index to cache, key: %s", key)
+	if err := c.Save(ctx, key, cacheContent, referrerCacheTTL); err != nil {
+		log.Warningf("failed to save referrer index to cache, key: %s, error: %v", key, err)
+	}
+
+	log.Debugf("current headers from upstream registry: %v", headerMap)
+	writeProxyHeaders(w, headerMap)
+	w.WriteHeader(http.StatusOK)
+	_, err = io.Copy(w, bytes.NewReader(b))
+	if err != nil {
+		// just log the error, as the response has already been committed
+		log.Errorf("failed to copy response body, %v", err)
+	}
+	return nil
 }

--- a/src/server/middleware/repoproxy/proxy_test.go
+++ b/src/server/middleware/repoproxy/proxy_test.go
@@ -17,11 +17,18 @@ package repoproxy
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
+	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
 	"testing"
+
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
 
 	"github.com/goharbor/harbor/src/common/security"
 	"github.com/goharbor/harbor/src/common/security/proxycachesecret"
@@ -31,12 +38,17 @@ import (
 	registryCtl "github.com/goharbor/harbor/src/controller/registry"
 	"github.com/goharbor/harbor/src/controller/robot"
 	"github.com/goharbor/harbor/src/lib"
+	libCache "github.com/goharbor/harbor/src/lib/cache"
+	_ "github.com/goharbor/harbor/src/lib/cache/memory"
 	liberrors "github.com/goharbor/harbor/src/lib/errors"
+	"github.com/goharbor/harbor/src/lib/q"
 	proModels "github.com/goharbor/harbor/src/pkg/project/models"
 	"github.com/goharbor/harbor/src/pkg/reg/model"
 	pkgRobot "github.com/goharbor/harbor/src/pkg/robot/model"
 	projecttesting "github.com/goharbor/harbor/src/testing/controller/project"
+	proxytesting "github.com/goharbor/harbor/src/testing/controller/proxy"
 	registrytesting "github.com/goharbor/harbor/src/testing/controller/registry"
+	testingcache "github.com/goharbor/harbor/src/testing/lib/cache"
 	testingmock "github.com/goharbor/harbor/src/testing/mock"
 )
 
@@ -511,5 +523,422 @@ func TestTagsListMiddlewareDefaultLibrary(t *testing.T) {
 	expectedLocation := "/v2/proxy_project/library/nginx/tags/list"
 	if location := rec.Header().Get("Location"); location != expectedLocation {
 		t.Errorf("expected Location header %q, got %q", expectedLocation, location)
+	}
+}
+
+// mockRegistryController is a minimal testify mock for registry.Controller.
+// Only Get is exercised by proxyReferrerGet; remaining methods panic if called.
+type mockRegistryController struct {
+	mock.Mock
+}
+
+func (m *mockRegistryController) Get(ctx context.Context, id int64) (*model.Registry, error) {
+	args := m.Called(ctx, id)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*model.Registry), args.Error(1)
+}
+
+func (m *mockRegistryController) Create(_ context.Context, _ *model.Registry) (int64, error) {
+	panic("not implemented")
+}
+func (m *mockRegistryController) Count(_ context.Context, _ *q.Query) (int64, error) {
+	panic("not implemented")
+}
+func (m *mockRegistryController) List(_ context.Context, _ *q.Query) ([]*model.Registry, error) {
+	panic("not implemented")
+}
+func (m *mockRegistryController) Update(_ context.Context, _ *model.Registry, _ ...string) error {
+	panic("not implemented")
+}
+func (m *mockRegistryController) Delete(_ context.Context, _ int64) error {
+	panic("not implemented")
+}
+func (m *mockRegistryController) GetInfo(_ context.Context, _ int64) (*model.RegistryInfo, error) {
+	panic("not implemented")
+}
+func (m *mockRegistryController) IsHealthy(_ context.Context, _ *model.Registry) (bool, error) {
+	panic("not implemented")
+}
+func (m *mockRegistryController) ListRegistryProviderTypes(_ context.Context) ([]string, error) {
+	panic("not implemented")
+}
+func (m *mockRegistryController) ListRegistryProviderInfos(_ context.Context) (map[string]*model.AdapterPattern, error) {
+	panic("not implemented")
+}
+func (m *mockRegistryController) StartRegularHealthCheck(_ context.Context, _, _ chan struct{}) {
+	panic("not implemented")
+}
+
+// --- ProxyReferrerMiddleware suite ---
+
+type ProxyReferrerMiddlewareSuite struct {
+	suite.Suite
+
+	origProjectCtl project.Controller
+	projectCtl     *projecttesting.Controller
+
+	next       http.Handler
+	nextCalled bool
+	artInfo    lib.ArtifactInfo
+}
+
+func (s *ProxyReferrerMiddlewareSuite) SetupTest() {
+	s.origProjectCtl = project.Ctl
+	s.projectCtl = &projecttesting.Controller{}
+	project.Ctl = s.projectCtl
+
+	s.nextCalled = false
+	s.next = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		s.nextCalled = true
+		w.WriteHeader(http.StatusOK)
+	})
+
+	s.artInfo = lib.ArtifactInfo{
+		ProjectName: "testproject",
+		Repository:  "testproject/image",
+		Reference:   "sha256:aaaa",
+		Digest:      "sha256:aaaa",
+	}
+}
+
+func (s *ProxyReferrerMiddlewareSuite) TearDownTest() {
+	project.Ctl = s.origProjectCtl
+}
+
+func (s *ProxyReferrerMiddlewareSuite) makeRequest() *http.Request {
+	req := httptest.NewRequest(http.MethodGet, "/v2/testproject/image/referrers/sha256:aaaa", nil)
+	ctx := lib.WithArtifactInfo(req.Context(), s.artInfo)
+	return req.WithContext(ctx)
+}
+
+func (s *ProxyReferrerMiddlewareSuite) TestNonProxyProject() {
+	proj := &proModels.Project{ProjectID: 1, Name: "testproject", RegistryID: 0}
+	testingmock.OnAnything(s.projectCtl, "GetByName").Return(proj, nil)
+
+	w := httptest.NewRecorder()
+	ProxyReferrerMiddleware()(s.next).ServeHTTP(w, s.makeRequest())
+
+	s.True(s.nextCalled, "next handler should be called for non-proxy project")
+}
+
+func (s *ProxyReferrerMiddlewareSuite) TestProjectNotFound() {
+	testingmock.OnAnything(s.projectCtl, "GetByName").Return(nil, liberrors.NotFoundError(nil))
+
+	w := httptest.NewRecorder()
+	ProxyReferrerMiddleware()(s.next).ServeHTTP(w, s.makeRequest())
+
+	s.False(s.nextCalled, "next handler should not be called when project lookup fails")
+	s.NotEqual(http.StatusOK, w.Code)
+}
+
+func (s *ProxyReferrerMiddlewareSuite) TestProxyReferrerAPIDisabled() {
+	proj := &proModels.Project{
+		ProjectID:  2,
+		Name:       "testproject",
+		RegistryID: 1,
+		Metadata:   map[string]string{},
+	}
+	testingmock.OnAnything(s.projectCtl, "GetByName").Return(proj, nil)
+
+	w := httptest.NewRecorder()
+	ProxyReferrerMiddleware()(s.next).ServeHTTP(w, s.makeRequest())
+
+	s.True(s.nextCalled, "next handler should be called when proxy referrer API is disabled")
+}
+
+func TestProxyReferrerMiddlewareSuite(t *testing.T) {
+	suite.Run(t, new(ProxyReferrerMiddlewareSuite))
+}
+
+// --- proxyReferrerGet suite ---
+
+type ProxyReferrerGetSuite struct {
+	suite.Suite
+
+	origRegistryCtl registryCtl.Controller
+	registryCtl     *mockRegistryController
+
+	mockCache  *testingcache.Cache
+	mockRemote *proxytesting.RemoteInterface
+
+	art lib.ArtifactInfo
+}
+
+func (s *ProxyReferrerGetSuite) SetupSuite() {
+	// Initialize memory cache as the global default for this suite.
+	s.Require().NoError(libCache.Initialize(libCache.Memory, ""))
+}
+
+func (s *ProxyReferrerGetSuite) SetupTest() {
+	s.origRegistryCtl = registryCtl.Ctl
+	s.registryCtl = &mockRegistryController{}
+	registryCtl.Ctl = s.registryCtl
+
+	s.mockRemote = &proxytesting.RemoteInterface{}
+	s.art = lib.ArtifactInfo{
+		ProjectName: "proxy-cache",
+		Repository:  "proxy-cache/app",
+		Reference:   "sha256:bbbb",
+		Digest:      "sha256:bbbb",
+	}
+}
+
+func (s *ProxyReferrerGetSuite) TearDownTest() {
+	registryCtl.Ctl = s.origRegistryCtl
+}
+
+func (s *ProxyReferrerGetSuite) makeRequest(rawQuery string) *http.Request {
+	url := "/v2/proxy-cache/app/referrers/sha256:bbbb"
+	if rawQuery != "" {
+		url += "?" + rawQuery
+	}
+	req := httptest.NewRequest(http.MethodGet, url, nil)
+	return req.WithContext(lib.WithArtifactInfo(req.Context(), s.art))
+}
+
+func (s *ProxyReferrerGetSuite) TestUpstreamNotFound() {
+	healthyReg := &model.Registry{ID: 1, Status: model.Healthy}
+	testingmock.OnAnything(s.registryCtl, "Get").Return(healthyReg, nil)
+	testingmock.OnAnything(s.mockRemote, "ListReferrers").Return(nil, nil, liberrors.NotFoundError(nil))
+
+	w := httptest.NewRecorder()
+	err := proxyReferrerGet(s.makeRequest(""), w, s.art, s.mockRemote, 1)
+
+	s.NoError(err)
+	s.Equal(http.StatusNotFound, w.Code)
+}
+
+func (s *ProxyReferrerGetSuite) TestUpstreamSuccessWritesResponse() {
+	healthyReg := &model.Registry{ID: 1, Status: model.Healthy}
+	testingmock.OnAnything(s.registryCtl, "Get").Return(healthyReg, nil)
+
+	upstreamIndex := &ocispec.Index{
+		Manifests: []ocispec.Descriptor{
+			{MediaType: "application/vnd.oci.image.manifest.v1+json", ArtifactType: "application/vnd.example.sbom"},
+		},
+	}
+	headers := map[string][]string{
+		"Content-Type":  {"application/vnd.oci.image.index.v1+json"},
+		"X-Total-Count": {"1"},
+	}
+	testingmock.OnAnything(s.mockRemote, "ListReferrers").Return(upstreamIndex, headers, nil)
+
+	w := httptest.NewRecorder()
+	err := proxyReferrerGet(s.makeRequest(""), w, s.art, s.mockRemote, 1)
+
+	s.NoError(err)
+	s.Equal(http.StatusOK, w.Code)
+	s.Equal("application/vnd.oci.image.index.v1+json", w.Header().Get("Content-Type"))
+
+	var gotIndex ocispec.Index
+	s.NoError(json.Unmarshal(w.Body.Bytes(), &gotIndex))
+	s.Len(gotIndex.Manifests, 1)
+}
+
+func (s *ProxyReferrerGetSuite) TestUpstreamSuccessRewritesPaginationLinks() {
+	healthyReg := &model.Registry{ID: 1, Status: model.Healthy}
+	testingmock.OnAnything(s.registryCtl, "Get").Return(healthyReg, nil)
+
+	upstreamIndex := &ocispec.Index{
+		Manifests: []ocispec.Descriptor{
+			{MediaType: "application/vnd.oci.image.manifest.v1+json", ArtifactType: "application/vnd.example.sbom"},
+		},
+	}
+	headers := map[string][]string{
+		"Content-Type":  {"application/vnd.oci.image.index.v1+json"},
+		"X-Total-Count": {"1"},
+		"Link":          {`</v2/app/referrers/sha256:bbbb?n=10&next=abc>; rel="next"`, `<https://upstream-registry.io/v2/app/referrers/sha256:bbbb?n=10&next=xyz>; rel="next"`},
+	}
+	testingmock.OnAnything(s.mockRemote, "ListReferrers").Return(upstreamIndex, headers, nil)
+
+	w := httptest.NewRecorder()
+	err := proxyReferrerGet(s.makeRequest(""), w, s.art, s.mockRemote, 1)
+
+	s.NoError(err)
+	s.Equal(http.StatusOK, w.Code)
+	s.Equal("application/vnd.oci.image.index.v1+json", w.Header().Get("Content-Type"))
+
+	gotLinks := w.Header().Values("Link")
+	s.Len(gotLinks, 2)
+	s.Contains(gotLinks[0], `/v2/proxy-cache/app/referrers/sha256:bbbb?n=10&next=abc`)
+	s.Contains(gotLinks[1], `/v2/proxy-cache/app/referrers/sha256:bbbb?n=10&next=xyz`)
+	s.NotContains(gotLinks[1], "upstream-registry.io")
+}
+
+func (s *ProxyReferrerGetSuite) TestUpstreamSuccessPreservesTotalCount() {
+	healthyReg := &model.Registry{ID: 1, Status: model.Healthy}
+	testingmock.OnAnything(s.registryCtl, "Get").Return(healthyReg, nil)
+
+	// Simulate a non-final page with 1 manifest, but total count of 100 from upstream
+	upstreamIndex := &ocispec.Index{
+		Manifests: []ocispec.Descriptor{
+			{MediaType: "application/vnd.oci.image.manifest.v1+json", ArtifactType: "application/vnd.example.sbom"},
+		},
+	}
+	headers := map[string][]string{
+		"Content-Type":  {"application/vnd.oci.image.index.v1+json"},
+		"X-Total-Count": {"100"},
+		"Link":          {`</v2/app/referrers/sha256:bbbb?n=1&next=abc>; rel="next"`},
+	}
+	testingmock.OnAnything(s.mockRemote, "ListReferrers").Return(upstreamIndex, headers, nil)
+
+	w := httptest.NewRecorder()
+	err := proxyReferrerGet(s.makeRequest(""), w, s.art, s.mockRemote, 1)
+
+	s.NoError(err)
+	s.Equal(http.StatusOK, w.Code)
+	s.Equal("100", w.Header().Get("X-Total-Count"))
+}
+
+func (s *ProxyReferrerGetSuite) TestUnhealthyRegistryCacheHit() {
+	unhealthyReg := &model.Registry{ID: 1, Status: "unhealthy"}
+	testingmock.OnAnything(s.registryCtl, "Get").Return(unhealthyReg, nil)
+
+	// Prime the cache manually.
+	cachedIndex := &ocispec.Index{
+		Manifests: []ocispec.Descriptor{
+			{MediaType: "application/vnd.oci.image.manifest.v1+json", ArtifactType: "application/vnd.sbom"},
+		},
+	}
+	b, err := json.Marshal(cachedIndex)
+	s.Require().NoError(err)
+	cacheKey := referrerCacheKey("/v2/proxy-cache/app/referrers/sha256:bbbb")
+	cached := referrerCache{
+		Content: b,
+		Header:  map[string][]string{"Content-Type": {"application/vnd.oci.image.index.v1+json"}},
+	}
+	s.Require().NoError(libCache.Default().Save(context.Background(), cacheKey, cached))
+
+	w := httptest.NewRecorder()
+	err = proxyReferrerGet(s.makeRequest(""), w, s.art, s.mockRemote, 1)
+
+	s.NoError(err)
+	s.Equal(http.StatusOK, w.Code)
+
+	var gotIndex ocispec.Index
+	s.NoError(json.Unmarshal(w.Body.Bytes(), &gotIndex))
+	s.Len(gotIndex.Manifests, 1)
+}
+
+func (s *ProxyReferrerGetSuite) TestUnhealthyRegistryCacheMiss() {
+	unhealthyReg := &model.Registry{ID: 1, Status: "unhealthy"}
+	testingmock.OnAnything(s.registryCtl, "Get").Return(unhealthyReg, nil)
+
+	// Use a unique URI so the cache lookup finds nothing.
+	req := httptest.NewRequest(http.MethodGet, "/v2/proxy-cache/app/referrers/sha256:miss", nil)
+	req = req.WithContext(lib.WithArtifactInfo(req.Context(), s.art))
+
+	w := httptest.NewRecorder()
+	err := proxyReferrerGet(req, w, s.art, s.mockRemote, 1)
+
+	s.Error(err, "should return error when registry is unhealthy and cache is empty")
+}
+
+func TestProxyReferrerGetSuite(t *testing.T) {
+	suite.Run(t, new(ProxyReferrerGetSuite))
+}
+
+// TestReferrerCacheKey tests the cache key generation
+func TestReferrerCacheKey(t *testing.T) {
+	cases := []struct {
+		name        string
+		requestURI  string
+		expectedKey string
+	}{
+		{
+			name:        "simple path",
+			requestURI:  "/v2/repo/image/referrers",
+			expectedKey: "{referrer_cache}:/v2/repo/image/referrers",
+		},
+		{
+			name:        "path with query",
+			requestURI:  "/v2/repo/image/referrers?filter=sbom&format=json",
+			expectedKey: "{referrer_cache}:/v2/repo/image/referrers?filter=sbom&format=json",
+		},
+		{
+			name:        "path with special chars",
+			requestURI:  "/v2/my-repo/my-image/referrers?annotation=key%3Dvalue",
+			expectedKey: "{referrer_cache}:/v2/my-repo/my-image/referrers?annotation=key%3Dvalue",
+		},
+	}
+
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			key := referrerCacheKey(tt.requestURI)
+			require.Equal(t, tt.expectedKey, key)
+		})
+	}
+}
+
+// TestWriteProxyHeaders tests that only allowed headers are written by writeProxyHeaders
+func TestWriteProxyHeaders(t *testing.T) {
+	cases := []struct {
+		name            string
+		headerMap       map[string][]string
+		expectedHeaders map[string]string
+		shouldNotHave   []string
+	}{
+		{
+			name: "allowed headers",
+			headerMap: map[string][]string{
+				"Content-Type":  {"application/json"},
+				"Link":          {"<http://example.com>; rel=\"next\""},
+				"X-Total-Count": {"100"},
+			},
+			expectedHeaders: map[string]string{
+				"Content-Type":  "application/json",
+				"Link":          "<http://example.com>; rel=\"next\"",
+				"X-Total-Count": "100",
+			},
+			shouldNotHave: []string{},
+		},
+		{
+			name: "mixed allowed and disallowed headers",
+			headerMap: map[string][]string{
+				"Content-Type":    {"application/json"},
+				"X-Custom-Header": {"should-not-appear"},
+				"X-Total-Count":   {"50"},
+				"Authorization":   {"Bearer token"},
+			},
+			expectedHeaders: map[string]string{
+				"Content-Type":  "application/json",
+				"X-Total-Count": "50",
+			},
+			shouldNotHave: []string{"X-Custom-Header", "Authorization"},
+		},
+		{
+			name: "multiple values for same header",
+			headerMap: map[string][]string{
+				"Link": {
+					"<http://example.com/page=1>; rel=\"first\"",
+					"<http://example.com/page=2>; rel=\"next\"",
+				},
+			},
+			expectedHeaders: map[string]string{
+				"Link": "<http://example.com/page=1>; rel=\"first\"",
+			},
+			shouldNotHave: []string{},
+		},
+	}
+
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			w := httptest.NewRecorder()
+			writeProxyHeaders(w, tt.headerMap)
+
+			// Check expected headers are present
+			for header, expectedValue := range tt.expectedHeaders {
+				actualValue := w.Header().Get(header)
+				require.Equal(t, expectedValue, actualValue, "header %s should match", header)
+			}
+
+			// Check disallowed headers are not present
+			for _, header := range tt.shouldNotHave {
+				actualValue := w.Header().Get(header)
+				require.Empty(t, actualValue, fmt.Sprintf("header %s should not be present", header))
+			}
+		})
 	}
 }

--- a/src/server/middleware/subject/subject.go
+++ b/src/server/middleware/subject/subject.go
@@ -24,6 +24,8 @@ import (
 	"github.com/opencontainers/go-digest"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 
+	"github.com/goharbor/harbor/src/common/security"
+	"github.com/goharbor/harbor/src/common/security/proxycachesecret"
 	"github.com/goharbor/harbor/src/controller/artifact"
 	"github.com/goharbor/harbor/src/lib"
 	"github.com/goharbor/harbor/src/lib/errors"
@@ -49,6 +51,11 @@ var (
 
 	// media type of harbor sbom
 	mediaTypeHarborSBOM = "application/vnd.goharbor.harbor.sbom.v1"
+
+	// source of accessory artifact is local, means the accessory is created by harbor itself
+	sourceLocal = "local"
+	// source of accessory artifact is from proxycache, means the accessory is created by proxycache service
+	sourceProxyCache = "proxycache"
 )
 
 /*
@@ -166,6 +173,13 @@ func Middleware() func(http.Handler) http.Handler {
 				accData.SubArtifactID = subjectArt.ID
 			}
 			if err := orm.WithTransaction(func(ctx context.Context) error {
+				source := sourceLocal
+				securityCtx, exist := security.FromContext(ctx)
+				if exist && securityCtx != nil && securityCtx.GetUsername() == proxycachesecret.ProxyCacheService {
+					source = sourceProxyCache
+				}
+				logger.Debugf("source: %s", source)
+				accData.Source = source
 				_, err := accessory.Mgr.Create(ctx, accData)
 				return err
 			})(orm.SetTransactionOpNameToContext(ctx, "tx-create-subject-accessory")); err != nil {

--- a/src/server/registry/route.go
+++ b/src/server/registry/route.go
@@ -123,6 +123,7 @@ func RegisterRoutes() {
 		Method(http.MethodGet).
 		Path("/*/referrers/:reference").
 		Middleware(metric.InjectOpIDMiddleware(metric.ReferrersOperationID)).
+		Middleware(repoproxy.ProxyReferrerMiddleware()).
 		Handler(newReferrersHandler())
 	// others
 	root.NewRoute().Path("/*").Middleware(metric.InjectOpIDMiddleware(metric.OthersOperationID)).Handler(proxy)

--- a/src/server/v2.0/handler/project_metadata.go
+++ b/src/server/v2.0/handler/project_metadata.go
@@ -156,7 +156,7 @@ func (p *projectMetadataAPI) validate(ctx context.Context, projectID int64, meta
 	switch key {
 	case proModels.ProMetaPublic, proModels.ProMetaEnableContentTrust, proModels.ProMetaEnableContentTrustCosign,
 		proModels.ProMetaAutoSBOMGen, proModels.ProMetaPreventVul, proModels.ProMetaAutoScan, proModels.ProMetaReuseSysCVEAllowlist,
-		proModels.ProMetaProxyCacheLocalOnNotFound:
+		proModels.ProMetaProxyCacheLocalOnNotFound, proModels.ProMetaProxyReferrerAPI:
 		v, err := strconv.ParseBool(value)
 		if err != nil {
 			return nil, errors.New(nil).WithCode(errors.BadRequestCode).WithMessagef("invalid value: %s", value)


### PR DESCRIPTION
Manual backport of #563 (`440fbd77b0c7` — upstream goharbor/harbor#23237: proxy the OCI referrers API to the upstream registry for proxy-cache projects) to `release-2.15`, as requested by the failed automatic backport.

## Why three commits

`release-2.15` already has the registry-client layer (`ListReferrers`, bearer `referrers` scope, `lib.ParseLinks`, `GoCacheFill`), but was missing the rest of the feature chain from `main`, so the cherry-pick pulls the two prerequisites along:

1. **`upstream: Add UI option to enable proxy cache referrer API`** (goharbor/harbor#23151) — `proxy_referrer_api` project metadata in swagger + portal toggle + i18n.
2. **`upstream: Update artifact_accessory to add source column to identify accessory`** (goharbor/harbor#23144) — `source` column on `artifact_accessory` (model, DAO, subject middleware) and `ProMetaProxyReferrerAPI`.
3. **`upstream: Proxy the referrer API to upstream registry with paging and local merge`** (goharbor/harbor#23237) — the referrer proxy middleware itself (#563's commit).

## Backport deviations (all deliberate)

- **Migration renumbered** `0190_2.16.0_schema.up.sql` → `0182_2.15.8_schema.up.sql` (release-2.15 migrations end at `0181_2.15.3`). The statement is `ALTER TABLE ... ADD COLUMN IF NOT EXISTS`, so it is idempotent when 2.16.0's `0190` applies it again on upgrade.
- **i18n**: `de-de`, `es-es`, `ko-kr`, `pt-br`, `ru-ru`, `tr-tr`, `zh-cn`, `zh-tw` already contain the `PROXY_REFERRER_API_*` keys on this branch — kept the branch versions; `en-us`/`fr-fr` got the keys from the pick.
- **Dropped** a debug-print change to `tests/apitests/python/test_verify_metrics_enabled.py` (file does not exist on release-2.15).

## Verification

- `route.go`, `accessory.go`, `subject.go`, `project.go` (models) are byte-identical to `main` after the picks; `proxy.go` differs from `main` only by main-only drift (proxy metrics instrumentation from #547's main variant, "cannot push" wording).
- `go build`, `go vet`, `gofmt` clean; `go test ./server/middleware/repoproxy/... ./pkg/accessory/...` passes locally.
