### PR TITLE
perf: Detach quota reserve/rollback from the request-wide transaction

### DIFF
--- a/DESCRIPTION.md
+++ b/DESCRIPTION.md
@@ -1,0 +1,108 @@
+# perf: Detach quota reserve/rollback from the request-wide transaction
+
+## Idea
+
+`quota.RequestMiddleware` reserves quota before proxying a push to the registry.
+Under `transaction.Middleware` the reserve's version-CAS `UPDATE quota_usage`
+executed on the request-wide `TxOrmer`, so the row lock taken by that UPDATE was
+held until the request transaction committed — across the proxied registry
+round-trip, the abstractor HTTP fetches in `artifact.Ctl.Ensure`, and all
+after-response blob bookkeeping. Every concurrent push to the same project
+serialized on that one row for the full request duration.
+
+This patch runs the reserve (and the compensating rollback) on a fresh
+autocommit ormer when the incoming context carries a transactional ormer. The
+row lock now lasts exactly one UPDATE statement. Semantics are unchanged:
+reserve-before-proxy, compensate-on-failure via the pre-existing
+`rollbackResources` path in `Request`.
+
+## Mechanism
+
+- `src/lib/orm/orm.go`: new `InTransaction(ctx)` helper — true when the ctx
+  ormer is a beego `TxOrmer` (i.e. inside `WithTransaction`, e.g. the request-
+  wide tx started by the transaction middleware).
+- `src/controller/quota/controller.go` `Request`: when the update provider is
+  the DB and `orm.InTransaction(ctx)`, the reserve runs on `orm.Clone(ctx)`
+  (fresh autocommit ormer, request cancellation kept) and the rollback on
+  `orm.Copy(ctx)` (fresh autocommit ormer, cancellation dropped so the
+  compensation still lands after the client goes away). No explicit side
+  transaction is needed: the reserve is a `SELECT quota` + `SELECT quota_usage`
+  + one CAS `UPDATE`, and the version CAS already provides the atomicity, so
+  autocommit is strictly better than a BEGIN/COMMIT pair (fewer statements,
+  shortest possible lock hold).
+- The redis update provider path is untouched (it does not touch the DB in the
+  request path). `Refresh` is untouched: its recalculation reads uncommitted
+  rows of the request tx, so detaching it would persist usage derived from data
+  that may roll back.
+- Unit tests: `InTransaction` table test; `Request` tests asserting the reserve
+  is persisted before `f()` runs and that the rollback compensates (usage back
+  to the pre-reserve value) when `f()` fails.
+
+## Files changed
+
+- `src/lib/orm/orm.go` (+12)
+- `src/lib/orm/in_transaction_test.go` (new)
+- `src/controller/quota/controller.go` (+18, -2)
+- `src/controller/quota/controller_test.go` (+38)
+
+## Measurements
+
+Harness (single-client push+pull of alpine:latest, Postgres `log_statement=all`,
+same machine/method as the baseline):
+
+| metric      | main@177e51e99 | patched | delta |
+|-------------|----------------|---------|-------|
+| push stmts  | 286            | 286     | 0     |
+| push tx     | 9              | 9       | 0     |
+| pull stmts  | 55             | 55      | 0     |
+
+No statement-count change — expected and honest: this patch moves the lock
+window, it does not remove queries (autocommit avoids even the +2 BEGIN/COMMIT
+the idea budgeted for).
+
+Concurrency lock probe (8 parallel `crane copy` pushes of 8 distinct alpine
+images into ONE project, `log_lock_waits=on`, `deadlock_timeout=50ms`,
+pg_locks sampled every ~150 ms for waiters whose query touches quota_usage;
+identical script run against baseline via `git stash` in this worktree):
+
+| metric                                  | baseline | patched |
+|-----------------------------------------|----------|---------|
+| quota_usage UPDATEs inside request tx   | 46       | 0       |
+| quota_usage UPDATEs autocommit          | 0        | 30      |
+| logged lock waits >50ms (quota_usage row) | 2      | 0       |
+| pg_locks samples with waiters           | 3 of 16  | 0 of 16 |
+| max concurrent backends blocked on row  | 5        | 0       |
+| wall time, 8 concurrent pushes          | 2.59 s   | 2.53 s  |
+
+Interpretation: baseline had up to 5 of 8 pushers simultaneously blocked on the
+quota_usage tuple; patched shows zero cross-request quota_usage waits in every
+sample, and fewer total UPDATE attempts (30 vs 46) because writers no longer
+queue behind a long-held row lock and then CAS-fail in a burst. Local wall time
+is within noise because the local registry round-trip is sub-ms; the lock hold
+it eliminates scales with the registry round-trip (100 ms – seconds against
+S3/R2-backed registries in production, where quota_usage contention is the
+observed fleet bottleneck).
+
+## Risks
+
+- The reservation is durable independently of the request tx. A core crash (or
+  request-tx commit failure) between the committed reserve and the rollback
+  leaves the quota over-counted until the next `Refresh` (any subsequent
+  successful push/delete of the project, or a manual refresh). This matches
+  the exposure already accepted by the redis update provider, which flushes
+  usage to the DB asynchronously.
+- Each in-flight push briefly takes one extra pooled connection for the
+  reserve (2 SELECTs + 1 UPDATE). In the theoretical case of ≥ max_open_conns
+  concurrent in-tx requests all reserving at once, requests could wait on the
+  pool while holding their tx connection; the window is sub-ms and
+  POSTGRESQL_MAX_OPEN_CONNS=100 per service makes this unlikely, but it is a
+  new (bounded) pool interaction.
+- The rollback deliberately drops request cancellation (`orm.Copy`) so the
+  compensation runs even when the client disconnected mid-push; previously the
+  request-tx rollback undid the reserve implicitly in that case.
+
+## Rollback
+
+Revert the branch (single commit) or just the `Request` hunk in
+`src/controller/quota/controller.go`; `orm.InTransaction` is a pure additive
+helper. No config, schema, or API surface involved.

