### PR TITLE
perf: Fetch CVE allowlist lazily in vulnerable middleware

### DIFF
--- a/DESCRIPTION.md
+++ b/DESCRIPTION.md
@@ -1,0 +1,66 @@
+# perf: Lazy CVE allowlist fetch in vulnerable middleware
+
+## Idea
+
+`src/server/middleware/vulnerable/vulnerable.go` runs on every manifest GET/HEAD and
+fetched the project with `project.WithEffectCVEAllowlist()` before checking whether the
+project has vulnerability prevention (`prevent_vul`) enabled at all. That option pulls
+the `cve_allowlist` row (or, when the project reuses the system allowlist, the system
+`cve_allowlist` row) on every manifest request, even though the value is only consumed
+when prevention is enforced. `prevent_vul` off is the overwhelming default, and the
+allowlist query path is not covered by the redis object cache, so this is a real DB
+round-trip per pull fleet-wide (including trivy pull-backs during auto-scan).
+
+## Change
+
+`src/server/middleware/vulnerable/vulnerable.go`:
+
+1. First fetch the project with default options (project + metadata only, no allowlist).
+2. Return early when `VulPrevented()` is false — no allowlist query at all.
+3. The scanner/cosign bypass (`util.SkipPolicyChecking`) also returns before any
+   allowlist query now, so scanner-driven pulls skip it even with `prevent_vul` on.
+4. Only on the enforced path, re-fetch the project with
+   `project.WithEffectCVEAllowlist()`. This goes through the controller's
+   `loadEffectCVEAllowlists`, so `ReuseSysCVEAllowlist` semantics and
+   `CVEAllowlist.IsExpired()` behavior are byte-identical to before.
+
+Cost on the enforced path: one extra project + project_metadata read (both covered by
+the redis object cache in production config). Enforcement outcomes are unchanged.
+
+`src/server/middleware/vulnerable/vulnerable_test.go`: added `AssertNumberOfCalls`
+assertions — 1 project Get when prevention is disabled and for scanner pulls (allowlist
+never fetched), 2 on the enforced path.
+
+## Measurements
+
+Same harness as baseline (devenv, Postgres log_statement=all, crane push+pull
+alpine:latest, redis object cache off).
+
+| metric | baseline main@177e51e99 | patched (2 runs) |
+|---|---|---|
+| push stmts | 286 | 288 / 283 |
+| push tx | 9 | 9 / 9 |
+| pull stmts | 55 | 54 / 54 |
+| cve_allowlist stmts in pull window | 1 | **0** (counted in run 2) |
+
+Honest read: the pull saving is exactly 1 statement (54 vs 55), stable across runs, and
+run 2 counted zero `cve_allowlist` statements in the pull window, confirming the
+mechanism. The test project does not trigger the 2-statement case (project allowlist +
+system merge). Push numbers vary by ±3 between runs (periodic health checks and async
+handlers land inside the 8s capture window), so the push-side saving (crane's manifest
+existence check) is within noise. This is a small win, but it applies to every manifest
+GET/HEAD in the fleet, including the 4 trivy pull-back pipelines per auto-scanned push,
+and it survives production config because the allowlist path is not redis-cached.
+
+## Risks
+
+Low. `prevent_vul` off: strictly fewer queries, same outcome. `prevent_vul` on: one
+extra project/metadata read (redis-cached in prod), allowlist loaded via the same
+controller path as before. A project whose `prevent_vul` flips between the two Get
+calls within one request could see the second read's metadata — same class of
+non-transactional read as before, not a new race.
+
+## Rollback
+
+Revert the single commit on `perf/vulnerable-lazy-allowlist`; the change is confined to
+`src/server/middleware/vulnerable/vulnerable.go` and its test file.

--- a/src/server/middleware/vulnerable/vulnerable.go
+++ b/src/server/middleware/vulnerable/vulnerable.go
@@ -50,10 +50,8 @@ func Middleware() func(http.Handler) http.Handler {
 			return errors.New("artifactinfo middleware required before this middleware").WithCode(errors.NotFoundCode)
 		}
 
