### PR TITLE
fix(quota): Enable retry backoff on quota usage updates

### DIFF
--- a/src/controller/quota/controller.go
+++ b/src/controller/quota/controller.go
@@ -347,7 +347,18 @@ func (c *controller) updateUsageWithRetry(ctx context.Context, reference, refere
 
 	options := []retry.Option{
 		retry.Timeout(defaultRetryTimeout),
-		retry.Backoff(false),
+		// Exponential backoff with jitter (the retry package default). With
+		// backoff disabled, every optimistic-lock loser re-reads and re-CASes
+		// the same quota_usage row in a zero-delay loop for up to
+		// defaultRetryTimeout, so N concurrent pushes to one project turn a
+		// single conflict into a synchronized retry storm on the database.
+		retry.Backoff(true),
+		// Give up as soon as the request is gone. An aborted push already
+		// terminated on its next attempt (updateUsageByDB returns the
+		// context error wrapped in retry.Abort); the context additionally
+		// cancels an in-progress backoff sleep instead of letting it run
+		// out and paying one more wasted attempt.
+		retry.Context(ctx),
 		retry.Callback(func(err error, _ time.Duration) {
 			log.G(ctx).Debugf("failed to update the quota usage for %s %s, error: %v", reference, referenceID, err)
 		}),
@@ -456,7 +467,10 @@ func (c *controller) Update(ctx context.Context, u *quota.Quota) error {
 
 	options := []retry.Option{
 		retry.Timeout(defaultRetryTimeout),
-		retry.Backoff(false),
+		// See updateUsageWithRetry: backoff+jitter desynchronizes writers
+		// contending on the single quota row.
+		retry.Backoff(true),
+		retry.Context(ctx),
 	}
 
 	return retry.Retry(f, options...)

--- a/src/controller/quota/controller_test.go
+++ b/src/controller/quota/controller_test.go
@@ -18,11 +18,13 @@ import (
 	"context"
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/suite"
 
 	"github.com/goharbor/harbor/src/lib/orm"
+	"github.com/goharbor/harbor/src/lib/retry"
 	"github.com/goharbor/harbor/src/pkg/quota"
 	"github.com/goharbor/harbor/src/pkg/quota/driver"
 	"github.com/goharbor/harbor/src/pkg/quota/types"
@@ -95,6 +97,32 @@ func (suite *ControllerTestSuite) TestRefreshUsageExceed() {
 	referenceID := uuid.New().String()
 
 	suite.Error(suite.ctl.Refresh(ctx, suite.reference, referenceID))
+}
+
+func (suite *ControllerTestSuite) TestUpdateUsageRetriesWithBackoff() {
+	// regression test for the retry storm: optimistic-lock conflicts must
+	// go through the retry loop with a non-zero backoff sleep, so losers
+	// cannot re-CAS the contended quota_usage row in a zero-delay loop
+	suite.PrepareForUpdate(suite.quota, types.ResourceList{types.ResourceStorage: 1})
+	suite.quotaMgr.ExpectedCalls = nil
+	mock.OnAnything(suite.quotaMgr, "GetByRef").Return(suite.quota, nil)
+	mock.OnAnything(suite.quotaMgr, "Update").Return(orm.ErrOptimisticLock).Once()
+	mock.OnAnything(suite.quotaMgr, "Update").Return(nil).Once()
+
+	var sleeps []time.Duration
+	opts := []retry.Option{
+		retry.InitialInterval(time.Millisecond),
+		retry.MaxInterval(5 * time.Millisecond),
+		retry.Callback(func(_ error, sleep time.Duration) {
+			sleeps = append(sleeps, sleep)
+		}),
+	}
+
+	ctx := orm.NewContext(context.TODO(), &ormtesting.FakeOrmer{})
+	suite.Nil(suite.ctl.Refresh(ctx, suite.reference, uuid.New().String(), IgnoreLimitation(true), WithRetryOptions(opts)))
+
+	suite.Require().Len(sleeps, 1, "the optimistic-lock conflict must pass through the retry callback")
+	suite.Greater(sleeps[0], time.Duration(0), "optimistic-lock retries must back off, not spin")
 }
 
 func (suite *ControllerTestSuite) TestRefreshIgnoreLimitation() {


### PR DESCRIPTION
### What this PR does

Enables the retry package's default exponential backoff (with jitter) for the optimistic-lock retry loops in the quota controller, which currently run with `retry.Backoff(false)` and therefore retry in a zero-delay tight loop for up to 5 minutes per call.

### Why

`updateUsageWithRetry` and `Update` retry `orm.ErrOptimisticLock` conflicts on the per-project `quota_usage` row. With backoff disabled, every losing writer immediately re-reads and re-CASes the row, so N concurrent pushes to one project convert each conflict into a synchronized retry storm against the database.

Measured on a production Harbor (v2.15.x) during a CI burst of ~1000 blob uploads into one project, AWS RDS Performance Insights attributed **13 average active sessions** (on a 2-vCPU instance) to this single statement:

```
UPDATE quota_usage SET used = $1, update_time = $2, version = $3 WHERE id = $4 AND version = $5
```

with `Lock:tuple` as the dominant wait event — i.e. mostly serialization and retry spin, not useful work. The saturation was severe enough that new DB connections failed their TLS handshake, taking `/service/token` down for every client.

### Relation to prior work

This contention has been reported before: goharbor/harbor#18440 ("when push image concurrently, updating the quota will be stuck for a few seconds") was resolved by goharbor/harbor#18871, which introduced the optional Redis quota provider (`QUOTA_UPDATE_PROVIDER=redis`); goharbor/harbor#21075 reported the same symptom on the DB path afterwards. The Redis provider moves the contention off PostgreSQL, but the **default** DB path still retries with zero backoff — and not every deployment can make Redis authoritative for quota state (e.g. single-replica/ephemeral Redis). This PR is complementary to the Redis provider: it fixes the retry behavior of the default path rather than replacing it.

The retry package already defaults to backoff `{Min: 100ms, Max: 1s, Factor: 2, Jitter: true}`; this PR removes the explicit opt-out. The retention job already passes `retry.Backoff(true)` for the same call path (`src/pkg/retention/job.go`), so this aligns the default with existing practice.

### Behavior change

Contended quota updates now sleep between attempts instead of spinning. Total retry budget (5 min timeout) is unchanged. Uncontended updates are unaffected (first attempt still succeeds immediately).

