### PR TITLE
feat: Capture client IP and user agent for artifact push/pull/delete

### DIFF
--- a/src/controller/event/metadata/artifact.go
+++ b/src/controller/event/metadata/artifact.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/goharbor/harbor/src/common/security"
 	event2 "github.com/goharbor/harbor/src/controller/event"
+	"github.com/goharbor/harbor/src/controller/event/metadata/requestinfo"
 	"github.com/goharbor/harbor/src/pkg/artifact"
 	"github.com/goharbor/harbor/src/pkg/notifier/event"
 )
@@ -51,6 +52,7 @@ func (p *PushArtifactEventMetadata) Resolve(event *event.Event) error {
 	if exist {
 		data.Operator = ctx.GetUsername()
 	}
+	ae.ClientAddress, ae.UserAgent = requestinfo.FromContext(p.Ctx)
 	event.Topic = event2.TopicPushArtifact
 	event.Data = data
 	return nil
@@ -61,15 +63,22 @@ type PullArtifactEventMetadata struct {
 	Artifact *artifact.Artifact
 	Tag      string
 	Operator string
+	// ClientAddress is the source IP address of the request that triggered
+	// the pull, empty when not resolved from an HTTP request.
+	ClientAddress string
+	// UserAgent is the User-Agent header of the request that triggered the pull.
+	UserAgent string
 }
 
 // Resolve to the event from the metadata
 func (p *PullArtifactEventMetadata) Resolve(event *event.Event) error {
 	ae := &event2.ArtifactEvent{
-		EventType:  event2.TopicPullArtifact,
-		Repository: p.Artifact.RepositoryName,
-		Artifact:   p.Artifact,
-		OccurAt:    time.Now(),
+		EventType:     event2.TopicPullArtifact,
+		Repository:    p.Artifact.RepositoryName,
+		Artifact:      p.Artifact,
+		OccurAt:       time.Now(),
+		ClientAddress: p.ClientAddress,
+		UserAgent:     p.UserAgent,
 	}
 	if p.Tag != "" {
 		ae.Tags = []string{p.Tag}
@@ -93,14 +102,17 @@ type DeleteArtifactEventMetadata struct {
 
 // Resolve to the event from the metadata
 func (d *DeleteArtifactEventMetadata) Resolve(event *event.Event) error {
+	clientAddress, userAgent := requestinfo.FromContext(d.Ctx)
 	data := &event2.DeleteArtifactEvent{
 		ArtifactEvent: &event2.ArtifactEvent{
-			EventType:  event2.TopicDeleteArtifact,
-			Repository: d.Artifact.RepositoryName,
-			Artifact:   d.Artifact,
-			Tags:       d.Tags,
-			Labels:     d.Labels,
-			OccurAt:    time.Now(),
+			EventType:     event2.TopicDeleteArtifact,
+			Repository:    d.Artifact.RepositoryName,
+			Artifact:      d.Artifact,
+			Tags:          d.Tags,
+			Labels:        d.Labels,
+			OccurAt:       time.Now(),
+			ClientAddress: clientAddress,
+			UserAgent:     userAgent,
 		},
 	}
 	ctx, exist := security.FromContext(d.Ctx)

--- a/src/controller/event/metadata/artifact_test.go
+++ b/src/controller/event/metadata/artifact_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/stretchr/testify/suite"
 
 	event2 "github.com/goharbor/harbor/src/controller/event"
+	"github.com/goharbor/harbor/src/controller/event/metadata/requestinfo"
 	"github.com/goharbor/harbor/src/pkg/artifact"
 	"github.com/goharbor/harbor/src/pkg/notifier/event"
 )
@@ -31,8 +32,9 @@ type artifactEventTestSuite struct {
 
 func (a *artifactEventTestSuite) TestResolveOfPushArtifactEventMetadata() {
 	e := &event.Event{}
+	ctx := requestinfo.NewContext(context.Background(), "203.0.113.10", "docker/24.0.0")
 	metadata := &PushArtifactEventMetadata{
-		Ctx:      context.Background(),
+		Ctx:      ctx,
 		Artifact: &artifact.Artifact{ID: 1},
 		Tag:      "latest",
 	}
@@ -44,14 +46,18 @@ func (a *artifactEventTestSuite) TestResolveOfPushArtifactEventMetadata() {
 	a.Require().True(ok)
 	a.Equal(int64(1), data.Artifact.ID)
 	a.Equal("latest", data.Tags[0])
+	a.Equal("203.0.113.10", data.ClientAddress)
+	a.Equal("docker/24.0.0", data.UserAgent)
 }
 
 func (a *artifactEventTestSuite) TestResolveOfPullArtifactEventMetadata() {
 	e := &event.Event{}
 	metadata := &PullArtifactEventMetadata{
-		Artifact: &artifact.Artifact{ID: 1},
-		Tag:      "latest",
-		Operator: "admin",
+		Artifact:      &artifact.Artifact{ID: 1},
+		Tag:           "latest",
+		Operator:      "admin",
+		ClientAddress: "203.0.113.10",
+		UserAgent:     "docker/24.0.0",
 	}
 	err := metadata.Resolve(e)
 	a.Require().Nil(err)
@@ -61,12 +67,15 @@ func (a *artifactEventTestSuite) TestResolveOfPullArtifactEventMetadata() {
 	a.Require().True(ok)
 	a.Equal(int64(1), data.Artifact.ID)
 	a.Equal("latest", data.Tags[0])
+	a.Equal("203.0.113.10", data.ClientAddress)
+	a.Equal("docker/24.0.0", data.UserAgent)
 }
 
 func (a *artifactEventTestSuite) TestResolveOfDeleteArtifactEventMetadata() {
 	e := &event.Event{}
+	ctx := requestinfo.NewContext(context.Background(), "203.0.113.10", "docker/24.0.0")
 	metadata := &DeleteArtifactEventMetadata{
-		Ctx:      context.Background(),
+		Ctx:      ctx,
 		Artifact: &artifact.Artifact{ID: 1},
 		Tags:     []string{"latest"},
 	}
@@ -79,6 +88,8 @@ func (a *artifactEventTestSuite) TestResolveOfDeleteArtifactEventMetadata() {
 	a.Equal(int64(1), data.Artifact.ID)
 	a.Require().Len(data.Tags, 1)
 	a.Equal("latest", data.Tags[0])
+	a.Equal("203.0.113.10", data.ClientAddress)
+	a.Equal("docker/24.0.0", data.UserAgent)
 }
 
 func TestArtifactEventTestSuite(t *testing.T) {

--- a/src/controller/event/metadata/requestinfo/requestinfo.go
+++ b/src/controller/event/metadata/requestinfo/requestinfo.go
@@ -1,0 +1,54 @@
+// Copyright Project Harbor Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package requestinfo threads the source IP address and User-Agent of the
+// originating HTTP request through the notification pipeline, mirroring how
+// the sibling "operator" package threads the acting username. It exists
+// because artifact push/pull/delete events are resolved several layers below
+// the HTTP handler (and sometimes asynchronously, e.g. proxy-cache
+// background pulls), where *http.Request is no longer available but the
+// request-scoped context still is.
+package requestinfo
+
+import "context"
+
+// ContextKey is the key for storing request info in the context.
+type ContextKey struct{}
+
+// Info carries the source IP address and User-Agent of the request that
+// triggered an artifact event.
+type Info struct {
+	ClientAddress string
+	UserAgent     string
+}
+
+// NewContext returns a copy of ctx carrying the given client address and
+// user agent.
+func NewContext(ctx context.Context, clientAddress, userAgent string) context.Context {
+	return context.WithValue(ctx, ContextKey{}, Info{
+		ClientAddress: clientAddress,
+		UserAgent:     userAgent,
+	})
+}
+
+// FromContext returns the client address and user agent stored on ctx, if
+// any. Both are empty when ctx carries no request info, e.g. for events
+// fired from background jobs rather than an HTTP request.
+func FromContext(ctx context.Context) (clientAddress, userAgent string) {
+	info, ok := ctx.Value(ContextKey{}).(Info)
+	if !ok {
+		return "", ""
+	}
+	return info.ClientAddress, info.UserAgent
+}

--- a/src/controller/event/metadata/requestinfo/requestinfo_test.go
+++ b/src/controller/event/metadata/requestinfo/requestinfo_test.go
@@ -1,0 +1,35 @@
+// Copyright Project Harbor Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package requestinfo
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewContext_FromContext_RoundTrip(t *testing.T) {
+	ctx := NewContext(context.Background(), "203.0.113.10", "docker/24.0.0")
+	ip, ua := FromContext(ctx)
+	assert.Equal(t, "203.0.113.10", ip)
+	assert.Equal(t, "docker/24.0.0", ua)
+}
+
+func TestFromContext_NoValue(t *testing.T) {
+	ip, ua := FromContext(context.Background())
+	assert.Empty(t, ip)
+	assert.Empty(t, ua)
+}

--- a/src/controller/event/topic.go
+++ b/src/controller/event/topic.go
@@ -152,6 +152,13 @@ type ArtifactEvent struct {
 	Labels     []string
 	Operator   string
 	OccurAt    time.Time
+	// ClientAddress is the source IP address of the request that triggered
+	// the event. Empty when the event originates outside an HTTP request
+	// (e.g. replication, retention).
+	ClientAddress string
+	// UserAgent is the User-Agent header of the request that triggered the
+	// event.
+	UserAgent string
 }
 
 func (a *ArtifactEvent) String() string {
@@ -174,7 +181,9 @@ func (p *PushArtifactEvent) ResolveToAuditLog() (*model.AuditLogExt, error) {
 		Username:             p.Operator,
 		IsSuccessful:         true,
 		OperationDescription: fmt.Sprintf("push artifact: %s@%s", p.Artifact.RepositoryName, p.Artifact.Digest),
-		ResourceType:         ResourceTypeArtifact}
+		ResourceType:         ResourceTypeArtifact,
+		ClientAddress:        p.ClientAddress,
+		UserAgent:            p.UserAgent}
 
 	if len(p.Tags) == 0 {
 		auditLog.Resource = fmt.Sprintf("%s@%s",
@@ -205,7 +214,9 @@ func (p *PullArtifactEvent) ResolveToAuditLog() (*model.AuditLogExt, error) {
 		Username:             p.Operator,
 		IsSuccessful:         true,
 		OperationDescription: fmt.Sprintf("pull artifact: %s@%s", p.Artifact.RepositoryName, p.Artifact.Digest),
-		ResourceType:         ResourceTypeArtifact}
+		ResourceType:         ResourceTypeArtifact,
+		ClientAddress:        p.ClientAddress,
+		UserAgent:            p.UserAgent}
 
 	if len(p.Tags) == 0 {
 		auditLog.Resource = fmt.Sprintf("%s@%s",
@@ -244,7 +255,9 @@ func (d *DeleteArtifactEvent) ResolveToAuditLog() (*model.AuditLogExt, error) {
 		ResourceType:         ResourceTypeArtifact,
 		IsSuccessful:         true,
 		OperationDescription: fmt.Sprintf("delete artifact: %s@%s", d.Artifact.RepositoryName, d.Artifact.Digest),
-		Resource:             fmt.Sprintf("%s@%s", d.Artifact.RepositoryName, d.Artifact.Digest)}
+		Resource:             fmt.Sprintf("%s@%s", d.Artifact.RepositoryName, d.Artifact.Digest),
+		ClientAddress:        d.ClientAddress,
+		UserAgent:            d.UserAgent}
 	return auditLog, nil
 }
 

--- a/src/controller/event/topic_test.go
+++ b/src/controller/event/topic_test.go
@@ -1,0 +1,61 @@
+// Copyright Project Harbor Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package event
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/goharbor/harbor/src/pkg/artifact"
+)
+
+func testArtifactEvent() *ArtifactEvent {
+	return &ArtifactEvent{
+		Repository:    "library/hello-world",
+		Artifact:      &artifact.Artifact{ProjectID: 1, RepositoryName: "library/hello-world", Digest: "sha256:abc"},
+		Tags:          []string{"latest"},
+		Operator:      "admin",
+		OccurAt:       time.Now(),
+		ClientAddress: "203.0.113.10",
+		UserAgent:     "docker/24.0.0",
+	}
+}
+
+func TestPushArtifactEvent_ResolveToAuditLog_CarriesClientInfo(t *testing.T) {
+	e := &PushArtifactEvent{ArtifactEvent: testArtifactEvent()}
+	auditLog, err := e.ResolveToAuditLog()
+	require.NoError(t, err)
+	assert.Equal(t, "203.0.113.10", auditLog.ClientAddress)
+	assert.Equal(t, "docker/24.0.0", auditLog.UserAgent)
+}
+
+func TestPullArtifactEvent_ResolveToAuditLog_CarriesClientInfo(t *testing.T) {
+	e := &PullArtifactEvent{ArtifactEvent: testArtifactEvent()}
+	auditLog, err := e.ResolveToAuditLog()
+	require.NoError(t, err)
+	assert.Equal(t, "203.0.113.10", auditLog.ClientAddress)
+	assert.Equal(t, "docker/24.0.0", auditLog.UserAgent)
+}
+
+func TestDeleteArtifactEvent_ResolveToAuditLog_CarriesClientInfo(t *testing.T) {
+	e := &DeleteArtifactEvent{ArtifactEvent: testArtifactEvent()}
+	auditLog, err := e.ResolveToAuditLog()
+	require.NoError(t, err)
+	assert.Equal(t, "203.0.113.10", auditLog.ClientAddress)
+	assert.Equal(t, "docker/24.0.0", auditLog.UserAgent)
+}

--- a/src/controller/proxy/controller.go
+++ b/src/controller/proxy/controller.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/goharbor/harbor/src/controller/artifact"
 	"github.com/goharbor/harbor/src/controller/blob"
+	"github.com/goharbor/harbor/src/controller/event/metadata/requestinfo"
 	"github.com/goharbor/harbor/src/controller/event/operator"
 	"github.com/goharbor/harbor/src/controller/tag"
 	"github.com/goharbor/harbor/src/lib"
@@ -256,7 +257,8 @@ func (c *controller) ProxyManifest(ctx context.Context, art lib.ArtifactInfo, re
 			}
 		}
 		if a != nil {
-			SendPullEvent(bCtx, a, art.Tag, op)
+			ip, ua := requestinfo.FromContext(bCtx)
+			SendPullEvent(bCtx, a, art.Tag, op, ip, ua)
 		}
 	}) {
 		go func() {
@@ -278,7 +280,8 @@ func (c *controller) sendManifestPullEvent(ctx context.Context, art lib.Artifact
 		log.Errorf("failed to get manifest, error %v", err)
 	}
 	if a != nil {
-		SendPullEvent(ctx, a, art.Tag, op)
+		ip, ua := requestinfo.FromContext(ctx)
+		SendPullEvent(ctx, a, art.Tag, op, ip, ua)
 	}
 }
 

--- a/src/controller/proxy/local.go
+++ b/src/controller/proxy/local.go
@@ -192,11 +192,13 @@ func (l *localHelper) UpdatePullTime(ctx context.Context, art lib.ArtifactInfo) 
 }
 
 // SendPullEvent send a pull image event
-func SendPullEvent(ctx context.Context, a *artifact.Artifact, tag, operator string) {
+func SendPullEvent(ctx context.Context, a *artifact.Artifact, tag, operator, clientAddress, userAgent string) {
 	e := &metadata.PullArtifactEventMetadata{
-		Artifact: &a.Artifact,
-		Tag:      tag,
-		Operator: operator,
+		Artifact:      &a.Artifact,
+		Tag:           tag,
+		Operator:      operator,
+		ClientAddress: clientAddress,
+		UserAgent:     userAgent,
 	}
 	event.BuildAndPublish(ctx, e)
 }

--- a/src/server/middleware/repoproxy/proxy.go
+++ b/src/server/middleware/repoproxy/proxy.go
@@ -34,6 +34,7 @@ import (
 	"github.com/goharbor/harbor/src/common/security"
 	"github.com/goharbor/harbor/src/common/security/proxycachesecret"
 	robotSc "github.com/goharbor/harbor/src/common/security/robot"
+	"github.com/goharbor/harbor/src/controller/event/metadata/requestinfo"
 	"github.com/goharbor/harbor/src/controller/project"
 	"github.com/goharbor/harbor/src/controller/proxy"
 	"github.com/goharbor/harbor/src/controller/registry"
@@ -55,6 +56,7 @@ import (
 	"github.com/goharbor/harbor/src/pkg/proxy/connection"
 	"github.com/goharbor/harbor/src/pkg/reg/model"
 	"github.com/goharbor/harbor/src/server/middleware"
+	securitymiddleware "github.com/goharbor/harbor/src/server/middleware/security"
 )
 
 const (
@@ -296,7 +298,10 @@ func upstreamRegistryConnectionKey(art lib.ArtifactInfo) string {
 }
 
 func handleManifest(w http.ResponseWriter, r *http.Request, next http.Handler) error {
-	ctx := r.Context()
+	// carry the client address/user agent down into the (possibly async,
+	// proxy-cache background) pull event so the eventual audit log entry
+	// still records who triggered it.
+	ctx := requestinfo.NewContext(r.Context(), securitymiddleware.GetClientIP(r), securitymiddleware.GetUserAgent(r))
 	art, p, proxyCtl, err := preCheck(ctx, true)
 	if err != nil {
 		return err

--- a/src/server/registry/manifest.go
+++ b/src/server/registry/manifest.go
@@ -26,6 +26,7 @@ import (
 	"github.com/goharbor/harbor/src/common"
 	"github.com/goharbor/harbor/src/controller/artifact"
 	"github.com/goharbor/harbor/src/controller/event/metadata"
+	"github.com/goharbor/harbor/src/controller/event/metadata/requestinfo"
 	"github.com/goharbor/harbor/src/controller/event/operator"
 	"github.com/goharbor/harbor/src/controller/repository"
 	"github.com/goharbor/harbor/src/lib"
@@ -35,6 +36,7 @@ import (
 	"github.com/goharbor/harbor/src/lib/log"
 	"github.com/goharbor/harbor/src/pkg"
 	"github.com/goharbor/harbor/src/pkg/notification"
+	securitymiddleware "github.com/goharbor/harbor/src/server/middleware/security"
 	"github.com/goharbor/harbor/src/server/router"
 )
 
@@ -129,8 +131,10 @@ func getManifest(w http.ResponseWriter, req *http.Request) {
 	}
 
 	e := &metadata.PullArtifactEventMetadata{
-		Artifact: &art.Artifact,
-		Operator: operator.FromContext(req.Context()),
+		Artifact:      &art.Artifact,
+		Operator:      operator.FromContext(req.Context()),
+		ClientAddress: securitymiddleware.GetClientIP(req),
+		UserAgent:     securitymiddleware.GetUserAgent(req),
 	}
 	// the reference is tag
 	if _, err = digest.Parse(reference); err != nil {
@@ -158,7 +162,8 @@ func deleteManifest(w http.ResponseWriter, req *http.Request) {
 		lib_http.SendError(w, err)
 		return
 	}
-	if err = artifact.Ctl.Delete(req.Context(), art.ID); err != nil {
+	ctx := requestinfo.NewContext(req.Context(), securitymiddleware.GetClientIP(req), securitymiddleware.GetUserAgent(req))
+	if err = artifact.Ctl.Delete(ctx, art.ID); err != nil {
 		lib_http.SendError(w, err)
 		return
 	}
@@ -225,7 +230,8 @@ func putManifest(w http.ResponseWriter, req *http.Request) {
 		tags = append(tags, reference)
 	}
 
-	if _, _, err := artifact.Ctl.Ensure(req.Context(), repo, dgt, &artifact.ArtOption{
+	ctx := requestinfo.NewContext(req.Context(), securitymiddleware.GetClientIP(req), securitymiddleware.GetUserAgent(req))
+	if _, _, err := artifact.Ctl.Ensure(ctx, repo, dgt, &artifact.ArtOption{
 		Tags: tags,
 	}); err != nil {
 		lib_http.SendError(w, err)


### PR DESCRIPTION
## Summary

Extends the client IP address / User-Agent audit log capture introduced by #701 to container image push, pull, and delete. Those operations go through the Docker Registry V2 API path (`server/registry`, `server/middleware/repoproxy`, `controller/proxy`), which is a separate pipeline from the generic REST API `commonevent` middleware and never picked up the IP/UA capture added in #701.

- `server/registry/manifest.go` now captures the client IP and User-Agent directly from the HTTP request for pull, and via a new `requestinfo`-carrying context for push/delete (which only have access to `context.Context`, not the request, several layers down).
- The proxy-cache pull path (`server/middleware/repoproxy`, `controller/proxy`) threads the same context through its background goroutines (cache-fill, delayed manifest pulls) so those still record who triggered the pull.
- `ArtifactEvent` (`controller/event/topic.go`) and its metadata resolvers (`controller/event/metadata/artifact.go`) gain `ClientAddress`/`UserAgent` fields, populated into `AuditLogExt` via the columns and API/UI surfacing #701 already added.

No new database columns, API fields, or UI are added here — this PR only extends *capture* to the artifact event path so push/pull/delete audit log entries get the same IP/User-Agent columns #701 introduced for the rest of the audit log.

Stacked on #701 since it depends on `AuditLogExt.ClientAddress`/`UserAgent` existing; base branch is `next-ipaddr-auditlog`, not `main`.

## Related Issues

N/A

## Type of Change

- [ ] Bug fix (`fix:`)
- [x] New feature (`feat:`)
- [ ] Breaking change (`feat!:` / `fix!:`)
- [ ] Documentation (`docs:`)
- [ ] Refactoring (`refactor:`)
- [ ] CI/CD or build changes (`ci:` / `build:`)
- [ ] Upstream Harbor cherry-pick (`upstream:`)
- [ ] Dependencies update (`chore:`)
- [ ] Tests (`test:`)

## Release Notes

Audit log entries for container image push, pull, and delete now record the source IP address and User-Agent of the request that triggered them, matching the IP/User-Agent capture already added for other audit log events.

## Testing

- [x] Unit tests added/updated
- [ ] Manual testing performed

Added/updated Go unit tests for `requestinfo`, `commonevent`/artifact metadata resolvers, and `ArtifactEvent.ResolveToAuditLog()`. Ran `go build ./...`, `go vet`, and `go test ./controller/event/... ./controller/proxy/... ./server/registry/... ./server/middleware/repoproxy/...` (all pass). Also confirmed a pre-existing, unrelated hang in `controller/artifact` `TestCopy` reproduces identically on an unmodified `main` checkout, i.e. it is not caused by this change.

## Checklist

- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] Commits are signed off (`git commit -s`)
- [x] No new warnings introduced
