### PR TITLE
perf: Skip request-wide DB transaction for POST initiate blob upload

### DIFF
--- a/DESCRIPTION.md
+++ b/DESCRIPTION.md
@@ -1,0 +1,81 @@
+# perf: Skip the request-wide DB transaction for POST /v2/&lt;name&gt;/blobs/uploads
+
+## Idea
+
+`dbTxSkippers` (src/core/middlewares/middlewares.go) already skip the request-wide
+`transaction.Middleware` for PATCH and PUT blob upload via
+`distribution.BlobUploadURLRegexp`, but that regexp requires a session id in the
+path. POST `/v2/<name>/blobs/uploads` (initiate upload / cross-repo mount) has no
+session id, so it did NOT match: every initiate-upload request ran inside a
+`BEGIN ... COMMIT` that stayed open across the proxied registry round-trip,
+holding one pooled Postgres connection per in-flight layer upload of every push.
+
+The only DB writes on this route are for the cross-repo mount case
+(`?mount=<digest>`): the blob middleware's after-hook associates the mounted blob
+with the target project, and the quota middleware reserves the mounted blob's
+size. The plain-initiate case reserves `{storage: 0}`, which
+`updateUsageByDB` short-circuits without any UPDATE (`types.Equals` early
+return), so it performs no writes at all.
+
+## Change
+
+- `src/core/middlewares/middlewares.go`: added
+  `middleware.MethodAndPathSkipper(http.MethodPost, distribution.InitiateBlobUploadRegexp)`
+  to `dbTxSkippers` (the regexp already existed in `src/pkg/distribution/distribution.go`)
+  and extended the explanatory comment.
+- `src/server/middleware/blob/post_initiate_blob_upload.go`: wrapped the
+  mount-case after-hook (project lookup + `AssociateWithProjectByDigest`) in
+  `orm.WithTransaction` with op name `tx-post-initiate-blob-mw`, exactly the
+  pattern `PutBlobUploadMiddleware` uses (`tx-put-blob-mw`).
+- `src/core/middlewares/middlewares_test.go`: added `Test_dbTxSkippers` covering
+  POST initiate (skip), POST initiate with `?mount=` (skip), PATCH/PUT session
+  URLs (skip), PUT manifest (not skipped), POST API route (not skipped).
+
+The quota reserve path needs no change: `quotaController.Request` uses
+optimistic-lock UPDATEs with its own retry/rollback compensation and already
+runs tx-less on the PUT blob upload route (which has skipped the request tx
+since the original skipper was introduced).
+
+## Measured numbers
+
+Same harness, same machine, alpine:latest via crane, Postgres `log_statement=all`:
+
+| metric      | baseline main@177e51e99 | this branch | delta |
+|-------------|------------------------|-------------|-------|
+| push_stmts  | 286                    | 277         | -9    |
+| push_tx     | 9                      | 3           | -6    |
+| pull_stmts  | 55                     | 55          | 0     |
+
+push_tx dropping 9 -> 3 confirms the initiate-upload BEGIN/COMMIT pairs are gone
+(crane issued more than the theoretical 2 POSTs for this image in the harness
+run; each removed tx saves its BEGIN + COMMIT). Pull is untouched by design:
+GET/HEAD were already skipped.
+
+The statement-count delta is modest for a 1-layer image; the real win is
+connection-hold time: previously each POST held a pooled connection for the
+entire proxied registry round-trip, now it holds none (plain initiate) or a
+short manual tx (mount case). This scales with layer count (~6-10 POSTs per
+single-arch push, ~100+ for a 17-manifest index) and with concurrency, which is
+what matters for the shared multi-tenant Postgres.
+
+## Risks
+
+- Mount case loses atomicity with the HTTP response: the registry may return
+  201 for the mount while the association tx fails, leaving the mounted blob
+  temporarily unassociated with the project. Exposure is bounded:
+  `blob.PutManifestMiddleware` unconditionally re-associates all referenced
+  blobs with the project on the subsequent manifest PUT.
+- Quota reserve for mounts now commits independently of the response; that is
+  the same compensation semantics (`rollbackResources` on failure, `Refresh`
+  heals drift) the PUT blob upload route has always had.
+- `InitiateBlobUploadRegexp` is a prefix match and also matches session-id
+  paths, but POST on a session URL is not part of the distribution API (405)
+  and those paths are already skipped for PATCH/PUT anyway.
+
+## Rollback
+
+Revert the commit. The two functional edits are independent but should be
+reverted together: reinstating the request-wide tx while keeping the manual tx
+in the after-hook would only nest a savepoint, and keeping the skipper without
+the manual tx would run the mount-case writes in autocommit (two independent
+statements instead of one tx).

