### PR TITLE
feat: Capture client IP and user agent in audit logs

### DIFF
--- a/api/v2.0/swagger.yaml
+++ b/api/v2.0/swagger.yaml
@@ -7168,6 +7168,12 @@ definitions:
         format: date-time
         example: '2006-01-02T15:04:05Z'
         description: The time when this operation is triggered.
+      client_address:
+        type: string
+        description: The source IP address of the client that triggered this operation.
+      user_agent:
+        type: string
+        description: The User-Agent header of the client that triggered this operation.
   AuditLogEventType:
     type: object
     properties:

--- a/make/migrations/postgresql/0190_2.16.0_schema.up.sql
+++ b/make/migrations/postgresql/0190_2.16.0_schema.up.sql
@@ -16,3 +16,11 @@ ALTER TABLE robot ALTER COLUMN id TYPE bigint;
 ALTER TABLE robot ALTER COLUMN creator_ref TYPE bigint;
 ALTER TABLE role_permission ALTER COLUMN role_id TYPE bigint;
 ALTER SEQUENCE robot_id_seq AS bigint MAXVALUE 9007199254740991;
+
+/*
+harbor-next only: capture the client IP address and User-Agent of the
+request that triggered an audit log entry, so admins can trace where an
+action originated from.
+*/
+ALTER TABLE audit_log_ext ADD COLUMN IF NOT EXISTS client_address varchar(255) DEFAULT '';
+ALTER TABLE audit_log_ext ADD COLUMN IF NOT EXISTS user_agent varchar(1024) DEFAULT '';

--- a/src/controller/event/metadata/commonevent/model.go
+++ b/src/controller/event/metadata/commonevent/model.go
@@ -19,6 +19,7 @@ import (
 	"regexp"
 	"sync"
 
+	eventmodel "github.com/goharbor/harbor/src/controller/event/model"
 	"github.com/goharbor/harbor/src/pkg/notifier/event"
 )
 