--- a/DESCRIPTION.md
+++ b/DESCRIPTION.md
@@ -30,20 +30,62 @@ reserve-before-proxy, compensate-on-failure via the pre-existing
   + one CAS `UPDATE`, and the version CAS already provides the atomicity, so
   autocommit is strictly better than a BEGIN/COMMIT pair (fewer statements,
   shortest possible lock hold).
-- The redis update provider path is untouched (it does not touch the DB in the
-  request path). `Refresh` is untouched: its recalculation reads uncommitted
-  rows of the request tx, so detaching it would persist usage derived from data
-  that may roll back.
+- The redis update provider path is untouched (its request-path usage lives in
+  redis; the DB is only read on a cache miss via `calcQuota`, and usage is
+  flushed to the DB asynchronously).
 - Unit tests: `InTransaction` table test; `Request` tests asserting the reserve
   is persisted before `f()` runs and that the rollback compensates (usage back
-  to the pre-reserve value) when `f()` fails.
+  to the pre-reserve value) when `f()` fails; `TestInflightLedger` covering the
+  ledger round-trip and expiry reaping (skips when redis is unreachable).
+
+## Refresh reconcile (in-flight reservation ledger)
+
+Detaching the reserve opens a window the request-wide transaction used to
+close implicitly: the committed reservation is visible in `quota_usage` while
+the push's artifact/blob rows are still uncommitted. A concurrent `Refresh`
+(artifact delete, GC, retention, manual) recalculates usage from those tables,
+cannot see the in-flight rows, and would CAS-overwrite the reservation
+(baseline avoided this only because Refresh's UPDATE blocked on the row lock
+until the push committed, then CAS-failed and recalculated against committed
+rows).
+
+`src/controller/quota/inflight.go` closes the window with a redis ledger:
+
+- `Request` (DB provider only) records the reserved delta under a unique token
+  **before** the reserve commits, so no ordering lets Refresh observe the
+  reservation without the ledger entry.
+- `Refresh`'s `calculateUsage` adds the sum of live ledger entries on top of
+  `driver.CalculateUsage`, so in-flight reservations survive a concurrent
+  recalculation.
+- The entry is removed after the enclosing request transaction commits
+  (`orm.AfterCommit`; runs immediately when there is no tx, e.g. the blob PUT
+  route) — at that point the rows are countable by the recalculation itself —
+  or right after a failed `f()` has been compensated by `rollbackResources`.
+- Crash safety: each entry carries a 10-minute deadline; readers skip and reap
+  expired entries, and the key has a 2× TTL as idle GC. An orphaned entry
+  therefore over-counts refreshes for at most 10 minutes, after which the next
+  Refresh converges — deliberately erring toward blocking pushes rather than
+  breaching quota.
+- Redis unavailability degrades gracefully: track/read failures are logged and
+  behavior falls back to the pre-ledger semantics (reserve still happens; the
+  race window returns until redis is back). This also means the ledger adds
+  zero SQL statements; it is 1–2 redis round-trips per reserving request.
+
+Known residual (documented, judged acceptable): between the request-tx commit
+and the `AfterCommit` HDEL, a Refresh counts the rows *and* the ledger entry —
+a transient over-count that the same Refresh path corrects on its next run.
+If the request tx rolls back after a successful `f()` (commit failure), the
+`AfterCommit` hook never fires and the entry lives until its deadline; usage
+is over-counted for that window, consistent with the crash exposure below.
 
 ## Files changed
 
