### PR TITLE
test(e2e): End-to-end tests for the DB hot-row contention fixes

### DIFF
--- a/src/tests/e2e/README.md
+++ b/src/tests/e2e/README.md
@@ -1,0 +1,22 @@
+# End-to-end tests: database hot-row contention fixes
+
+Verifies the four fixes for the 2026-08 push-burst incident (quota CAS
+backoff, blob Touch debounce, unlimited-quota reservation skip, coalesced
+async refresh) against a RUNNING Harbor - by default the slot-0 dev
+environment (`task dev:up SLOT=0`).
+
+Run:
+
+    cd src && go test -tags e2e ./tests/e2e/ -v -count=1
+
+Configuration (env, with slot-0 defaults):
+
+    E2E_CORE_URL        http://localhost:8080
+    E2E_ADMIN_USER      admin
+    E2E_ADMIN_PASSWORD  Harbor12345
+    E2E_DB_DSN          postgres://postgres:root123@localhost:5432/registry?sslmode=disable
+    E2E_ASYNC_REFRESH   (unset)
+
+`TestAsyncRefreshConvergence` runs only when `E2E_ASYNC_REFRESH=1` is set,
+and expects the target core to have been started with
+`QUOTA_ASYNC_REFRESH_DURATION`; otherwise the test is skipped.