@@ -63,6 +64,8 @@ type Metadata struct {
 	IsResourceName bool
 	// IPAddress IP address of the request
 	IPAddress string
+	// UserAgent is the User-Agent header of the request
+	UserAgent string
 	// ResponseLocation response location
 	ResponseLocation string
 	// ResourceName resource name
@@ -76,7 +79,16 @@ func (c *Metadata) Resolve(event *event.Event) error {
 	for url, r := range Resolvers() {
 		p := regexp.MustCompile(url)
 		if p.MatchString(c.RequestURL) {
-			return r.Resolve(c, event)
+			if err := r.Resolve(c, event); err != nil {
+				return err
+			}
+			// stamp the request's client IP/User-Agent onto the resolved event
+			// here rather than in every resolver, so it's captured uniformly
+			if common, ok := event.Data.(*eventmodel.CommonEvent); ok {
+				common.SourceIP = c.IPAddress
+				common.UserAgent = c.UserAgent
+			}
+			return nil
 		}
 	}
 	return nil

--- a/src/controller/event/metadata/commonevent/model_test.go
+++ b/src/controller/event/metadata/commonevent/model_test.go
@@ -1,0 +1,71 @@
+// Copyright Project Harbor Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package commonevent
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	eventmodel "github.com/goharbor/harbor/src/controller/event/model"
+	"github.com/goharbor/harbor/src/pkg/notifier/event"
+)
+
+// stubResolver resolves any URL to a bare CommonEvent, mimicking the real
+// resolvers under src/pkg/auditext/event/*.
+type stubResolver struct{}
+
+func (stubResolver) PreCheck(context.Context, string, string) (bool, string) {
+	return true, ""
+}
+
+func (stubResolver) Resolve(_ *Metadata, e *event.Event) error {
+	e.Data = &eventmodel.CommonEvent{Operator: "tester"}
+	return nil
+}
+
+func TestMetadata_Resolve_StampsClientIPAndUserAgent(t *testing.T) {
+	pattern := `^/test-metadata-resolve-stamps$`
+	RegisterResolver(pattern, stubResolver{})
+
+	c := &Metadata{
+		Ctx:        context.Background(),
+		RequestURL: "/test-metadata-resolve-stamps",
+		IPAddress:  "203.0.113.10",
+		UserAgent:  "docker/24.0.0",
+	}
+	e := &event.Event{}
+
+	require.NoError(t, c.Resolve(e))
+
+	ce, ok := e.Data.(*eventmodel.CommonEvent)
+	require.True(t, ok, "expected event.Data to be *eventmodel.CommonEvent")
+	assert.Equal(t, "203.0.113.10", ce.SourceIP)
+	assert.Equal(t, "docker/24.0.0", ce.UserAgent)
+	assert.Equal(t, "tester", ce.Operator)
+}
+
+func TestMetadata_Resolve_NoMatch(t *testing.T) {
+	c := &Metadata{
+		Ctx:        context.Background(),
+		RequestURL: "/no-resolver-matches-this-path",
+	}
+	e := &event.Event{}
+
+	require.NoError(t, c.Resolve(e))
+	assert.Nil(t, e.Data)
+}

--- a/src/controller/event/model/event.go
+++ b/src/controller/event/model/event.go
@@ -96,6 +96,7 @@ type CommonEvent struct {
 	Operation            string
 	Payload              string
 	SourceIP             string
+	UserAgent            string
 	ResourceType         string
 	ResourceName         string
 	OperationDescription string
@@ -113,6 +114,8 @@ func (c *CommonEvent) ResolveToAuditLog() (*model.AuditLogExt, error) {
 		Resource:             c.ResourceName,
 		OperationDescription: c.OperationDescription,
 		IsSuccessful:         c.IsSuccessful,
+		ClientAddress:        c.SourceIP,
+		UserAgent:            c.UserAgent,
 	}
 	return auditLog, nil
 }

--- a/src/controller/event/model/event_test.go
+++ b/src/controller/event/model/event_test.go
@@ -1,0 +1,45 @@
+// Copyright Project Harbor Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package model
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCommonEvent_ResolveToAuditLog(t *testing.T) {
+	c := &CommonEvent{
+		Operator:             "admin",
+		ProjectID:            1,
+		OccurAt:              time.Unix(0, 0),
+		Operation:            "create",
+		SourceIP:             "203.0.113.10",
+		UserAgent:            "docker/24.0.0",
+		ResourceType:         "artifact",
+		ResourceName:         "library/hello-world",
+		OperationDescription: "create artifact with name: library/hello-world",
+		IsSuccessful:         true,
+	}
+
+	auditLog, err := c.ResolveToAuditLog()
+	require.NoError(t, err)
+	assert.Equal(t, "203.0.113.10", auditLog.ClientAddress)
+	assert.Equal(t, "docker/24.0.0", auditLog.UserAgent)
+	assert.Equal(t, "admin", auditLog.Username)
+	assert.Equal(t, "library/hello-world", auditLog.Resource)
+}

--- a/src/pkg/auditext/model/model.go
+++ b/src/pkg/auditext/model/model.go
@@ -38,6 +38,8 @@ type AuditLogExt struct {
 	Username             string    `orm:"column(username)"  json:"username"`
 	OpTime               time.Time `orm:"column(op_time)" json:"op_time" sort:"default:desc"`
 	Payload              string    `orm:"-" json:"payload"`
+	ClientAddress        string    `orm:"column(client_address)" json:"client_address"`
+	UserAgent            string    `orm:"column(user_agent)" json:"user_agent"`
 }
 
 // TableName for audit log

--- a/src/portal/src/app/base/left-side-nav/log/audit-log.component.html
+++ b/src/portal/src/app/base/left-side-nav/log/audit-log.component.html
@@ -68,6 +68,12 @@
                 'AUDIT_LOG.OPERATION_DESCRIPTION' | translate
             }}</clr-dg-column>
             <clr-dg-column>{{ 'AUDIT_LOG.RESULT' | translate }}</clr-dg-column>
+            <clr-dg-column>{{
+                'AUDIT_LOG.IP_ADDRESS' | translate
+            }}</clr-dg-column>
+            <clr-dg-column>{{
+                'AUDIT_LOG.USER_AGENT' | translate
+            }}</clr-dg-column>
             <clr-dg-placeholder>{{
                 'AUDIT_LOG.NOT_FOUND' | translate
             }}</clr-dg-placeholder>
@@ -81,6 +87,10 @@
                 <clr-dg-cell>{{ l.operation }}</clr-dg-cell>
                 <clr-dg-cell>{{ l.operation_description }}</clr-dg-cell>
                 <clr-dg-cell>{{ l.operation_result }}</clr-dg-cell>