-- `src/lib/orm/orm.go` (+12)
+- `src/lib/orm/orm.go` (`InTransaction` helper)
 - `src/lib/orm/in_transaction_test.go` (new)
-- `src/controller/quota/controller.go` (+18, -2)
-- `src/controller/quota/controller_test.go` (+38)
+- `src/controller/quota/controller.go` (`Request` detach + ledger wiring,
+  `Refresh` in-flight adjustment)
+- `src/controller/quota/inflight.go` (new: in-flight reservation ledger)
+- `src/controller/quota/controller_test.go`, `inflight_test.go` (tests)
 
 ## Measurements
 
@@ -88,9 +130,14 @@ observed fleet bottleneck).
 - The reservation is durable independently of the request tx. A core crash (or
   request-tx commit failure) between the committed reserve and the rollback
   leaves the quota over-counted until the next `Refresh` (any subsequent
-  successful push/delete of the project, or a manual refresh). This matches
-  the exposure already accepted by the redis update provider, which flushes
-  usage to the DB asynchronously.
+  successful push/delete of the project, or a manual refresh); the matching
+  ledger entry additionally makes refreshes over-count until its 10-minute
+  deadline. This matches the direction of the exposure already accepted by the
+  redis update provider (asynchronous flush): quota errs toward over-counting,
+  never toward breaching the limit.
+- Concurrent `Refresh` vs in-flight reserve is reconciled by the ledger (see
+  above); with redis down the pre-ledger race window returns, bounded by redis
+  availability.
 - Each in-flight push briefly takes one extra pooled connection for the
   reserve (2 SELECTs + 1 UPDATE). In the theoretical case of ≥ max_open_conns
   concurrent in-tx requests all reserving at once, requests could wait on the

--- a/src/controller/quota/controller.go
+++ b/src/controller/quota/controller.go
@@ -388,7 +388,24 @@ func (c *controller) Request(ctx context.Context, reference, referenceID string,
 	}
 
 	provider := updateQuotaProviderType(config.GetQuotaUpdateProvider())
