### PR TITLE
perf(quota): Coalesce per-request refresh through the deferred flush

### DIFF
--- a/src/controller/quota/refresh_async.go
+++ b/src/controller/quota/refresh_async.go
@@ -16,6 +16,9 @@ package quota
 
 import (
 	"context"
+	"math"
+	"os"
+	"strconv"
 	"sync"
 	"time"
 
@@ -40,7 +43,14 @@ import (
 // process restart, or a concurrent flush from another core replica, can
 // only delay convergence - never corrupt the stored value. A failed flush
 // re-marks the project and is retried on the next interval.
-const deferredRefreshInterval = 10 * time.Second
+// defaultDeferredRefreshInterval is the flush cadence; override with the
+// QUOTA_ASYNC_REFRESH_DURATION env var (seconds). Setting the env var also
+// switches RefreshMiddleware to the coalesced path (see AsyncRefreshEnabled).
+const defaultDeferredRefreshInterval = 10 * time.Second
+
+const asyncRefreshDurationEnv = "QUOTA_ASYNC_REFRESH_DURATION"
+
+var asyncRefreshConfigured bool
 
 // perRefreshTimeout bounds a single project's recompute inside the flush
 // loop; see refreshDirty.
@@ -57,7 +67,34 @@ type refKey struct {
 }
 
 func init() {
-	gtask.DefaultPool().AddTask(flushDirtyQuota, deferredRefreshInterval)
+	interval, configured := parseRefreshInterval(os.Getenv(asyncRefreshDurationEnv))
+	asyncRefreshConfigured = configured
+	gtask.DefaultPool().AddTask(flushDirtyQuota, interval)
+}
+
+// parseRefreshInterval turns the QUOTA_ASYNC_REFRESH_DURATION value into the
+// flush interval. It returns the default interval and configured=false for
+// an empty or invalid value; an invalid value is additionally logged.
+func parseRefreshInterval(env string) (time.Duration, bool) {
+	if len(env) == 0 {
+		return defaultDeferredRefreshInterval, false
+	}
+	seconds, err := strconv.ParseInt(env, 10, 64)
+	// the upper bound keeps seconds*time.Second representable in a
+	// time.Duration; beyond it the multiplication overflows negative
+	// and the flush loop would spin without sleeping
+	if err != nil || seconds <= 0 || seconds > math.MaxInt64/int64(time.Second) {
+		log.Warningf("invalid %s %q, using default flush interval %s", asyncRefreshDurationEnv, env, defaultDeferredRefreshInterval)
+		return defaultDeferredRefreshInterval, false
+	}
+	return time.Duration(seconds) * time.Second, true
+}
+
+// AsyncRefreshEnabled returns true when QUOTA_ASYNC_REFRESH_DURATION is set
+// to a positive number of seconds; RefreshMiddleware then coalesces its
+// per-request full recomputes through the deferred flush as well.
+func AsyncRefreshEnabled() bool {
+	return asyncRefreshConfigured
 }
 
 // MarkRefresh records that the usage of the reference object changed and

--- a/src/controller/quota/refresh_async_test.go
+++ b/src/controller/quota/refresh_async_test.go
@@ -16,7 +16,9 @@ package quota
 
 import (
 	"context"
+	"os"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 
@@ -40,6 +42,42 @@ func dirtyLen() int {
 	dirty.Lock()
 	defer dirty.Unlock()
 	return len(dirty.keys)
+}
+
+func TestAsyncRefreshDisabledByDefault(t *testing.T) {
+	if os.Getenv(asyncRefreshDurationEnv) != "" {
+		// asyncRefreshConfigured is fixed at init time, so an environment
+		// that legitimately enables async refresh cannot satisfy this test
+		t.Skipf("%s is set in this environment", asyncRefreshDurationEnv)
+	}
+	assert.False(t, AsyncRefreshEnabled())
+}
+
+func TestParseRefreshInterval(t *testing.T) {
+	cases := []struct {
+		name       string
+		env        string
+		interval   time.Duration
+		configured bool
+	}{
+		{"unset", "", defaultDeferredRefreshInterval, false},
+		{"valid", "60", 60 * time.Second, true},
+		{"one second", "1", time.Second, true},
+		{"zero", "0", defaultDeferredRefreshInterval, false},
+		{"negative", "-5", defaultDeferredRefreshInterval, false},
+		{"not a number", "10s", defaultDeferredRefreshInterval, false},
+		{"largest representable", "9223372036", 9223372036 * time.Second, true},
+		{"overflows time.Duration", "9223372037", defaultDeferredRefreshInterval, false},
+		{"overflows int64", "99999999999999999999", defaultDeferredRefreshInterval, false},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			interval, configured := parseRefreshInterval(c.env)
+			assert.Equal(t, c.interval, interval)
+			assert.Equal(t, c.configured, configured)
+		})
+	}
 }
 
 func TestMarkRefreshCoalesces(t *testing.T) {

--- a/src/server/middleware/quota/quota.go
+++ b/src/server/middleware/quota/quota.go
@@ -229,6 +229,17 @@ func RefreshMiddleware(config RefreshConfig, skipers ...middleware.Skipper) func
 			return nil
 		}
 
+		// When async refresh is enabled, only mark the reference dirty
+		// instead of recomputing and writing the usage synchronously; a
+		// background task coalesces all marks and recomputes the usage once
+		// per reference per interval. (The reference lookup above still
+		// reads the database - the mark itself is memory-only.) See
+		// controller/quota/refresh_async.go for semantics.
+		if cq.AsyncRefreshEnabled() {
+			cq.MarkRefresh(reference, referenceID)
+			return nil
+		}
+
 		if err = quotaController.Refresh(r.Context(), reference, referenceID, cq.IgnoreLimitation(config.IgnoreLimitation)); err != nil {
 			logger.Errorf("refresh quota for %s %s failed, error: %v", reference, referenceID, err)
 


### PR DESCRIPTION
### What this PR does

Extends the deferred quota refresh introduced in the previous commit: `QUOTA_ASYNC_REFRESH_DURATION` (seconds) overrides the flush interval and, when set, also routes `RefreshMiddleware`'s per-request full recomputes (artifact/repository DELETE routes) through the same in-memory dirty set instead of writing synchronously — one recompute per project per interval regardless of how many requests marked it. Default (env unset) keeps today's synchronous behavior for those paths.

### Why

Each gated DELETE triggers a full usage recompute plus an optimistic-locked write to the project's single `quota_usage` row. Under bulk deletes these serialize on that row — many recomputes per interval that all converge to the same value.

The codebase already recognizes this exact problem: the middleware skips refresh for retention jobs because per-item refresh under bulk load "will cause huge db CPU resource for refresh quota" (goharbor/harbor#18795 touched the same path), and pull_time/pull_count updates are batched in-process via `ARTIFACT_PULL_ASYNC_FLUSH_DURATION`. This applies the established pattern to the remaining synchronous refresh path, opt-in, with the same naming shape.

### Trade-off (documented in code)

In coalesced mode the synchronous refresh's post-response denial (second-line rejection when a reservation under-estimated the true size) does not happen; enforcement relies on the reserve step. Deployments that depend on that behavior should keep the feature disabled — the default.

Tests: env gate off by default; coalescing, one-flush-per-reference, and failed-flush re-mark covered by the flusher tests.

