### PR TITLE
ci: Run workflows on GitHub-hosted ubuntu-26.04 runners

### DIFF
--- a/.github/workflows/backport-suggestion.yml
+++ b/.github/workflows/backport-suggestion.yml
@@ -16,7 +16,7 @@ jobs:
       ${{
         github.event.pull_request.base.ref == 'main'
       }}
-    runs-on: ${{ vars.RUNNER || 'ubuntu-latest' }}
+    runs-on: ubuntu-26.04
     steps:
       - name: Suggest backports
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0

--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -17,7 +17,7 @@ jobs:
         startsWith(github.event.comment.body, '/backport ') &&
         contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association)
       }}
-    runs-on: ${{ vars.RUNNER || 'ubuntu-latest' }}
+    runs-on: ubuntu-26.04
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       GH_REPO: ${{ github.repository }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,7 +30,7 @@ concurrency:
 jobs:
   build:
     name: Build Binaries
-    runs-on: ${{ (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository || contains(fromJSON('["OWNER","MEMBER"]'), github.event.pull_request.author_association)) && vars.RUNNER || 'ubuntu-latest' }}
+    runs-on: ubuntu-26.04
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:

--- a/.github/workflows/cache-cleanup.yml
+++ b/.github/workflows/cache-cleanup.yml
@@ -10,50 +10,6 @@ permissions:
   actions: write
 
 jobs:
-  cleanup-host:
-    name: Trim host caches
-    # Do not run the upstream maintenance schedule in forks.
-    if: github.event_name != 'schedule' || github.repository == 'container-registry/harbor-next'
-    runs-on: ${{ vars.RUNNER || 'ubuntu-latest' }}
-    steps:
-      - name: Trim Go build cache (files not modified in 7 days)
-        run: |
-          if [ -z "$GOCACHE" ] || [ ! -d "$GOCACHE" ]; then
-            echo "No GOCACHE directory found at '${GOCACHE:-<unset>}'"
-            exit 0
-          fi
-          # Canonicalize to defeat traversal tricks like /home/../../etc
-          GOCACHE="$(realpath -m "$GOCACHE")"
-          case "$GOCACHE" in /home/*|/opt/ci-cache/*) ;; *)
-            echo "ERROR: GOCACHE='$GOCACHE' not under /home or /opt/ci-cache, skipping"; exit 0 ;; esac
-          echo "Build cache before: $(du -sh "$GOCACHE" | cut -f1)"
-          find "$GOCACHE" -type f -mtime +7 -delete 2>/dev/null || true
-          find "$GOCACHE" -type d -empty -delete 2>/dev/null || true
-          echo "Build cache after: $(du -sh "$GOCACHE" | cut -f1)"
-
-      - name: Check module cache size
-        run: |
-          if [ -z "$GOMODCACHE" ] || [ ! -d "$GOMODCACHE" ]; then
-            echo "No GOMODCACHE directory found at '${GOMODCACHE:-<unset>}'"
-            exit 0
-          fi
-          # Canonicalize to defeat traversal tricks like /home/../../etc
-          GOMODCACHE="$(realpath -m "$GOMODCACHE")"
-          case "$GOMODCACHE" in /home/*|/opt/ci-cache/*) ;; *)
-            echo "ERROR: GOMODCACHE='$GOMODCACHE' not under /home or /opt/ci-cache, skipping"; exit 0 ;; esac
-          size_mb=$(du -sm "$GOMODCACHE" | cut -f1)
-          echo "Module cache: ${size_mb}MB"
-          if [ "$size_mb" -gt 2048 ]; then
-            echo "Exceeds 2GB threshold, clearing..."
-            chmod -R u+w "$GOMODCACHE" && rm -rf "${GOMODCACHE:?}"/* 2>/dev/null || true
-          fi
-
-      - name: Report tool cache size
-        run: |
-          if [ -d "/opt/hostedtoolcache" ]; then
-            echo "Tool cache: $(du -sh /opt/hostedtoolcache | cut -f1)"
-          fi
-
   cleanup-github-cache:
     name: Purge stale GitHub Actions caches
     # Do not run the upstream maintenance schedule in forks.

--- a/.github/workflows/chart-ci.yml
+++ b/.github/workflows/chart-ci.yml
@@ -16,7 +16,7 @@ permissions:
 jobs:
   chart-quality:
     name: Chart Quality Gate
-    runs-on: ${{ vars.RUNNER || 'ubuntu-latest' }}
+    runs-on: ubuntu-26.04
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:

--- a/.github/workflows/compose-ci.yml
+++ b/.github/workflows/compose-ci.yml
@@ -15,7 +15,7 @@ permissions:
 jobs:
   compose-check:
     name: Compose env drift
-    runs-on: ${{ vars.RUNNER || 'ubuntu-latest' }}
+    runs-on: ubuntu-26.04
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -10,7 +10,7 @@ permissions:
 
 jobs:
   dependency-review:
-    runs-on: ${{ (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository || contains(fromJSON('["OWNER","MEMBER"]'), github.event.pull_request.author_association)) && vars.RUNNER || 'ubuntu-latest' }}
+    runs-on: ubuntu-26.04
     # Requires Dependency Graph to be enabled in repo settings
     if: github.event.repository.private == false || always()
     continue-on-error: true

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -10,7 +10,7 @@ permissions:
 
 jobs:
   labeler:
-    runs-on: ${{ vars.RUNNER || 'ubuntu-latest' }}
+    runs-on: ubuntu-26.04
     steps:
       - uses: actions/labeler@bf12e9b00b37c5c0ca2b87b79b2daf7891dbda13 # v7.0.0
         with:

--- a/.github/workflows/lint-actions.yml
+++ b/.github/workflows/lint-actions.yml
@@ -15,7 +15,7 @@ permissions:
 jobs:
   pinned-actions:
     name: Check Pinned Action SHAs
-    runs-on: ${{ (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository || contains(fromJSON('["OWNER","MEMBER"]'), github.event.pull_request.author_association)) && vars.RUNNER || 'ubuntu-latest' }}
+    runs-on: ubuntu-26.04
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:

--- a/.github/workflows/lint-go.yml
+++ b/.github/workflows/lint-go.yml
@@ -31,7 +31,7 @@ env:
 jobs:
   lint:
     name: Go Lint
-    runs-on: ${{ (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository || contains(fromJSON('["OWNER","MEMBER"]'), github.event.pull_request.author_association)) && vars.RUNNER || 'ubuntu-latest' }}
+    runs-on: ubuntu-26.04
     env:
       GOLANGCI_LINT_CACHE: ${{ github.workspace }}/.ci-cache/golangci-lint
       XDG_CACHE_HOME: ${{ github.workspace }}/.ci-cache/xdg

--- a/.github/workflows/lint-ui.yml
+++ b/.github/workflows/lint-ui.yml
@@ -32,7 +32,7 @@ env:
 jobs:
   lint:
     name: UI Lint
-    runs-on: ${{ (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository || contains(fromJSON('["OWNER","MEMBER"]'), github.event.pull_request.author_association)) && vars.RUNNER || 'ubuntu-latest' }}
+    runs-on: ubuntu-26.04
     env:
       CYPRESS_CACHE_FOLDER: ${{ github.workspace }}/.ci-cache/cypress
       CYPRESS_INSTALL_BINARY: "0"

--- a/.github/workflows/main-images.yml
+++ b/.github/workflows/main-images.yml
@@ -17,7 +17,7 @@ jobs:
   version:
     name: Read Version
     if: ${{ github.event.workflow_run.conclusion == 'success' }}
-    runs-on: ${{ vars.RUNNER || 'ubuntu-latest' }}
+    runs-on: ubuntu-26.04
     outputs:
       version: ${{ steps.version.outputs.version }}
     steps:

--- a/.github/workflows/notify-fork-sync.yml
+++ b/.github/workflows/notify-fork-sync.yml
@@ -8,7 +8,7 @@ permissions: {}
 
 jobs:
   dispatch:
-    runs-on: ${{ vars.RUNNER || 'ubuntu-latest' }}
+    runs-on: ubuntu-26.04
     steps:
       - name: Generate GitHub App token
         id: app-token

--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -49,7 +49,7 @@ jobs:
         platform:
           - linux/amd64
           - linux/arm64
-    runs-on: ${{ vars.RUNNER || 'ubuntu-latest' }}
+    runs-on: ubuntu-26.04
     permissions:
       contents: read
     steps:
@@ -163,7 +163,7 @@ jobs:
       fail-fast: false
       matrix:
         component: [core, jobservice, registryctl, exporter, portal, registry, trivy-adapter]
-    runs-on: ${{ vars.RUNNER || 'ubuntu-latest' }}
+    runs-on: ubuntu-26.04
     permissions:
       contents: read
     steps:
@@ -212,7 +212,7 @@ jobs:
     name: Sign preview images
     if: ${{ github.event.pull_request.head.repo.full_name == github.repository && github.actor != 'renovate[bot]' }}
     needs: [merge]
-    runs-on: ${{ vars.RUNNER || 'ubuntu-latest' }}
+    runs-on: ubuntu-26.04
     permissions:
       contents: read
       id-token: write
@@ -269,7 +269,7 @@ jobs:
     name: Comment preview image refs
     if: ${{ github.event.pull_request.head.repo.full_name == github.repository && github.actor != 'renovate[bot]' }}
     needs: [sign]
-    runs-on: ${{ vars.RUNNER || 'ubuntu-latest' }}
+    runs-on: ubuntu-26.04
     permissions:
       issues: write
       pull-requests: write

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -9,7 +9,7 @@ permissions:
 
 jobs:
   lint:
-    runs-on: ${{ vars.RUNNER || 'ubuntu-latest' }}
+    runs-on: ubuntu-26.04
     steps:
       - uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50 # v6.1.1
         env:

--- a/.github/workflows/publish-chart.yml
+++ b/.github/workflows/publish-chart.yml
@@ -30,7 +30,7 @@ concurrency:
 jobs:
   publish:
     name: Publish Helm Chart
-    runs-on: ${{ vars.RUNNER || 'ubuntu-latest' }}
+    runs-on: ubuntu-26.04
     timeout-minutes: 30
     env:
       REGISTRY_ADDRESS: ${{ vars.REGISTRY_ADDRESS || '8gears.container-registry.com' }}

--- a/.github/workflows/publish-images.yml
+++ b/.github/workflows/publish-images.yml
@@ -43,7 +43,7 @@ jobs:
         platform:
           - linux/amd64
           - linux/arm64
-    runs-on: ${{ vars.RUNNER || 'ubuntu-latest' }}
+    runs-on: ubuntu-26.04
     permissions:
       contents: read
     env:
@@ -210,7 +210,7 @@ jobs:
     strategy:
       matrix:
         component: [core, jobservice, registryctl, exporter, portal, registry, trivy-adapter, grype-scanner, snyk-scanner]
-    runs-on: ${{ vars.RUNNER || 'ubuntu-latest' }}
+    runs-on: ubuntu-26.04
     permissions:
       contents: read
     env:
@@ -263,7 +263,7 @@ jobs:
   sign:
     name: Sign images
     needs: [merge]
-    runs-on: ${{ vars.RUNNER || 'ubuntu-latest' }}
+    runs-on: ubuntu-26.04
     permissions:
       contents: read
       id-token: write

--- a/.github/workflows/release-notes-engine.yml
+++ b/.github/workflows/release-notes-engine.yml
@@ -31,7 +31,7 @@ concurrency:
 jobs:
   update:
     name: Recreate ${{ inputs.tag_name || 'Release Preview' }} Notes
-    runs-on: ${{ vars.RUNNER || 'ubuntu-latest' }}
+    runs-on: ubuntu-26.04
     timeout-minutes: 15
     env:
       GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -14,7 +14,7 @@ permissions:
 jobs:
   validate-release-ref:
     name: Validate Release Ref
-    runs-on: ${{ vars.RUNNER || 'ubuntu-latest' }}
+    runs-on: ubuntu-26.04
     steps:
       - name: Allow only release refs
         run: |
@@ -27,7 +27,7 @@ jobs:
 
   release-please:
     needs: [validate-release-ref]
-    runs-on: ${{ vars.RUNNER || 'ubuntu-latest' }}
+    runs-on: ubuntu-26.04
     outputs:
       release_created: ${{ steps.release.outputs.release_created }}
       tag_name: ${{ steps.release.outputs.tag_name }}
@@ -127,7 +127,7 @@ jobs:
     # unprefixed release-please outputs. Chart releases run on main only.
     needs: [validate-release-ref]
     if: ${{ github.ref_name == 'main' }}
-    runs-on: ${{ vars.RUNNER || 'ubuntu-latest' }}
+    runs-on: ubuntu-26.04
     permissions:
       contents: write
       pull-requests: write
@@ -153,7 +153,7 @@ jobs:
         needs.release-please.outputs.release_created == 'true' &&
         needs.release-please.outputs.patch == '0'
       }}
-    runs-on: ${{ vars.RUNNER || 'ubuntu-latest' }}
+    runs-on: ubuntu-26.04
     permissions:
       contents: write
     env:

--- a/.github/workflows/release-ready.yml
+++ b/.github/workflows/release-ready.yml
@@ -15,7 +15,7 @@ concurrency:
 jobs:
   release-ready:
     name: Validate Release Patches
-    runs-on: ${{ vars.RUNNER || 'ubuntu-latest' }}
+    runs-on: ubuntu-26.04
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:

--- a/.github/workflows/spellcheck.yml
+++ b/.github/workflows/spellcheck.yml
@@ -20,7 +20,7 @@ permissions:
 
 jobs:
   typos:
-    runs-on: ${{ (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository || contains(fromJSON('["OWNER","MEMBER"]'), github.event.pull_request.author_association)) && vars.RUNNER || 'ubuntu-latest' }}
+    runs-on: ubuntu-26.04
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,7 +33,7 @@ jobs:
   # --------------------------------------------------------------------------
   test-unit:
     name: Unit Tests (pure)
-    runs-on: ${{ (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository || contains(fromJSON('["OWNER","MEMBER"]'), github.event.pull_request.author_association)) && vars.RUNNER || 'ubuntu-latest' }}
+    runs-on: ubuntu-26.04
     env:
       CGO_ENABLED: "1"
       RACE_FLAGS: -race
@@ -66,7 +66,7 @@ jobs:
   # --------------------------------------------------------------------------
   test-db:
     name: Unit Tests (DB ${{ matrix.shard_name }})
-    runs-on: ${{ (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository || contains(fromJSON('["OWNER","MEMBER"]'), github.event.pull_request.author_association)) && vars.RUNNER || 'ubuntu-latest' }}
+    runs-on: ubuntu-26.04
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/upstream-cherry-pick.yml
+++ b/.github/workflows/upstream-cherry-pick.yml
@@ -25,7 +25,7 @@ jobs:
     name: Open upstream cherry-pick PRs
     # Forks may use the manual dry-run, but must not run the canonical schedule.
     if: github.event_name != 'schedule' || github.repository == 'container-registry/harbor-next'
-    runs-on: ${{ vars.RUNNER || 'ubuntu-latest' }}
+    runs-on: ubuntu-26.04
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       GH_REPO: ${{ github.repository }}

--- a/.github/workflows/vulnerability-check.yml
+++ b/.github/workflows/vulnerability-check.yml
@@ -18,7 +18,7 @@ env:
 jobs:
   govulncheck:
     name: govulncheck
-    runs-on: ${{ (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository || contains(fromJSON('["OWNER","MEMBER"]'), github.event.pull_request.author_association)) && vars.RUNNER || 'ubuntu-latest' }}
+    runs-on: ubuntu-26.04
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:

--- a/.github/workflows/welcome.yml
+++ b/.github/workflows/welcome.yml
@@ -12,7 +12,7 @@ permissions:
 
 jobs:
   welcome:
-    runs-on: ${{ vars.RUNNER || 'ubuntu-latest' }}
+    runs-on: ubuntu-26.04
     steps:
       - uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -226,7 +226,6 @@ Upstream-Author: @original-author
 
 | Name | Type | Required | Purpose |
 |------|------|----------|---------|
-| `RUNNER` | Variable | No | Custom runner label |
 | `REGISTRY_ADDRESS` | Variable | No | Registry host, defaults to `8gears.container-registry.com` |
 | `REGISTRY_PROJECT` | Variable | No | Registry project, defaults to `8gcr` |
 | `REGISTRY_USERNAME` | Variable | Yes | Registry push username |

--- a/src/migration/authoritative.go
+++ b/src/migration/authoritative.go
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// https://www.apache.org/licenses/LICENSE-2.0
+//    http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,


### PR DESCRIPTION
## Summary

Switches all workflows from the `vars.RUNNER`-driven runner selection (self-hosted, falling back to `ubuntu-latest`) to a hardcoded GitHub-hosted `ubuntu-26.04` runner.

## Related Issues

N/A

## Type of Change

- [ ] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` / `fix!:`)
- [ ] Documentation (`docs:`)
- [ ] Refactoring (`refactor:`)
- [x] CI/CD or build changes (`ci:` / `build:`)
- [ ] Dependencies update (`chore:`)
- [ ] Tests (`test:`)

## Release Notes

N/A (CI-only change, excluded from release notes)

## Testing

- [ ] Unit tests added/updated
- [x] Manual testing performed

All 25 modified workflow files verified as valid YAML (`yaml.safe_load`). No `vars.RUNNER` references remain. CI running this PR itself is the real-world test.

## Checklist

- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] Commits are signed off (`git commit -s`)
- [x] No new warnings introduced
