### PR TITLE
chore: Fix Apache license header URL scheme in migration tests

### DIFF
--- a/src/migration/authoritative_db_test.go
+++ b/src/migration/authoritative_db_test.go
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// https://www.apache.org/licenses/LICENSE-2.0
+//    http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/migration/authoritative_test.go
+++ b/src/migration/authoritative_test.go
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// https://www.apache.org/licenses/LICENSE-2.0
+//    http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,


### PR DESCRIPTION
Companion to #722.

#722 fixes the goheader mismatch in `authoritative.go` (`https://`, no indent, vs the canonical `   http://www.apache.org/licenses/LICENSE-2.0` in `src/copyright.tmpl`), but the two test files added alongside it in #711 have the identical bug and aren't touched by #722:

- `src/migration/authoritative_test.go`
- `src/migration/authoritative_db_test.go`

Without this, Go Lint keeps failing on every PR branched from main even after #722 merges — I hit it directly on #723 and #725.

## Testing

Diffed the fixed line byte-for-byte against a known-passing file (`src/common/dao/pgsql.go`) and against `src/copyright.tmpl` — exact match.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] Conventional commit title
- [x] DCO sign-off
- [x] No new warnings