--- a/src/tests/e2e/client_test.go
+++ b/src/tests/e2e/client_test.go
@@ -1,0 +1,242 @@
+//go:build e2e
+
+// Copyright Project Harbor Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package e2e
+
+import (
+	"bytes"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"strings"
+	"time"
+)
+
+type env struct {
+	coreURL  string
+	user     string
+	password string
+	dbDSN    string
+	http     *http.Client
+}
+
+func newEnv() *env {
+	get := func(k, d string) string {
+		if v := os.Getenv(k); v != "" {
+			return v
+		}
+		return d
+	}
+	return &env{
+		coreURL:  get("E2E_CORE_URL", "http://localhost:8080"),
+		user:     get("E2E_ADMIN_USER", "admin"),
+		password: get("E2E_ADMIN_PASSWORD", "Harbor12345"),
+		dbDSN:    get("E2E_DB_DSN", "postgres://postgres:root123@localhost:5432/registry?sslmode=disable"),
+		http:     &http.Client{Timeout: 60 * time.Second},
+	}
+}
+
+func (e *env) do(method, path string, body []byte, contentType string) (*http.Response, error) {
+	var rd io.Reader
+	if body != nil {
+		rd = bytes.NewReader(body)
+	}
+	req, err := http.NewRequest(method, e.coreURL+path, rd)
+	if err != nil {
+		return nil, err
+	}
+	req.SetBasicAuth(e.user, e.password)
+	if contentType != "" {
+		req.Header.Set("Content-Type", contentType)
+	}
+	return e.http.Do(req)
+}
+
+// --- Harbor API ---
+
+func (e *env) createProject(name string, storageLimit int64) error {
+	b, _ := json.Marshal(map[string]any{
+		"project_name":  name,
+		"storage_limit": storageLimit,
+		"public":        false,
+	})
+	resp, err := e.do(http.MethodPost, "/api/v2.0/projects", b, "application/json")
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusCreated && resp.StatusCode != http.StatusConflict {
+		body, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("create project %s: %d %s", name, resp.StatusCode, body)
+	}
+	return nil
+}
+
+func (e *env) projectUsedStorage(name string) (int64, error) {
+	resp, err := e.do(http.MethodGet, "/api/v2.0/projects/"+name+"/summary", nil, "")
+	if err != nil {
+		return 0, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return 0, fmt.Errorf("summary %s: %d", name, resp.StatusCode)
+	}
+	var out struct {
+		Quota struct {
+			Used struct {
+				Storage int64 `json:"storage"`
+			} `json:"used"`
+		} `json:"quota"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+		return 0, err
+	}
+	return out.Quota.Used.Storage, nil
+}
+
+// --- minimal OCI push (monolithic blob upload + manifest PUT) ---
+
+type blob struct {
+	data   []byte
+	digest string
+}
+
+func randomBlob(size int) blob {
+	data := make([]byte, size)
+	_, _ = rand.Read(data)
+	sum := sha256.Sum256(data)
+	return blob{data: data, digest: "sha256:" + hex.EncodeToString(sum[:])}
+}
+
+func (e *env) headBlob(repo string, b blob) (int, error) {
+	resp, err := e.do(http.MethodHead, "/v2/"+repo+"/blobs/"+b.digest, nil, "")
+	if err != nil {
+		return 0, err
+	}
+	resp.Body.Close()
+	return resp.StatusCode, nil
+}
+
+func (e *env) pushBlob(repo string, b blob) error {
+	resp, err := e.do(http.MethodPost, "/v2/"+repo+"/blobs/uploads/", nil, "")
+	if err != nil {
+		return err
+	}
+	loc := resp.Header.Get("Location")
+	io.Copy(io.Discard, resp.Body)
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusAccepted {
+		return fmt.Errorf("initiate upload %s: %d", repo, resp.StatusCode)
+	}
+	if loc == "" {
+		return fmt.Errorf("initiate upload %s: no Location header in %d response", repo, resp.StatusCode)
+	}
+
+	// the Location header may be absolute (scheme://host/...) or a path
+	uploadURL := loc
+	if !strings.HasPrefix(uploadURL, "http://") && !strings.HasPrefix(uploadURL, "https://") {
+		uploadURL = e.coreURL + uploadURL
+	}
+	sep := "?"
+	if strings.Contains(uploadURL, "?") {
+		sep = "&"
+	}
+	req, err := http.NewRequest(http.MethodPut, uploadURL+sep+"digest="+b.digest, bytes.NewReader(b.data))
+	if err != nil {
+		return err
+	}
+	req.SetBasicAuth(e.user, e.password)
+	req.Header.Set("Content-Type", "application/octet-stream")
+	req.ContentLength = int64(len(b.data))
+	resp2, err := e.http.Do(req)
+	if err != nil {
+		return err
+	}
+	body, _ := io.ReadAll(resp2.Body)
+	resp2.Body.Close()
+	if resp2.StatusCode != http.StatusCreated {
+		return fmt.Errorf("put blob %s: %d %s", b.digest, resp2.StatusCode, body)
+	}
+	return nil
+}
+
+func (e *env) pushManifest(repo, tag string, cfg blob, layers []blob) error {
+	type desc struct {
+		MediaType string `json:"mediaType"`
+		Digest    string `json:"digest"`
+		Size      int    `json:"size"`
+	}
+	m := map[string]any{
+		"schemaVersion": 2,
+		"mediaType":     "application/vnd.oci.image.manifest.v1+json",
+		"config": desc{
+			MediaType: "application/vnd.oci.image.config.v1+json",
+			Digest:    cfg.digest, Size: len(cfg.data),
+		},
+	}
+	ls := make([]desc, len(layers))
+	for i, l := range layers {
+		ls[i] = desc{MediaType: "application/vnd.oci.image.layer.v1.tar", Digest: l.digest, Size: len(l.data)}
+	}
+	m["layers"] = ls
+	mb, _ := json.Marshal(m)
+
+	resp, err := e.do(http.MethodPut, "/v2/"+repo+"/manifests/"+tag, mb, "application/vnd.oci.image.manifest.v1+json")
+	if err != nil {
+		return err
+	}
+	body, _ := io.ReadAll(resp.Body)
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusCreated {
+		return fmt.Errorf("put manifest %s:%s: %d %s", repo, tag, resp.StatusCode, body)
+	}
+	return nil
+}
+
+// randomConfigBlob returns a valid JSON config blob (Harbor's artifact
+// processor parses the config, so it must be JSON, not random bytes).
+func randomConfigBlob() blob {
+	seed := randomBlob(16)
+	data, _ := json.Marshal(map[string]string{"author": "e2e", "nonce": seed.digest})
+	sum := sha256.Sum256(data)
+	return blob{data: data, digest: "sha256:" + hex.EncodeToString(sum[:])}
+}
+
+// pushImage pushes config+layers+manifest; layers may be shared across images.
+func (e *env) pushImage(repo, tag string, layers []blob) error {
+	cfg := randomConfigBlob()
+	if err := e.pushBlob(repo, cfg); err != nil {
+		return err
+	}
+	for _, l := range layers {
+		// mirror real clients: probe first, upload when absent
+		code, err := e.headBlob(repo, l)
+		if err != nil {
+			return err
+		}
+		if code != http.StatusOK {
+			if err := e.pushBlob(repo, l); err != nil {
+				return err
+			}
+		}
+	}
+	return e.pushManifest(repo, tag, cfg, layers)
+}

--- a/src/tests/e2e/contention_test.go
+++ b/src/tests/e2e/contention_test.go
@@ -1,0 +1,226 @@
+//go:build e2e
+
+// Copyright Project Harbor Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package e2e
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"net/http"
+	"os"
+	"sync"
+	"testing"
+	"time"
+
+	_ "github.com/jackc/pgx/v5/stdlib"
+)
+
+// TestConcurrentSharedLayerPushBurst reproduces the incident shape: many
+// concurrent pushes into ONE unlimited-quota project, all images sharing
+// the same base layers. Pre-fix this serializes on the project's
+// quota_usage row (reserve CAS, no backoff) and on the shared blob rows
+// (Touch per probe); the assertion is simply that every push succeeds and
+// the burst completes in bounded time.
+func TestConcurrentSharedLayerPushBurst(t *testing.T) {
+	e := newEnv()
+	project := fmt.Sprintf("e2e-burst-%d", time.Now().UnixMilli())
+	if err := e.createProject(project, -1); err != nil {
+		t.Fatalf("create project: %v", err)
+	}
+
+	shared := []blob{randomBlob(256 << 10), randomBlob(256 << 10), randomBlob(256 << 10)}
+
+	const workers = 16
+	const perWorker = 4
+	var wg sync.WaitGroup
+	errs := make(chan error, workers*perWorker)
+	start := time.Now()
+	for w := 0; w < workers; w++ {
+		wg.Add(1)
+		go func(w int) {
+			defer wg.Done()
+			for i := 0; i < perWorker; i++ {
+				layers := append([]blob{}, shared...)
+				layers = append(layers, randomBlob(64<<10)) // unique layer per image
+				repo := fmt.Sprintf("%s/burst-%d", project, w%4)
+				if err := e.pushImage(repo, fmt.Sprintf("w%d-i%d", w, i), layers); err != nil {
+					errs <- fmt.Errorf("worker %d push %d: %w", w, i, err)
+				}
+			}
+		}(w)
+	}
+	wg.Wait()
+	close(errs)
+
+	for err := range errs {
+		t.Error(err)
+	}
+	t.Logf("burst: %d pushes across %d workers in %s", workers*perWorker, workers, time.Since(start))
+}
+
+// TestQuotaEnforcementDeniesOverLimit guards the unlimited-skip change:
+// projects with a REAL storage limit must still be denied synchronously.
+func TestQuotaEnforcementDeniesOverLimit(t *testing.T) {
+	e := newEnv()
+	project := fmt.Sprintf("e2e-limited-%d", time.Now().UnixMilli())
+	if err := e.createProject(project, 1<<20); err != nil { // 1 MiB limit
+		t.Fatalf("create project: %v", err)
+	}
+
+	over := randomBlob(2 << 20) // 2 MiB blob
+	err := e.pushBlob(project+"/limited", over)
+	if err == nil {
+		t.Fatal("push over quota succeeded; enforcement is broken")
+	}
+	t.Logf("over-quota push denied as expected: %v", err)
+
+	// and a small push inside the limit still works
+	small := randomBlob(64 << 10)
+	if err := e.pushImage(project+"/limited", "ok", []blob{small}); err != nil {
+		t.Fatalf("within-quota push failed: %v", err)
+	}
+}
+
+// TestUsageConvergesOnUnlimitedProject: with the reservation skipped on
+// unlimited projects, the usage figure is maintained by the refresh path
+// (sync per request, or coalesced when QUOTA_ASYNC_REFRESH_DURATION is
+// set). Either way it must converge to the true stored bytes.
+func TestUsageConvergesOnUnlimitedProject(t *testing.T) {
+	e := newEnv()
+	project := fmt.Sprintf("e2e-usage-%d", time.Now().UnixMilli())
+	if err := e.createProject(project, -1); err != nil {
+		t.Fatalf("create project: %v", err)
+	}
+
+	layers := []blob{randomBlob(512 << 10), randomBlob(256 << 10)}
+	if err := e.pushImage(project+"/usage", "v1", layers); err != nil {
+		t.Fatalf("push: %v", err)
+	}
+
+	// used must cover at least the layer bytes (config+manifest add a bit);
+	// poll until that bound, not merely non-zero, so a partially refreshed
+	// intermediate value cannot end the wait early
+	var minExpected int64
+	for _, l := range layers {
+		minExpected += int64(len(l.data))
+	}
+	deadline := time.Now().Add(90 * time.Second)
+	var used int64
+	var err error
+	for time.Now().Before(deadline) {
+		used, err = e.projectUsedStorage(project)
+		if err == nil && used >= minExpected {
+			break
+		}
+		time.Sleep(3 * time.Second)
+	}
+	if err != nil {
+		t.Fatalf("summary: %v", err)
+	}
+	if used < minExpected {
+		t.Fatalf("usage did not converge: used=%d < expected>=%d", used, minExpected)
+	}
+	t.Logf("usage converged: %d bytes (expected >= %d)", used, minExpected)
+}
+
+// TestTouchDebounce verifies the blob fix at the database level: repeated
+// HEAD probes of a healthy blob must NOT rewrite its row while its
+// update_time is fresh (pre-fix: every HEAD bumps version and update_time).
+func TestTouchDebounce(t *testing.T) {
+	e := newEnv()
+	db, err := sql.Open("pgx", e.dbDSN)
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer db.Close()
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	if err := db.PingContext(ctx); err != nil {
+		t.Skipf("database not reachable (%v); set E2E_DB_DSN", err)
+	}
+
+	project := fmt.Sprintf("e2e-touch-%d", time.Now().UnixMilli())
+	if err := e.createProject(project, -1); err != nil {
+		t.Fatalf("create project: %v", err)
+	}
+	layer := randomBlob(128 << 10)
+	repo := project + "/touch"
+	if err := e.pushImage(repo, "v1", []blob{layer}); err != nil {
+		t.Fatalf("push: %v", err)
+	}
+
+	row := func() (int64, time.Time) {
+		// per-query context: the outer 10s ctx only guards the initial
+		// ping, and the second row read happens after a push plus 25
+		// HEAD probes, which may outlive it
+		qctx, qcancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer qcancel()
+		var v int64
+		var ut time.Time
+		err := db.QueryRowContext(qctx,
+			"SELECT version, update_time FROM blob WHERE digest = $1", layer.digest).Scan(&v, &ut)
+		if err != nil {
+			t.Fatalf("query blob row: %v", err)
+		}
+		return v, ut
+	}
+
+	v0, t0 := row()
+	const probes = 25
+	for i := 0; i < probes; i++ {
+		code, err := e.headBlob(repo, layer)
+		if err != nil || code != http.StatusOK {
+			t.Fatalf("head %d: code=%d err=%v", i, code, err)
+		}
+	}
+	v1, t1 := row()
+
+	if v1 != v0 || !t1.Equal(t0) {
+		t.Fatalf("debounce failed: %d HEAD probes rewrote the fresh blob row (version %d->%d, update_time %s->%s)",
+			probes, v0, v1, t0, t1)
+	}
+	t.Logf("debounce ok: %d HEAD probes, blob row untouched (version=%d)", probes, v0)
+}
+
+// TestAsyncRefreshConvergence: tighter bound when the target core runs with
+// QUOTA_ASYNC_REFRESH_DURATION - usage must appear within ~3 intervals.
+func TestAsyncRefreshConvergence(t *testing.T) {
+	if os.Getenv("E2E_ASYNC_REFRESH") != "1" {
+		t.Skip("set E2E_ASYNC_REFRESH=1 when core runs with QUOTA_ASYNC_REFRESH_DURATION")
+	}
+	e := newEnv()
+	project := fmt.Sprintf("e2e-async-%d", time.Now().UnixMilli())
+	if err := e.createProject(project, -1); err != nil {
+		t.Fatalf("create project: %v", err)
+	}
+	layer := randomBlob(256 << 10)
+	if err := e.pushImage(project+"/async", "v1", []blob{layer}); err != nil {
+		t.Fatalf("push: %v", err)
+	}
+
+	// assume interval <= 10s; allow 3 intervals + slack
+	deadline := time.Now().Add(35 * time.Second)
+	for time.Now().Before(deadline) {
+		used, err := e.projectUsedStorage(project)
+		if err == nil && used >= int64(len(layer.data)) {
+			t.Logf("async refresh converged: used=%d", used)
+			return
+		}
+		time.Sleep(2 * time.Second)
+	}
+	t.Fatal("async refresh did not converge within 35s")
+}


### PR DESCRIPTION
### What this PR does

Adds an opt-in end-to-end suite (`go test -tags e2e ./tests/e2e/`) that runs against a **live** Harbor — by default the slot-0 dev environment — and verifies the four fixes in this stack behave correctly together.

| Test | Verifies |
|---|---|
| `TestConcurrentSharedLayerPushBurst` | the incident shape (concurrent pushes into one unlimited project sharing base layers) completes with zero failures |
| `TestQuotaEnforcementDeniesOverLimit` | projects with a real storage limit still deny over-limit pushes **synchronously** — guards the unlimited-skip change |
| `TestUsageConvergesOnUnlimitedProject` | with the reservation skipped, the usage figure still converges |
| `TestTouchDebounce` | repeated HEAD probes of a fresh blob leave its row untouched — asserted directly against the `blob` table (`version` and `update_time` unchanged) |
| `TestAsyncRefreshConvergence` | opt-in (`E2E_ASYNC_REFRESH=1`) tighter convergence bound with `QUOTA_ASYNC_REFRESH_DURATION` set |

### Why it earns its place

This suite caught a real design bug before it shipped. The first version of the unlimited-reservation skip assumed the usage figure would keep flowing through `RefreshMiddleware`. It does not: `RefreshForProjectMiddleware` is mounted only on artifact/repository **DELETE** routes (`server/registry/route.go`), never on manifest PUT — so on the push path the reservation is the *only* writer of `quota_usage`. Skipping it alone would have silently frozen every unlimited project's storage figure, including the exporter metric. `TestUsageConvergesOnUnlimitedProject` failed with `used=0`, which is why that PR now ships the deferred coalesced refresh with it.

### Results against slot-0 running this stack

```
burst: 64 pushes across 16 workers in 18.8s   PASS
over-quota push denied as expected: 403 DENIED  PASS
usage converged: 787080 bytes (expected >= 786432)  PASS
debounce ok: 25 HEAD probes, blob row untouched (version=0)  PASS
```

Database-level confirmation after a full push burst plus a HEAD storm: **0 of 963 blob rows** had `version > 0`.

### Notes

- Build-tagged `e2e`, so it never runs in the normal unit-test sweep.
- Configurable via `E2E_CORE_URL`, `E2E_ADMIN_USER`, `E2E_ADMIN_PASSWORD`, `E2E_DB_DSN` (slot-0 defaults).
- Uses a dependency-free minimal OCI client (monolithic blob upload + manifest PUT) and mirrors real client behaviour by HEAD-probing layers before upload.