-	if err := c.updateUsageWithRetry(ctx, reference, referenceID, reserveResources(resources), provider); err != nil {
+
+	// When called inside the request-wide transaction (transaction middleware),
+	// the reserve UPDATE would keep the quota_usage row lock until that
+	// transaction commits, i.e. across the proxied registry round-trip, which
+	// serializes all concurrent pushes to the same project. Detach the
+	// reserve/rollback onto fresh autocommit ormers so the row lock is released
+	// right after the single CAS UPDATE. The rollback additionally drops the
+	// request cancellation because the compensation must still run when the
+	// client has gone away. The residual exposure — a crash between the
+	// committed reserve and the rollback over-counts usage until the next
+	// refresh — matches what the redis update provider already accepts.
+	reserveCtx, rollbackCtx := ctx, ctx
+	if provider != updateQuotaProviderRedis && orm.InTransaction(ctx) {
+		reserveCtx = orm.Clone(ctx)
+		rollbackCtx = orm.Copy(ctx)
+	}
+
+	if err := c.updateUsageWithRetry(reserveCtx, reference, referenceID, reserveResources(resources), provider); err != nil {
 		log.G(ctx).Errorf("reserve resources %s for %s %s failed, error: %v", resources.String(), reference, referenceID, err)
 		return err
 	}
@@ -396,7 +413,7 @@ func (c *controller) Request(ctx context.Context, reference, referenceID string,
 	err := f()
 
 	if err != nil {
-		if er := c.updateUsageWithRetry(ctx, reference, referenceID, rollbackResources(resources), provider); er != nil {
+		if er := c.updateUsageWithRetry(rollbackCtx, reference, referenceID, rollbackResources(resources), provider); er != nil {
 			// ignore this error, the quota usage will be correct when users do operations which will call refresh quota
 			log.G(ctx).Warningf("rollback resources %s for %s %s failed, error: %v", resources.String(), reference, referenceID, er)
 		}

--- a/src/controller/quota/controller.go
+++ b/src/controller/quota/controller.go
@@ -375,9 +375,7 @@ func (c *controller) Refresh(ctx context.Context, reference, referenceID string,
 			return nil, err
 		}
 
-		// Reservations whose rows are not yet committed are invisible to
-		// CalculateUsage; without this the refresh would overwrite them (see
-		// inflight.go).
+		// uncommitted in-flight reservations are invisible to CalculateUsage (see inflight.go)
 		if inflight := c.inflightSum(ctx, reference, referenceID); len(inflight) > 0 {
 			newUsed = types.Add(newUsed, inflight)
 		}
@@ -396,16 +394,11 @@ func (c *controller) Request(ctx context.Context, reference, referenceID string,
 
 	provider := updateQuotaProviderType(config.GetQuotaUpdateProvider())
 
-	// When called inside the request-wide transaction (transaction middleware),
-	// the reserve UPDATE would keep the quota_usage row lock until that
-	// transaction commits, i.e. across the proxied registry round-trip, which
-	// serializes all concurrent pushes to the same project. Detach the
-	// reserve/rollback onto fresh autocommit ormers so the row lock is released
-	// right after the single CAS UPDATE. The rollback additionally drops the
-	// request cancellation because the compensation must still run when the
-	// client has gone away. The residual exposure — a crash between the
-	// committed reserve and the rollback over-counts usage until the next
-	// refresh — matches what the redis update provider already accepts.
+	// Inside the request-wide tx the reserve UPDATE would hold the quota_usage
+	// row lock across the proxied registry round-trip, serializing all pushes
+	// to the project — detach it onto autocommit ormers (the version CAS gives
+	// atomicity). Rollback uses orm.Copy: compensation must still run after
+	// the client disconnected.
 	reserveCtx, rollbackCtx := ctx, ctx
 	detached := provider != updateQuotaProviderRedis && orm.InTransaction(ctx)
 	if detached {
@@ -413,10 +406,8 @@ func (c *controller) Request(ctx context.Context, reference, referenceID string,
 		rollbackCtx = orm.Copy(ctx)
 	}
 
-	// The ledger entry must exist before the reserve commits so a concurrent
-	// Refresh never observes the committed reservation without it (see
-	// inflight.go). Only the DB provider needs it: the redis provider's usage
-	// lives in redis and is flushed asynchronously anyway.
+	// track before the reserve commits — no ordering may let a concurrent
+	// Refresh see the reservation without the ledger entry (see inflight.go)
 	cleanup := func() {}
 	if provider == updateQuotaProviderDB {
 		if token, err := c.trackInflight(ctx, reference, referenceID, resources); err != nil {
@@ -443,8 +434,7 @@ func (c *controller) Request(ctx context.Context, reference, referenceID string,
 		return err
 	}
 
-	// On success the reserved rows become countable only once the enclosing
-	// transaction commits; AfterCommit runs immediately when there is none.
+	// the reserved rows only become countable by Refresh at commit
 	orm.AfterCommit(ctx, cleanup)
 
 	return nil

--- a/src/controller/quota/controller.go
+++ b/src/controller/quota/controller.go
@@ -375,6 +375,13 @@ func (c *controller) Refresh(ctx context.Context, reference, referenceID string,
 			return nil, err
 		}
 
+		// Reservations whose rows are not yet committed are invisible to
+		// CalculateUsage; without this the refresh would overwrite them (see
+		// inflight.go).
+		if inflight := c.inflightSum(ctx, reference, referenceID); len(inflight) > 0 {
+			newUsed = types.Add(newUsed, inflight)
+		}
+
 		return newUsed, err
 	}
 
@@ -400,13 +407,28 @@ func (c *controller) Request(ctx context.Context, reference, referenceID string,
 	// committed reserve and the rollback over-counts usage until the next
 	// refresh — matches what the redis update provider already accepts.
 	reserveCtx, rollbackCtx := ctx, ctx
-	if provider != updateQuotaProviderRedis && orm.InTransaction(ctx) {
+	detached := provider != updateQuotaProviderRedis && orm.InTransaction(ctx)
+	if detached {
 		reserveCtx = orm.Clone(ctx)
 		rollbackCtx = orm.Copy(ctx)
 	}
 
+	// The ledger entry must exist before the reserve commits so a concurrent
+	// Refresh never observes the committed reservation without it (see
+	// inflight.go). Only the DB provider needs it: the redis provider's usage
+	// lives in redis and is flushed asynchronously anyway.
+	cleanup := func() {}
+	if provider == updateQuotaProviderDB {
+		if token, err := c.trackInflight(ctx, reference, referenceID, resources); err != nil {
+			log.G(ctx).Warningf("failed to track in-flight quota reservation for %s %s, refresh may transiently under-count: %v", reference, referenceID, err)
+		} else {
+			cleanup = func() { c.untrackInflight(ctx, reference, referenceID, token) }
+		}
+	}
+
 	if err := c.updateUsageWithRetry(reserveCtx, reference, referenceID, reserveResources(resources), provider); err != nil {
 		log.G(ctx).Errorf("reserve resources %s for %s %s failed, error: %v", resources.String(), reference, referenceID, err)
+		cleanup()
 		return err
 	}
 
@@ -417,9 +439,15 @@ func (c *controller) Request(ctx context.Context, reference, referenceID string,
 			// ignore this error, the quota usage will be correct when users do operations which will call refresh quota
 			log.G(ctx).Warningf("rollback resources %s for %s %s failed, error: %v", resources.String(), reference, referenceID, er)
 		}
+		cleanup()
+		return err
 	}
 
-	return err
+	// On success the reserved rows become countable only once the enclosing
+	// transaction commits; AfterCommit runs immediately when there is none.
+	orm.AfterCommit(ctx, cleanup)
+
+	return nil
 }
 
 // calcQuota calculates the quota and usage in real time.

--- a/src/controller/quota/controller_test.go
+++ b/src/controller/quota/controller_test.go
@@ -143,6 +143,43 @@ func (suite *ControllerTestSuite) TestRequestFunctionFailed() {
 	suite.Error(suite.ctl.Request(ctx, suite.reference, referenceID, resources, func() error { return fmt.Errorf("error") }))
 }
 
+func (suite *ControllerTestSuite) TestRequestReservePersistedBeforeF() {
+	mock.OnAnything(suite.quotaMgr, "GetByRef").Return(suite.quota, nil)
+
+	updates := 0
+	mock.OnAnything(suite.quotaMgr, "Update").Run(func(mock.Arguments) { updates++ }).Return(nil)
+
+	ctx := orm.NewContext(context.TODO(), &ormtesting.FakeOrmer{})
+	referenceID := uuid.New().String()
+	resources := types.ResourceList{types.ResourceStorage: 10}
+
+	suite.Nil(suite.ctl.Request(ctx, suite.reference, referenceID, resources, func() error {
+		suite.Equal(1, updates, "the reserve must be persisted before f runs")
+		return nil
+	}))
+	suite.Equal(1, updates, "no rollback expected when f succeeds")
+}
+
+func (suite *ControllerTestSuite) TestRequestRollbackCompensatesOnFError() {
+	mock.OnAnything(suite.quotaMgr, "GetByRef").Return(suite.quota, nil)
+
+	updates := 0
+	mock.OnAnything(suite.quotaMgr, "Update").Run(func(mock.Arguments) { updates++ }).Return(nil)
+
+	ctx := orm.NewContext(context.TODO(), &ormtesting.FakeOrmer{})
+	referenceID := uuid.New().String()
+	resources := types.ResourceList{types.ResourceStorage: 10}
+
+	suite.Error(suite.ctl.Request(ctx, suite.reference, referenceID, resources, func() error {
+		return fmt.Errorf("error")
+	}))
+	suite.Equal(2, updates, "the rollback must compensate the reserve when f fails")
+
+	used, err := suite.quota.GetUsed()
+	suite.Nil(err)
+	suite.Equal(int64(0), used[types.ResourceStorage], "usage must be back to the pre-reserve value")
+}
+
 func (suite *ControllerTestSuite) TestRequestResourceIsZero() {
 	suite.PrepareForUpdate(suite.quota, nil)
 

--- a/src/controller/quota/inflight.go
+++ b/src/controller/quota/inflight.go
@@ -27,22 +27,15 @@ import (
 	"github.com/goharbor/harbor/src/pkg/quota/types"
 )
 
-// A reserve that committed on its own short transaction (see Request) is
-// visible in quota_usage before the artifact/blob rows of the request it
-// belongs to are committed. A concurrent Refresh recalculating usage from
-// those tables would not see the in-flight rows and would CAS-overwrite the
-// reservation. The in-flight ledger closes that gap: every detached reserve
-// is recorded here first, and Refresh adds the ledger sum on top of the
-// recalculated usage. Entries are removed once the owning transaction has
-// committed (the rows are then counted by the recalculation itself) or after
-// the reservation has been rolled back; the per-entry deadline reclaims
-// entries orphaned by a crash, erring on the side of over-counting until it
-// expires.
+// A detached reserve (see Request) commits before the artifact/blob rows it
+// pays for; a concurrent Refresh recalculating from those tables would
+// CAS-overwrite it. This ledger closes the gap: reserves are recorded before
+// they commit, Refresh adds the ledger sum, entries are removed on tx commit
+// or rollback. Deadlines reclaim crash orphans, erring toward over-counting.
 
 const (
-	// inflightEntryTTL must outlive the longest request that can sit between
-	// a committed reserve and its transaction commit (manifest PUT incl.
-	// abstractor fetches). Key-level TTL doubles it as idle-project GC.
+	// must outlive the longest request between reserve and tx commit
+	// (manifest PUT incl. abstractor fetches)
 	inflightEntryTTL = 10 * time.Minute
 )
 
@@ -56,9 +49,6 @@ func inflightKey(reference, referenceID string) string {
 	return fmt.Sprintf("cache:quota:inflight:%s:%s", reference, referenceID)
 }
 
-// trackInflight records resources in the ledger and returns the token to
-// remove them with. A failure only degrades Refresh accuracy back to the
-// pre-ledger behavior, so it is logged and the reservation proceeds.
 func (c *controller) trackInflight(ctx context.Context, reference, referenceID string, resources types.ResourceList) (string, error) {
 	client, err := libredis.GetHarborClient()
 	if err != nil {
@@ -78,15 +68,13 @@ func (c *controller) trackInflight(ctx context.Context, reference, referenceID s
 	if err := client.HSet(ctx, key, token, payload).Err(); err != nil {
 		return "", err
 	}
-	// best effort: bounds the key when a busy project never drains to zero entries
+	// key-level TTL alone is not enough: a busy project keeps refreshing it,
+	// so expired fields are additionally reaped in inflightSum
 	client.Expire(ctx, key, 2*inflightEntryTTL)
 
 	return token, nil
 }
 
-// untrackInflight removes one ledger entry. Runs after the owning transaction
-// committed or after the reservation was rolled back, so it must not be tied
-// to the request's cancellation.
 func (c *controller) untrackInflight(ctx context.Context, reference, referenceID, token string) {
 	client, err := libredis.GetHarborClient()
 	if err != nil {
@@ -98,9 +86,7 @@ func (c *controller) untrackInflight(ctx context.Context, reference, referenceID
 	}
 }
 
-// inflightSum returns the total of live ledger entries for the reference.
-// Expired entries are skipped and opportunistically deleted. Any error means
-// "no adjustment" so Refresh still converges the way it did before the ledger.
+// Errors degrade to "no adjustment": Refresh then behaves as before the ledger.
 func (c *controller) inflightSum(ctx context.Context, reference, referenceID string) types.ResourceList {
 	client, err := libredis.GetHarborClient()
 	if err != nil {

--- a/src/controller/quota/inflight.go
+++ b/src/controller/quota/inflight.go
@@ -1,0 +1,134 @@
+// Copyright Project Harbor Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package quota
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/goharbor/harbor/src/lib/log"
+	libredis "github.com/goharbor/harbor/src/lib/redis"
+	"github.com/goharbor/harbor/src/pkg/quota/types"
+)
+
+// A reserve that committed on its own short transaction (see Request) is
+// visible in quota_usage before the artifact/blob rows of the request it
+// belongs to are committed. A concurrent Refresh recalculating usage from
+// those tables would not see the in-flight rows and would CAS-overwrite the
+// reservation. The in-flight ledger closes that gap: every detached reserve
+// is recorded here first, and Refresh adds the ledger sum on top of the
+// recalculated usage. Entries are removed once the owning transaction has
+// committed (the rows are then counted by the recalculation itself) or after
+// the reservation has been rolled back; the per-entry deadline reclaims
+// entries orphaned by a crash, erring on the side of over-counting until it
+// expires.
+
+const (
+	// inflightEntryTTL must outlive the longest request that can sit between
+	// a committed reserve and its transaction commit (manifest PUT incl.
+	// abstractor fetches). Key-level TTL doubles it as idle-project GC.
+	inflightEntryTTL = 10 * time.Minute
+)
+
+type inflightEntry struct {
+	Resources types.ResourceList `json:"r"`
+	Deadline  int64              `json:"exp"`
+}
+
+func inflightKey(reference, referenceID string) string {
+	// same namespace convention as updateUsageByRedis
+	return fmt.Sprintf("cache:quota:inflight:%s:%s", reference, referenceID)
+}
+
+// trackInflight records resources in the ledger and returns the token to
+// remove them with. A failure only degrades Refresh accuracy back to the
+// pre-ledger behavior, so it is logged and the reservation proceeds.
+func (c *controller) trackInflight(ctx context.Context, reference, referenceID string, resources types.ResourceList) (string, error) {
+	client, err := libredis.GetHarborClient()
+	if err != nil {
+		return "", err
+	}
+
+	token := uuid.NewString()
+	payload, err := json.Marshal(inflightEntry{
+		Resources: resources,
+		Deadline:  time.Now().Add(inflightEntryTTL).Unix(),
+	})
+	if err != nil {
+		return "", err
+	}
+
+	key := inflightKey(reference, referenceID)
+	if err := client.HSet(ctx, key, token, payload).Err(); err != nil {
+		return "", err
+	}
+	// best effort: bounds the key when a busy project never drains to zero entries
+	client.Expire(ctx, key, 2*inflightEntryTTL)
+
+	return token, nil
+}
+
+// untrackInflight removes one ledger entry. Runs after the owning transaction
+// committed or after the reservation was rolled back, so it must not be tied
+// to the request's cancellation.
+func (c *controller) untrackInflight(ctx context.Context, reference, referenceID, token string) {
+	client, err := libredis.GetHarborClient()
+	if err != nil {
+		log.G(ctx).Warningf("quota inflight: failed to get redis client to untrack %s/%s: %v", reference, referenceID, err)
+		return
+	}
+	if err := client.HDel(context.WithoutCancel(ctx), inflightKey(reference, referenceID), token).Err(); err != nil {
+		log.G(ctx).Warningf("quota inflight: failed to untrack %s/%s (entry expires at its deadline): %v", reference, referenceID, err)
+	}
+}
+
+// inflightSum returns the total of live ledger entries for the reference.
+// Expired entries are skipped and opportunistically deleted. Any error means
+// "no adjustment" so Refresh still converges the way it did before the ledger.
+func (c *controller) inflightSum(ctx context.Context, reference, referenceID string) types.ResourceList {
+	client, err := libredis.GetHarborClient()
+	if err != nil {
+		log.G(ctx).Warningf("quota inflight: failed to get redis client for %s/%s: %v", reference, referenceID, err)
+		return nil
+	}
+
+	key := inflightKey(reference, referenceID)
+	entries, err := client.HGetAll(ctx, key).Result()
+	if err != nil {
+		log.G(ctx).Warningf("quota inflight: failed to read ledger for %s/%s: %v", reference, referenceID, err)
+		return nil
+	}
+
+	now := time.Now().Unix()
+	var sum types.ResourceList
+	var expired []string
+	for token, raw := range entries {
+		var entry inflightEntry
+		if err := json.Unmarshal([]byte(raw), &entry); err != nil || entry.Deadline <= now {
+			expired = append(expired, token)
+			continue
+		}
+		sum = types.Add(sum, entry.Resources)
+	}
+	if len(expired) > 0 {
+		client.HDel(context.WithoutCancel(ctx), key, expired...)
+	}
+
+	return sum
+}

--- a/src/controller/quota/inflight_test.go
+++ b/src/controller/quota/inflight_test.go
@@ -1,0 +1,74 @@
+// Copyright Project Harbor Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package quota
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	libredis "github.com/goharbor/harbor/src/lib/redis"
+	"github.com/goharbor/harbor/src/pkg/quota/types"
+)
+
+func TestInflightLedger(t *testing.T) {
+	client, err := libredis.GetHarborClient()
+	if err != nil {
+		t.Skipf("redis not available: %v", err)
+	}
+	ctx := context.TODO()
+	if err := client.Ping(ctx).Err(); err != nil {
+		t.Skipf("redis not reachable: %v", err)
+	}
+	c := &controller{}
+	ref, refID := "project", "inflight-test"
+	key := inflightKey(ref, refID)
+	t.Cleanup(func() { client.Del(ctx, key) })
+	client.Del(ctx, key)
+
+	assert.Len(t, c.inflightSum(ctx, ref, refID), 0)
+
+	res := types.ResourceList{types.ResourceStorage: 100}
+	token, err := c.trackInflight(ctx, ref, refID, res)
+	require.NoError(t, err)
+
+	sum := c.inflightSum(ctx, ref, refID)
+	assert.Equal(t, int64(100), sum[types.ResourceStorage])
+
+	token2, err := c.trackInflight(ctx, ref, refID, types.ResourceList{types.ResourceStorage: 50})
+	require.NoError(t, err)
+	assert.Equal(t, int64(150), c.inflightSum(ctx, ref, refID)[types.ResourceStorage])
+
+	c.untrackInflight(ctx, ref, refID, token)
+	assert.Equal(t, int64(50), c.inflightSum(ctx, ref, refID)[types.ResourceStorage])
+	c.untrackInflight(ctx, ref, refID, token2)
+	assert.Len(t, c.inflightSum(ctx, ref, refID), 0)
+
+	// expired entries are ignored and reaped
+	stale, err := json.Marshal(inflightEntry{
+		Resources: types.ResourceList{types.ResourceStorage: 999},
+		Deadline:  time.Now().Add(-time.Minute).Unix(),
+	})
+	require.NoError(t, err)
+	require.NoError(t, client.HSet(ctx, key, "stale-token", stale).Err())
+	assert.Len(t, c.inflightSum(ctx, ref, refID), 0)
+	n, err := client.HExists(ctx, key, "stale-token").Result()
+	require.NoError(t, err)
+	assert.False(t, n, "expired entry should have been reaped")
+}

--- a/src/lib/orm/in_transaction_test.go
+++ b/src/lib/orm/in_transaction_test.go
@@ -1,0 +1,30 @@
+// Copyright Project Harbor Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package orm
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	ormtesting "github.com/goharbor/harbor/src/testing/lib/orm"
+)
+
+func TestInTransaction(t *testing.T) {
+	assert.False(t, InTransaction(context.Background()), "no orm in the ctx")
+	assert.False(t, InTransaction(NewContext(context.Background(), &ormtesting.FakeOrmer{})), "plain ormer is not transactional")
+	assert.True(t, InTransaction(NewContext(context.Background(), &ormtesting.FakeTxOrmer{})), "tx ormer is transactional")
+}

--- a/src/lib/orm/orm.go
+++ b/src/lib/orm/orm.go
@@ -104,6 +104,18 @@ func Copy(ctx context.Context) context.Context {
 	return NewContext(valueOnlyContext{ctx}, orm.NewOrm())
 }
 
+// InTransaction returns true when the orm in ctx runs inside a transaction,
+// e.g. the request-wide transaction started by the transaction middleware.
+func InTransaction(ctx context.Context) bool {
+	o, err := FromContext(ctx)
+	if err != nil {
+		return false
+	}
+
+	_, ok := o.(orm.TxOrmer)
+	return ok
+}
+
 type operationNameKey struct{}
 
 // SetTransactionOpNameToContext sets the transaction operation name


### PR DESCRIPTION
## Problem

Every push runs inside a request-wide DB transaction, and quota reservation writes the project's single `quota_usage` row at the start of it. The row lock is therefore held across the proxied registry round-trip and all post-processing — **all concurrent pushes into one project serialize on one row**, for the full duration of each request. Against S3/R2-backed registries that is 100 ms to seconds per push; this is the contention we observe on the shared production database.

## Solution

Make the reservation its own sub-millisecond atomic operation outside the request transaction (the existing optimistic version-CAS already guarantees atomicity; the existing compensation path handles failures). Consistency with concurrent quota refreshes is preserved by an in-flight reservation ledger in Redis: refresh adds reservations whose artifact rows are not yet committed, entries are cleared on commit/rollback and expire after 10 minutes as crash safety. Quota semantics err toward over-counting, never toward breaching a limit.

## Result (measured, 8 concurrent pushes into one project)

| | baseline | patched |
|---|---|---|
| pushers blocked on the quota_usage row (max) | 5 of 8 | 0 |
| lock waits > 50 ms | 2 | 0 |
| lock hold time | full request | one statement |

SQL statement count per push is unchanged (286) — the patch moves the lock window, it does not add queries. Full analysis, residual risks and rollback: `DESCRIPTION.md` on this branch.
