### PR TITLE
chore: Fix Build Core Binary From Package Directory, Not Single File

### DIFF
--- a/devenv/air.core.toml
+++ b/devenv/air.core.toml
@@ -8,7 +8,7 @@ tmp_dir = "tmp"
 [build]
   # Fast build by default. Set DEBUG=true to enable Delve step-through debugging:
   #   docker compose exec core env DEBUG=true air -c devenv/air.core.toml
-  cmd = "cd src && CGO_ENABLED=0 GOMODCACHE=/go/pkg/mod /usr/local/go/bin/go build ${DEBUG:+-gcflags=all='-N -l'} -trimpath -o ../tmp/core ./core/main.go"
+  cmd = "cd src && CGO_ENABLED=0 GOMODCACHE=/go/pkg/mod /usr/local/go/bin/go build ${DEBUG:+-gcflags=all='-N -l'} -trimpath -o ../tmp/core ./core/"
 
   bin = "tmp/core"
   args_bin = []

--- a/taskfile/build.yml
+++ b/taskfile/build.yml
@@ -77,7 +77,7 @@ tasks:
       - task: _go-build
         vars:
           PLATFORM: '{{index .MATCH 0}}'
-          MAIN_PATH: ./core/main.go
+          MAIN_PATH: ./core/
           OUTPUT_NAME: core
 
   binary:jobservice:*:


### PR DESCRIPTION
Ports the same fix as `release-2.15`'s #688 to `main`.

`MAIN_PATH: ./core/main.go` builds `core` as a single file, invisible to sibling files in the same package. When commercial patches add files like `src/core/commercial.go` (0001) or `src/core/main_auditlog.go` (0008) alongside `main.go`, the build fails with `undefined: <symbol>` for anything those files declare — since single-file `go build` treats the named file as the entire package.

Found while re-verifying `task apply-patches` after #711: patches now apply cleanly, but `task build` still failed on `core` for this pre-existing, unrelated reason.

- `taskfile/build.yml`: `MAIN_PATH: ./core/main.go` → `./core/`
- `devenv/air.core.toml`: same fix for the hot-reload dev build

Verified `task build:binary:core:linux-amd64` succeeds on `main` alone and with all 8 commercial patches applied.