--- a/src/core/middlewares/middlewares.go
+++ b/src/core/middlewares/middlewares.go
@@ -47,14 +47,17 @@ var (
 	// which will make ping request timeout, so skip the middlewares which will require DB conn.
 	pingSkipper = middleware.MethodAndPathSkipper(http.MethodGet, match("^/api/v2.0/ping"))
 
-	// dbTxSkippers skip the transaction middleware for PATCH Blob Upload, PUT Blob Upload and `Read` APIs
+	// dbTxSkippers skip the transaction middleware for POST Initiate Blob Upload, PATCH Blob Upload, PUT Blob Upload and `Read` APIs
 	// because the APIs may take a long time to run, enable the transaction middleware in them will hold the database connections
 	// until the API finished, this behavior may eat all the database connections.
 	// There are no database writing operations in the PATCH Blob APIs, so skip the transaction middleware is all ok.
 	// For the PUT Blob Upload API, we will make a transaction manually to write blob info to the database when put blob upload successfully.
+	// For the POST Initiate Blob Upload API, the only database writes happen on the cross-repo mount case,
+	// which makes a transaction manually in the blob middleware, so the request-wide transaction is not needed either.
 	dbTxSkippers = []middleware.Skipper{
 		middleware.MethodAndPathSkipper(http.MethodPatch, distribution.BlobUploadURLRegexp),
 		middleware.MethodAndPathSkipper(http.MethodPut, distribution.BlobUploadURLRegexp),
+		middleware.MethodAndPathSkipper(http.MethodPost, distribution.InitiateBlobUploadRegexp),
 		middleware.MethodAndPathSkipper(http.MethodPost, match("^/service/token")),
 		func(r *http.Request) bool { // skip tx for GET, HEAD and Options requests
 			m := r.Method

--- a/src/core/middlewares/middlewares.go
+++ b/src/core/middlewares/middlewares.go
@@ -52,8 +52,7 @@ var (
 	// until the API finished, this behavior may eat all the database connections.
 	// There are no database writing operations in the PATCH Blob APIs, so skip the transaction middleware is all ok.
 	// For the PUT Blob Upload API, we will make a transaction manually to write blob info to the database when put blob upload successfully.
-	// For the POST Initiate Blob Upload API, the only database writes happen on the cross-repo mount case,
-	// which makes a transaction manually in the blob middleware, so the request-wide transaction is not needed either.
+	// The POST Initiate Blob Upload API only writes on the cross-repo mount case, covered by a manual transaction in the blob middleware.
 	dbTxSkippers = []middleware.Skipper{
 		middleware.MethodAndPathSkipper(http.MethodPatch, distribution.BlobUploadURLRegexp),
 		middleware.MethodAndPathSkipper(http.MethodPut, distribution.BlobUploadURLRegexp),

--- a/src/core/middlewares/middlewares_test.go
+++ b/src/core/middlewares/middlewares_test.go
@@ -20,6 +20,35 @@ import (
 	"testing"
 )
 
+func Test_dbTxSkippers(t *testing.T) {
+	tests := []struct {
+		name string
+		r    *http.Request
+		want bool
+	}{
+		{"post initiate blob upload", httptest.NewRequest(http.MethodPost, "/v2/library/photon/blobs/uploads", nil), true},
+		{"post initiate blob upload with mount", httptest.NewRequest(http.MethodPost, "/v2/library/photon/blobs/uploads?mount=sha256:aaa&from=library/app", nil), true},
+		{"patch blob upload", httptest.NewRequest(http.MethodPatch, "/v2/library/photon/blobs/uploads/uuid-123", nil), true},
+		{"put blob upload", httptest.NewRequest(http.MethodPut, "/v2/library/photon/blobs/uploads/uuid-123?digest=sha256:aaa", nil), true},
+		{"put manifest", httptest.NewRequest(http.MethodPut, "/v2/library/photon/manifests/latest", nil), false},
+		{"post api", httptest.NewRequest(http.MethodPost, "/api/v2.0/projects", nil), false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var got bool
+			for _, skipper := range dbTxSkippers {
+				if skipper(tt.r) {
+					got = true
+					break
+				}
+			}
+			if got != tt.want {
+				t.Errorf("dbTxSkippers(%s %s) = %v, want %v", tt.r.Method, tt.r.URL.Path, got, tt.want)
+			}
+		})
+	}
+}
+
 func Test_readonlySkipper(t *testing.T) {
 	type args struct {
 		r *http.Request

--- a/src/server/middleware/blob/post_initiate_blob_upload.go
+++ b/src/server/middleware/blob/post_initiate_blob_upload.go
@@ -15,9 +15,11 @@
 package blob
 
 import (
+	"context"
 	"net/http"
 
 	"github.com/goharbor/harbor/src/lib/log"
+	"github.com/goharbor/harbor/src/lib/orm"
 	"github.com/goharbor/harbor/src/pkg/distribution"
 	"github.com/goharbor/harbor/src/server/middleware"
 )
@@ -38,19 +40,25 @@ func PostInitiateBlobUploadMiddleware() func(http.Handler) http.Handler {
 
 		ctx := r.Context()
 
-		logger := log.G(ctx).WithFields(log.Fields{"middleware": "blob"})
+		h := func(ctx context.Context) error {
+			logger := log.G(ctx).WithFields(log.Fields{"middleware": "blob"})
 
-		project, err := projectController.GetByName(ctx, distribution.ParseProjectName(r.URL.Path))
-		if err != nil {
-			logger.Errorf("get project failed, error: %v", err)
-			return err
+			project, err := projectController.GetByName(ctx, distribution.ParseProjectName(r.URL.Path))
+			if err != nil {
+				logger.Errorf("get project failed, error: %v", err)
+				return err
+			}
+
+			if err := blobController.AssociateWithProjectByDigest(ctx, mount, project.ProjectID); err != nil {
+				logger.Errorf("mount blob %s to project %s failed, error: %v", mount, project.Name, err)
+				return err
+			}
+
+			return nil
 		}
 
-		if err := blobController.AssociateWithProjectByDigest(ctx, mount, project.ProjectID); err != nil {
-			logger.Errorf("mount blob %s to project %s failed, error: %v", mount, project.Name, err)
-			return err
-		}
-
-		return nil
+		// the route skips the request-wide transaction middleware, so make a short transaction
+		// manually for the mount-case writes, same as the PUT blob upload middleware does
+		return orm.WithTransaction(h)(orm.SetTransactionOpNameToContext(ctx, "tx-post-initiate-blob-mw"))
 	})
 }

--- a/src/server/middleware/blob/post_initiate_blob_upload.go
+++ b/src/server/middleware/blob/post_initiate_blob_upload.go
@@ -57,8 +57,7 @@ func PostInitiateBlobUploadMiddleware() func(http.Handler) http.Handler {
 			return nil
 		}
 
-		// the route skips the request-wide transaction middleware, so make a short transaction
-		// manually for the mount-case writes, same as the PUT blob upload middleware does
+		// the route skips the request-wide transaction middleware
 		return orm.WithTransaction(h)(orm.SetTransactionOpNameToContext(ctx, "tx-post-initiate-blob-mw"))
 	})
 }


### PR DESCRIPTION
## Problem

Upload initiation (`POST /v2/*/blobs/uploads`, issued once per layer of every push) was the only upload route still wrapped in the request-wide DB transaction: a `BEGIN…COMMIT` and a pooled connection held across the proxied registry round-trip — per layer, per push, per tenant. Pure connection-pool pressure on the shared multi-tenant Postgres, with no write needing that transaction (the route's only DB write is the rare cross-repo mount case).

## Solution

Exempt the route from the request-wide transaction, exactly as PATCH/PUT blob upload already are (the pattern the code itself documents as intended for long-running blob APIs). The cross-repo mount bookkeeping gets its own short transaction; its worst-case failure is bounded, since manifest PUT unconditionally re-associates all referenced blobs.

## Result (measured, single-arch push of alpine:latest)

| | baseline | patched |
|---|---|---|
| SQL statements per push | 286 | **277** |
| transactions per push | 9 | **3** |
| connection hold on the route | request duration | none (short tx on mount only) |

Scales with layer count: a full multi-arch index push sheds ~100+ held-connection windows. Details: `DESCRIPTION.md` on this branch.