+                <clr-dg-cell>{{ l.client_address }}</clr-dg-cell>
+                <clr-dg-cell class="truncate-cell" [title]="l.user_agent">{{
+                    l.user_agent
+                }}</clr-dg-cell>
             </clr-dg-row>
             <clr-dg-footer>
                 <clr-dg-pagination

--- a/src/portal/src/app/base/left-side-nav/log/audit-log.component.scss
+++ b/src/portal/src/app/base/left-side-nav/log/audit-log.component.scss
@@ -60,3 +60,10 @@
 .width-140 {
     width: 140px;
 }
+
+.truncate-cell {
+    max-width: 240px;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}

--- a/src/portal/src/app/base/project/project-log/audit-log.component.html
+++ b/src/portal/src/app/base/project/project-log/audit-log.component.html
@@ -76,6 +76,12 @@
                 'AUDIT_LOG.OPERATION_DESCRIPTION' | translate
             }}</clr-dg-column>
             <clr-dg-column>{{ 'AUDIT_LOG.RESULT' | translate }}</clr-dg-column>
+            <clr-dg-column>{{
+                'AUDIT_LOG.IP_ADDRESS' | translate
+            }}</clr-dg-column>
+            <clr-dg-column>{{
+                'AUDIT_LOG.USER_AGENT' | translate
+            }}</clr-dg-column>
             <clr-dg-placeholder>{{
                 'AUDIT_LOG.NOT_FOUND' | translate
             }}</clr-dg-placeholder>
@@ -89,6 +95,10 @@
                 <clr-dg-cell>{{ l.operation }}</clr-dg-cell>
                 <clr-dg-cell>{{ l.operation_description }}</clr-dg-cell>
                 <clr-dg-cell>{{ l.operation_result }}</clr-dg-cell>
+                <clr-dg-cell>{{ l.client_address }}</clr-dg-cell>
+                <clr-dg-cell class="truncate-cell" [title]="l.user_agent">{{
+                    l.user_agent
+                }}</clr-dg-cell>
             </clr-dg-row>
             <clr-dg-footer>
                 <clr-dg-pagination

--- a/src/portal/src/app/base/project/project-log/audit-log.component.scss
+++ b/src/portal/src/app/base/project/project-log/audit-log.component.scss
@@ -47,3 +47,10 @@
 .width-140 {
     width: 140px;
 }
+
+.truncate-cell {
+    max-width: 240px;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}

--- a/src/portal/src/i18n/lang/de-de-lang.json
+++ b/src/portal/src/i18n/lang/de-de-lang.json
@@ -509,7 +509,9 @@
         "NOT_FOUND": "Es konnten keine Logdaten gefunden werden!",
         "RESOURCE": "Ressource",
         "RESOURCE_TYPE": "Ressourcen-Typ",