-		// fetch the project without the CVE allowlist first, the allowlist is
-		// only needed when the vulnerability prevention is actually enforced,
-		// which spares 1-2 allowlist queries on every manifest GET/HEAD for
-		// projects with the prevention deactivated (the common case)
+		// the CVE allowlist is fetched later, only on the enforced path — this
+		// middleware runs on every manifest GET/HEAD and prevention is off by default
 		proj, err := projectController.Get(ctx, info.ProjectName)
 		if err != nil {
 			logger.Errorf("get the project %s failed, error: %v", info.ProjectName, err)

--- a/src/server/middleware/vulnerable/vulnerable.go
+++ b/src/server/middleware/vulnerable/vulnerable.go
@@ -50,7 +50,11 @@ func Middleware() func(http.Handler) http.Handler {
 			return errors.New("artifactinfo middleware required before this middleware").WithCode(errors.NotFoundCode)
 		}
 
-		proj, err := projectController.Get(ctx, info.ProjectName, project.WithEffectCVEAllowlist())
+		// fetch the project without the CVE allowlist first, the allowlist is
+		// only needed when the vulnerability prevention is actually enforced,
+		// which spares 1-2 allowlist queries on every manifest GET/HEAD for
+		// projects with the prevention deactivated (the common case)
+		proj, err := projectController.Get(ctx, info.ProjectName)
 		if err != nil {
 			logger.Errorf("get the project %s failed, error: %v", info.ProjectName, err)
 			return err
@@ -76,6 +80,12 @@ func Middleware() func(http.Handler) http.Handler {
 		if ok {
 			logger.Debugf("artifact %s@%s is pulling by the scanner/cosign, skip the checking", info.Repository, info.Digest)
 			return nil
+		}
+
+		proj, err = projectController.Get(ctx, info.ProjectName, project.WithEffectCVEAllowlist())
+		if err != nil {
+			logger.Errorf("get the project %s with effect CVE allowlist failed, error: %v", info.ProjectName, err)
+			return err
 		}
 		allowlist := proj.CVEAllowlist.CVESet()
 

--- a/src/server/middleware/vulnerable/vulnerable_test.go
+++ b/src/server/middleware/vulnerable/vulnerable_test.go
@@ -174,6 +174,8 @@ func (suite *MiddlewareTestSuite) TestPreventionDisabled() {
 
 	Middleware()(suite.next).ServeHTTP(rr, req)
 	suite.Equal(rr.Code, http.StatusOK)
+	// the CVE allowlist must not be fetched when the prevention is deactivated
+	suite.projectController.AssertNumberOfCalls(suite.T(), "Get", 1)
 }
 
 func (suite *MiddlewareTestSuite) TestNonScannerPulling() {
@@ -208,6 +210,8 @@ func (suite *MiddlewareTestSuite) TestScannerPulling() {
 
 	Middleware()(suite.next).ServeHTTP(rr, req)
 	suite.Equal(rr.Code, http.StatusOK)
+	// the CVE allowlist must not be fetched for scanner pulls
+	suite.projectController.AssertNumberOfCalls(suite.T(), "Get", 1)
 }
 
 func (suite *MiddlewareTestSuite) TestCheckIsScannableFailed() {
@@ -312,6 +316,8 @@ func (suite *MiddlewareTestSuite) TestNoVulnerabilities() {
 
 	Middleware()(suite.next).ServeHTTP(rr, req)
 	suite.Equal(rr.Code, http.StatusOK)
+	// enforced path re-fetches the project with the effect CVE allowlist
+	suite.projectController.AssertNumberOfCalls(suite.T(), "Get", 2)
 }
 
 func (suite *MiddlewareTestSuite) TestAllowed() {


### PR DESCRIPTION
## Problem

The vulnerability-blocking middleware runs on **every** manifest GET/HEAD and fetched the project's CVE-allowlist data before ever checking whether the `prevent_vul` policy is enabled. Since the policy is off by default, virtually every image pull in the fleet paid a DB read whose result was discarded.

## Solution

Evaluate the cheap policy gate first (project metadata, already loaded); fetch the allowlist only on the enforced path, through the same controller path so allowlist semantics (system-list reuse, expiry) are unchanged. Decision order is otherwise identical — verified this cannot become an enforcement bypass.

## Result (measured, pull of alpine:latest)

| | baseline | patched |
|---|---|---|
| allowlist reads per manifest pull (policy off) | 1 | **0** |
| SQL statements per pull | 55 | **54** |

One query removed from the hottest read path in the registry — every pull, every tenant. Projects with `prevent_vul` enabled pay one extra metadata read, absorbed by the object cache in production. Details: `DESCRIPTION.md` on this branch.
