### PR TITLE
chore: Fall Back To Plain Binary When Delve Is Missing In Dev Env

### DIFF
--- a/devenv/air.core.toml
+++ b/devenv/air.core.toml
@@ -15,7 +15,8 @@ tmp_dir = "tmp"
 
   # Delve debugger on port 2345, starts immediately (--continue)
   # Attach anytime with: dlv connect localhost:2345
-  full_bin = "/go/bin/dlv exec ./tmp/core --listen=0.0.0.0:2345 --headless=true --api-version=2 --accept-multiclient --continue --"
+  # Falls back to the plain binary when dlv can't run; run() keeps Air-appended args working.
+  full_bin = "run() { if /go/bin/dlv version >/dev/null 2>&1; then exec /go/bin/dlv exec ./tmp/core --listen=0.0.0.0:2345 --headless=true --api-version=2 --accept-multiclient --continue -- \"$@\"; else echo 'air: dlv unavailable - running plain binary (no debugger on :2345)' >&2; exec ./tmp/core \"$@\"; fi; }; run"
 
   # Watch src directory for Go files only
   include_dir = ["src"]

--- a/devenv/air.jobservice.toml
+++ b/devenv/air.jobservice.toml
@@ -17,7 +17,8 @@ tmp_dir = "tmp"
 
   # Run via Delve debugger - allows attaching debugger at any time
   # Port 2346 for Jobservice (Core uses 2345), --continue starts immediately without waiting for debugger
-  full_bin = "/go/bin/dlv exec ./tmp/jobservice --listen=0.0.0.0:2346 --headless=true --api-version=2 --accept-multiclient --continue -- -c config/jobservice.yml"
+  # Falls back to the plain binary when dlv can't run; run() keeps Air-appended args working.
+  full_bin = "run() { if /go/bin/dlv version >/dev/null 2>&1; then exec /go/bin/dlv exec ./tmp/jobservice --listen=0.0.0.0:2346 --headless=true --api-version=2 --accept-multiclient --continue -- \"$@\"; else echo 'air: dlv unavailable - running plain binary (no debugger on :2346)' >&2; exec ./tmp/jobservice \"$@\"; fi; }; run -c config/jobservice.yml"
 
   # Watch these directories
   include_dir = ["src"]

--- a/devenv/air.registryctl.toml
+++ b/devenv/air.registryctl.toml
@@ -14,7 +14,8 @@ tmp_dir = "tmp"
 
   # Delve debugger on port 2347, starts immediately (--continue)
   # Attach anytime with: dlv connect localhost:2347
-  full_bin = "/go/bin/dlv exec ./tmp/registryctl --listen=0.0.0.0:2347 --headless=true --api-version=2 --accept-multiclient --continue --"
+  # Falls back to the plain binary when dlv can't run; run() keeps Air-appended args_bin working.
+  full_bin = "run() { if /go/bin/dlv version >/dev/null 2>&1; then exec /go/bin/dlv exec ./tmp/registryctl --listen=0.0.0.0:2347 --headless=true --api-version=2 --accept-multiclient --continue -- \"$@\"; else echo 'air: dlv unavailable - running plain binary (no debugger on :2347)' >&2; exec ./tmp/registryctl \"$@\"; fi; }; run"
 
   # Watch src directory for Go files only
   include_dir = ["src"]


### PR DESCRIPTION
Follow-up to #698 (this part missed the merge). When `/go/bin/dlv` is absent from the dev image, every air hot-reload restart dies with `/bin/sh: /go/bin/dlv: not found` — the service stays down and the portal dev proxy answers 504 for every request until the image is rebuilt.

The three air configs now check for dlv in `full_bin` and fall back to executing the freshly built binary directly. A broken or missing debugger install degrades step-through debugging but can never take Core, JobService, or RegistryCtl down.

Verified locally: with dlv removed from the container, hot reload restarts keep the services serving.