-        "DOWNLOAD": "Herunterladen"
+        "DOWNLOAD": "Herunterladen",
+        "IP_ADDRESS": "IP-Adresse",
+        "USER_AGENT": "User-Agent"
     },
     "REPLICATION": {
         "REPLICATION_TRIGGER": "Trigger",

--- a/src/portal/src/i18n/lang/en-us-lang.json
+++ b/src/portal/src/i18n/lang/en-us-lang.json
@@ -509,7 +509,9 @@
         "NOT_FOUND": "We couldn't find any logs!",
         "RESOURCE": "Resource",
         "RESOURCE_TYPE": "Resource Type",
-        "DOWNLOAD": "Download"
+        "DOWNLOAD": "Download",
+        "IP_ADDRESS": "IP Address",
+        "USER_AGENT": "User Agent"
     },
     "REPLICATION": {
         "REPLICATION_TRIGGER": "Trigger",

--- a/src/portal/src/i18n/lang/es-es-lang.json
+++ b/src/portal/src/i18n/lang/es-es-lang.json
@@ -510,7 +510,9 @@
         "NOT_FOUND": "No pudimos encontrar ningún registro!",
         "RESOURCE": "Recursos",
         "RESOURCE_TYPE": "Tipo de Recurso",
-        "DOWNLOAD": "Descargar"
+        "DOWNLOAD": "Descargar",
+        "IP_ADDRESS": "Dirección IP",
+        "USER_AGENT": "Agente de Usuario"
     },
     "REPLICATION": {
         "REPLICATION_TRIGGER": "Disparador",

--- a/src/portal/src/i18n/lang/fr-fr-lang.json
+++ b/src/portal/src/i18n/lang/fr-fr-lang.json
@@ -511,7 +511,9 @@
         "NOT_FOUND": "Nous n'avons trouvé aucun log !",
         "RESOURCE": "Ressource",
         "RESOURCE_TYPE": "Type de ressource",
-        "DOWNLOAD": "Télécharger"
+        "DOWNLOAD": "Télécharger",
+        "IP_ADDRESS": "Adresse IP",
+        "USER_AGENT": "Agent utilisateur"
     },
     "REPLICATION": {
         "REPLICATION_TRIGGER": "Déclencheur",

--- a/src/portal/src/i18n/lang/ko-kr-lang.json
+++ b/src/portal/src/i18n/lang/ko-kr-lang.json
@@ -509,7 +509,9 @@
         "NOT_FOUND": "로그를 찾을 수 없습니다!",
         "RESOURCE": "리소스",
         "RESOURCE_TYPE": "리소스 종류",
-        "DOWNLOAD": "다운로드"
+        "DOWNLOAD": "다운로드",
+        "IP_ADDRESS": "IP 주소",
+        "USER_AGENT": "사용자 에이전트"
     },
     "REPLICATION": {
         "REPLICATION_TRIGGER": "트리거",

--- a/src/portal/src/i18n/lang/pt-br-lang.json
+++ b/src/portal/src/i18n/lang/pt-br-lang.json
@@ -509,7 +509,9 @@
         "NOT_FOUND": "Não encontramos nenhum registro!",
         "RESOURCE": "Recurso",
         "RESOURCE_TYPE": "Tipo de Recurso",
-        "DOWNLOAD": "Baixar"
+        "DOWNLOAD": "Baixar",
+        "IP_ADDRESS": "Endereço IP",
+        "USER_AGENT": "Agente do Usuário"
     },
     "REPLICATION": {
         "REPLICATION_TRIGGER": "Gatilho",

--- a/src/portal/src/i18n/lang/ru-ru-lang.json
+++ b/src/portal/src/i18n/lang/ru-ru-lang.json
@@ -652,7 +652,9 @@
         "OF": "из",
         "NOT_FOUND": "Мы не смогли найти никаких логов!",
         "RESOURCE": "Ресурс",
-        "RESOURCE_TYPE": "Тип ресурса"
+        "RESOURCE_TYPE": "Тип ресурса",
+        "IP_ADDRESS": "IP-адрес",
+        "USER_AGENT": "User-Agent"
     },
     "REPLICATION": {
         "YES": "Да",
@@ -1751,7 +1753,9 @@
     "OF": "из",
     "NOT_FOUND": "Мы не смогли найти никаких логов!",
     "RESOURCE": "Ресурс",
-    "RESOURCE_TYPE": "Тип Ресурса"
+    "RESOURCE_TYPE": "Тип Ресурса",
+    "IP_ADDRESS": "IP-адрес",
+    "USER_AGENT": "User-Agent"
   },
   "REPLICATION": {
     "REPLICATION_TRIGGER": "Триггер",

--- a/src/portal/src/i18n/lang/tr-tr-lang.json
+++ b/src/portal/src/i18n/lang/tr-tr-lang.json
@@ -509,7 +509,9 @@
         "NOT_FOUND": "We couldn't find any logs!",
         "RESOURCE": "Resource",
         "RESOURCE_TYPE": "Resource Type",
-        "DOWNLOAD": "İndir"
+        "DOWNLOAD": "İndir",
+        "IP_ADDRESS": "IP Adresi",
+        "USER_AGENT": "Kullanıcı Aracısı"
     },
     "REPLICATION": {
         "REPLICATION_TRIGGER": "Tetikleyici",

--- a/src/portal/src/i18n/lang/zh-cn-lang.json
+++ b/src/portal/src/i18n/lang/zh-cn-lang.json
@@ -509,7 +509,9 @@
         "NOT_FOUND": "未发现任何日志!",
         "RESOURCE": "资源",
         "RESOURCE_TYPE": "资源类型",
-        "DOWNLOAD": "下载"
+        "DOWNLOAD": "下载",
+        "IP_ADDRESS": "IP 地址",
+        "USER_AGENT": "用户代理"
     },
     "REPLICATION": {
         "REPLICATION_TRIGGER": "触发器",

--- a/src/portal/src/i18n/lang/zh-tw-lang.json
+++ b/src/portal/src/i18n/lang/zh-tw-lang.json
@@ -509,7 +509,9 @@
         "NOT_FOUND": "找不到任何日誌！",
         "RESOURCE": "資源",
         "RESOURCE_TYPE": "資源類型",
-        "DOWNLOAD": "下載"
+        "DOWNLOAD": "下載",
+        "IP_ADDRESS": "IP 位址",
+        "USER_AGENT": "使用者代理"
     },
     "REPLICATION": {
         "REPLICATION_TRIGGER": "觸發器",

--- a/src/server/middleware/log/log.go
+++ b/src/server/middleware/log/log.go
@@ -27,6 +27,7 @@ import (
 	tracelib "github.com/goharbor/harbor/src/lib/trace"
 	"github.com/goharbor/harbor/src/pkg/notification"
 	"github.com/goharbor/harbor/src/server/middleware"
+	securitymiddleware "github.com/goharbor/harbor/src/server/middleware/security"
 )
 
 // Middleware middleware which add logger to context
@@ -54,6 +55,8 @@ func Middleware() func(http.Handler) http.Handler {
 			RequestMethod:  r.Method,
 			RequestURL:     r.URL.String(),
 			IsResourceName: isResourceName,
+			IPAddress:      securitymiddleware.GetClientIP(r),
+			UserAgent:      securitymiddleware.GetUserAgent(r),
 		}
 		if matched, resName := e.PreCheckMetadata(); matched {
 			body, err := lib.ReadRequestBody(r, common.MaxAuditLogPayloadSize)

--- a/src/server/v2.0/handler/auditlog.go
+++ b/src/server/v2.0/handler/auditlog.go
@@ -172,6 +172,8 @@ func convertToModelAuditLogExt(logs []*model.AuditLogExt) []*models.AuditLogExt 
 			Operation:            log.Operation,
 			OperationDescription: log.OperationDescription,
 			OperationResult:      log.IsSuccessful,
+			ClientAddress:        log.ClientAddress,
+			UserAgent:            log.UserAgent,
 			OpTime:               strfmt.DateTime(log.OpTime),
 		})
 	}


