### PR TITLE
chore: Align Dev Toolchain Versions With Requirements

### DIFF
--- a/versions.env
+++ b/versions.env
@@ -4,7 +4,7 @@
 
 # Go toolchain and build tools
 # renovate: datasource=golang-version depName=golang versioning=semver extractVersion=^go(?<version>.*)$
-GO_VERSION=1.26.4
+GO_VERSION=1.26.5
 # renovate: datasource=github-tags depName=go-swagger/go-swagger
 SWAGGER_VERSION=v0.33.1
 # renovate: datasource=github-releases depName=golangci/golangci-lint
@@ -17,7 +17,8 @@ GH_CLI_VERSION=2.83.1
 # Dev tools
 # renovate: datasource=github-tags depName=air-verse/air
 AIR_VERSION=v1.61.5
-DELVE_VERSION=latest
+# renovate: datasource=github-tags depName=go-delve/delve
+DELVE_VERSION=v1.27.1
 # renovate: datasource=docker depName=oven/bun versioning=docker
 BUN_VERSION=1.2.13
 # renovate: datasource=docker depName=stoplight/spectral versioning=docker


### PR DESCRIPTION
Two dev-environment toolchain fixes:

**1. `GO_VERSION` 1.26.4 → 1.26.5.** Every `task dev:up` on current `main` failed at `wait-core`: `src/go.mod` requires `go >= 1.26.5`, but `versions.env` pinned 1.26.4. The golang base images set `GOTOOLCHAIN=local`, so the air hot-reload build inside the core container exited immediately with

```
go: go.mod requires go >= 1.26.5 (running go 1.26.4; GOTOOLCHAIN=local)
```

Core never listened, the 120s readiness wait timed out, and the deferred `dev:down` tore everything down (destroying the evidence).

**2. Pin `DELVE_VERSION` to v1.27.1 (was `latest`), with a renovate marker.** Unpinned dlv made dev image builds unreproducible; a stale cached layer produced an image with no `/go/bin/dlv` at all, so every air hot-reload restart died with `/bin/sh: /go/bin/dlv: not found` — Core stayed down and the portal dev proxy answered 504 on every request.

Verified locally: with these pins, `dev:up` comes up, Core answers `/api/v2.0/ping`, hot reload restarts survive, and the full login/CSRF/project-creation flow works through the portal (`localhost:4200`) over plain HTTP.