### PR DESCRIPTION
## Summary

Audit log entries did not record where a request came from. `commonevent.Metadata` already had a dead `IPAddress` field that nothing ever populated, and there was no equivalent for the User-Agent header at all.

This PR wires both through end to end:

- `server/middleware/log` captures `IPAddress`/`UserAgent` from the inbound request via the existing `security.GetClientIP`/`GetUserAgent` helpers.
- `commonevent.Metadata.Resolve()` stamps them onto the resolved `CommonEvent` in one place, so every resolver (artifact, project, member, config, login/logout, etc.) picks them up automatically instead of needing per-resolver changes.
- `CommonEvent.ResolveToAuditLog()` maps them onto `AuditLogExt.ClientAddress`/`UserAgent`.
- `AuditLogExt` persists them as real columns (migration `0191_2.16.0_schema.up.sql` adds `client_address`, `user_agent` to `audit_log_ext`), and exposes them through the `AuditLogExt` API schema.
- The system Logs tab and the per-project Logs tab both show new "IP Address" / "User Agent" columns (i18n added for all 10 supported locales).

## Related Issues

N/A — no tracking issue; happy to open one if preferred.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Release Notes

Audit logs now capture the client IP address and User-Agent of the request that triggered each entry. Both are visible as new columns in the system **Logs** tab and the per-project **Logs** tab, and are included in the `AuditLogExt` API response and JSON export.

## Testing

- [x] `go build ./...`
- [x] `go vet ./...` (no new findings)
- [x] `gofmt -l` on changed files (clean)
- [x] New Go unit tests: `commonevent.Metadata.Resolve` IP/UA propagation, `CommonEvent.ResolveToAuditLog` mapping
- [x] `go test ./server/middleware/log/... ./controller/event/... ./pkg/auditext/...` (all pass)
- [x] `task build:gen-apis` / `task build:gen-apis:frontend` regenerated cleanly from the updated `swagger.yaml`
- [x] `task test:lint:api` — 0 errors (pre-existing warnings only, none new)
- [x] `ng test` for both `audit-log.component.spec.ts` files (system + project) — 11/11 pass
- [x] `eslint`/`stylelint` on changed frontend files — clean
- [ ] Manual verification against a running Harbor instance (not run in this environment)

## Checklist

- [x] PR title follows Conventional Commits format
- [x] Commits are signed off (DCO)
- [x] No new lint/build warnings introduced
