### PR TITLE
fix: Backport Authoritative Harbor Next Schema Reconciliation (#711, #722)

### DIFF
--- a/make/migrations/postgresql/harbor_next.sql
+++ b/make/migrations/postgresql/harbor_next.sql
@@ -1,0 +1,64 @@
+-- Harbor Next authoritative schema
+--
+-- This public, unversioned schema is reconciled after Harbor's numbered
+-- migrations every time database migration is enabled. Keep every statement
+-- idempotent: this file is intentionally executed more than once and is not
+-- tracked in schema_migrations.
+--
+-- Only additive, data-preserving changes belong here. Destructive changes and
+-- large data backfills require a separately reviewed operational procedure.
+--
+-- branding and identity_providers/robot_identity_providers/claim_rules were
+-- formerly release-2.15 migrations 0181/0182; both numbers were later reused
+-- by real upstream migrations, so they moved here instead of being renumbered.
+
+-- Branding customization
+CREATE TABLE IF NOT EXISTS branding (
+    id           INTEGER PRIMARY KEY NOT NULL,
+    config       TEXT NOT NULL,
+    update_time  TIMESTAMP WITH TIME ZONE DEFAULT NOW() NOT NULL
+);
+
+-- Workload identity federation
+CREATE TABLE IF NOT EXISTS identity_providers (
+    id                      SERIAL PRIMARY KEY,
+    name                    TEXT NOT NULL,
+    description             TEXT,
+    issuer                  TEXT NOT NULL,
+    openid_config_url       TEXT,
+    offline_validation      BOOLEAN NOT NULL DEFAULT FALSE,
+    supported_algorithms    TEXT,
+    claims_supported        TEXT,
+    jwks_uri                TEXT,
+    jwks_keys               JSONB,
+    jwks_cached_at          TIMESTAMP,
+    jwks_expires_at         TIMESTAMP,
+    jwks_last_fetch_attempt TIMESTAMP,
+    project_id              INT NOT NULL DEFAULT 0,
+    creation_time           TIMESTAMP DEFAULT NOW(),
+    update_time             TIMESTAMP DEFAULT NOW(),
+    UNIQUE (issuer, project_id)
+);
+
+CREATE TABLE IF NOT EXISTS robot_identity_providers (
+    id                   SERIAL PRIMARY KEY,
+    identity_provider_id INT NOT NULL REFERENCES identity_providers(id) ON DELETE CASCADE,
+    robot_id             BIGINT NOT NULL REFERENCES robot(id) ON DELETE CASCADE,
+    creation_time        TIMESTAMP DEFAULT NOW(),
+    UNIQUE (identity_provider_id, robot_id)
+);
+
+CREATE TABLE IF NOT EXISTS claim_rules (
+    id                   SERIAL PRIMARY KEY,
+    identity_provider_id INT NOT NULL REFERENCES identity_providers(id) ON DELETE CASCADE,
+    robot_id             BIGINT NOT NULL DEFAULT 0,
+    claim_path           TEXT NOT NULL,
+    value                TEXT,
+    creation_time        TIMESTAMP DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_claim_rules_lookup
+    ON claim_rules (identity_provider_id, claim_path, value, robot_id);
+
+CREATE INDEX IF NOT EXISTS idx_identity_providers_jwks_cache
+    ON identity_providers (id, jwks_expires_at, jwks_last_fetch_attempt);

--- a/src/common/dao/migrator_dsn_test.go
+++ b/src/common/dao/migrator_dsn_test.go
@@ -1,0 +1,60 @@
+// Copyright Project Harbor Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package dao
+
+import (
+	"testing"
+
+	"github.com/goharbor/harbor/src/common/models"
+)
+
+func TestMigratorDSNFromFields(t *testing.T) {
+	cfg := &models.PostGreSQL{
+		Host:     "db.internal",
+		Port:     5432,
+		Username: "postgres",
+		Password: "root123",
+		Database: "registry",
+		SSLMode:  "disable",
+	}
+	got, err := migratorDSN(cfg)
+	if err != nil {
+		t.Fatalf("migratorDSN() error = %v", err)
+	}
+	want := "pgx5://postgres:root123@db.internal:5432/registry?sslmode=disable"
+	if got != want {
+		t.Errorf("migratorDSN() = %q, want %q", got, want)
+	}
+}
+
+func TestMigratorDSNHonorsURL(t *testing.T) {
+	// e.g. an RDS IAM auth token embedded as the password, per 0006-aws-rds-iam-auth
+	cfg := &models.PostGreSQL{URL: "postgres://iam-user:rds-token@rds.example.com:5432/registry?sslmode=require"}
+	got, err := migratorDSN(cfg)
+	if err != nil {
+		t.Fatalf("migratorDSN() error = %v", err)
+	}
+	want := "pgx5://iam-user:rds-token@rds.example.com:5432/registry?sslmode=require"
+	if got != want {
+		t.Errorf("migratorDSN() = %q, want %q — URL field must take precedence over individual fields", got, want)
+	}
+}
+
+func TestMigratorDSNInvalidURL(t *testing.T) {
+	cfg := &models.PostGreSQL{URL: "://not a url"}
+	if _, err := migratorDSN(cfg); err == nil {
+		t.Error("migratorDSN() with an invalid URL returned nil error")
+	}
+}

--- a/src/common/dao/pgsql.go
+++ b/src/common/dao/pgsql.go
@@ -109,12 +109,9 @@ func (p *pgsql) UpgradeSchema() error {
 // golang-migrate's pgx/v5 driver registers under that name (not "pgx", which
 // is the v4 driver).
 func NewMigrator(database *models.PostGreSQL) (*migrate.Migrate, error) {
-	dbURL := url.URL{
-		Scheme:   "pgx5",
-		User:     url.UserPassword(database.Username, database.Password),
-		Host:     net.JoinHostPort(database.Host, strconv.Itoa(database.Port)),
-		Path:     database.Database,
-		RawQuery: fmt.Sprintf("sslmode=%s", database.SSLMode),
+	dsn, err := migratorDSN(database)
+	if err != nil {
+		return nil, err
 	}
 
 	// For UT
@@ -123,10 +120,34 @@ func NewMigrator(database *models.PostGreSQL) (*migrate.Migrate, error) {
 		path = defaultMigrationPath
 	}
 	srcURL := fmt.Sprintf("file://%s", path)
-	m, err := migrate.New(srcURL, dbURL.String())
+	m, err := migrate.New(srcURL, dsn)
 	if err != nil {
 		return nil, err
 	}
 	m.Log = newMigrateLogger()
 	return m, nil
+}
+
+// migratorDSN returns the pgx5-scheme URL golang-migrate connects with.
+// Honors database.URL when set (matches dbpool.BuildDSN's precedence for
+// cloud-managed databases like RDS IAM auth, where the DSN carries a token
+// that Host/Username/Password alone can't reconstruct) so the numbered and
+// authoritative migration phases always target the same database.
+func migratorDSN(database *models.PostGreSQL) (string, error) {
+	if database.URL == "" {
+		dbURL := url.URL{
+			Scheme:   "pgx5",
+			User:     url.UserPassword(database.Username, database.Password),
+			Host:     net.JoinHostPort(database.Host, strconv.Itoa(database.Port)),
+			Path:     database.Database,
+			RawQuery: fmt.Sprintf("sslmode=%s", database.SSLMode),
+		}
+		return dbURL.String(), nil
+	}
+	u, err := url.Parse(database.URL)
+	if err != nil {
+		return "", fmt.Errorf("parse database URL: %w", err)
+	}
+	u.Scheme = "pgx5"
+	return u.String(), nil
 }

--- a/src/lib/metric/collector.go
+++ b/src/lib/metric/collector.go
@@ -26,6 +26,7 @@ func RegisterCollectors() {
 		TotalInFlightGauge,
 		TotalReqCnt,
 		TotalReqDurSummary,
+		MigrationPhaseDuration,
 	}...)
 }
 
@@ -61,4 +62,15 @@ var (
 			Objectives: map[float64]float64{0.5: 0.05, 0.9: 0.01, 0.99: 0.001},
 		},
 		[]string{"method", "operation"})
+
+	// MigrationPhaseDuration collects how long each DB migration phase takes at core startup
+	MigrationPhaseDuration = prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Namespace: os.Getenv(NamespaceEnvKey),
+			Subsystem: os.Getenv(SubsystemEnvKey),
+			Name:      "migration_phase_duration_seconds",
+			Help:      "Duration of each database migration phase at core startup",
+			Buckets:   []float64{.01, .05, .1, .25, .5, 1, 2.5, 5, 10, 30, 60},
+		},
+		[]string{"phase"})
 )

--- a/src/migration/authoritative.go
+++ b/src/migration/authoritative.go
@@ -1,0 +1,117 @@
+// Copyright Project Harbor Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package migration
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/goharbor/harbor/src/lib/log"
+)
+
+const (
+	defaultMigrationDir     = "migrations/postgresql"
+	authoritativeSchemaFile = "harbor_next.sql"
+
+	// authoritativeSchemaLockID is the ASCII encoding of "HNEXTSCH". It
+	// serializes reconciliation when multiple core replicas start together.
+	authoritativeSchemaLockID int64 = 0x484e455854534348
+)
+
+type schemaDB interface {
+	Begin(context.Context) (schemaTx, error)
+}
+
+type schemaTx interface {
+	Exec(context.Context, string, ...any) error
+	Commit() error
+	Rollback() error
+}
+
+type sqlSchemaDB struct {
+	db *sql.DB
+}
+
+func (d sqlSchemaDB) Begin(ctx context.Context) (schemaTx, error) {
+	tx, err := d.db.BeginTx(ctx, nil)
+	if err != nil {
+		return nil, err
+	}
+	return sqlSchemaTx{tx: tx}, nil
+}
+
+type sqlSchemaTx struct {
+	tx *sql.Tx
+}
+
+func (t sqlSchemaTx) Exec(ctx context.Context, query string, args ...any) error {
+	_, err := t.tx.ExecContext(ctx, query, args...)
+	return err
+}
+
+func (t sqlSchemaTx) Commit() error {
+	return t.tx.Commit()
+}
+
+func (t sqlSchemaTx) Rollback() error {
+	return t.tx.Rollback()
+}
+
+func authoritativeSchemaPath() string {
+	dir := os.Getenv("POSTGRES_MIGRATION_SCRIPTS_PATH")
+	if dir == "" {
+		dir = defaultMigrationDir
+	}
+	return filepath.Join(dir, authoritativeSchemaFile)
+}
+
+func applyAuthoritativeSchema(ctx context.Context, db schemaDB, path string) error {
+	schema, err := os.ReadFile(path)
+	if err != nil {
+		return fmt.Errorf("read authoritative Harbor Next schema %q: %w", path, err)
+	}
+	if strings.TrimSpace(string(schema)) == "" {
+		return fmt.Errorf("authoritative Harbor Next schema %q is empty", path)
+	}
+
+	log.Infof("Applying authoritative Harbor Next schema from %s ...", path)
+	tx, err := db.Begin(ctx)
+	if err != nil {
+		return fmt.Errorf("begin authoritative Harbor Next schema transaction: %w", err)
+	}
+	committed := false
+	defer func() {
+		if !committed {
+			_ = tx.Rollback()
+		}
+	}()
+
+	if err := tx.Exec(ctx, "SELECT pg_advisory_xact_lock($1)", authoritativeSchemaLockID); err != nil {
+		return fmt.Errorf("lock authoritative Harbor Next schema: %w", err)
+	}
+	if err := tx.Exec(ctx, string(schema)); err != nil {
+		return fmt.Errorf("apply authoritative Harbor Next schema: %w", err)
+	}
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("commit authoritative Harbor Next schema: %w", err)
+	}
+	committed = true
+	log.Info("Authoritative Harbor Next schema applied successfully")
+	return nil
+}

--- a/src/migration/authoritative_db_test.go
+++ b/src/migration/authoritative_db_test.go
@@ -1,0 +1,170 @@
+// Copyright Project Harbor Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build db
+
+package migration
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/goharbor/harbor/src/common/models"
+	"github.com/goharbor/harbor/src/lib/dbpool"
+)
+
+func TestAuthoritativeSchemaAgainstPostgreSQL(t *testing.T) {
+	ctx := context.Background()
+	cfg := authoritativeTestDatabaseConfig()
+	adminPool, err := dbpool.New(ctx, cfg)
+	if err != nil {
+		t.Fatalf("create admin database pool: %v", err)
+	}
+	t.Cleanup(adminPool.Close)
+
+	schemaName := fmt.Sprintf("harbor_next_schema_test_%d", time.Now().UnixNano())
+	if _, err := adminPool.DB().ExecContext(ctx, "CREATE SCHEMA "+schemaName); err != nil {
+		t.Fatalf("create test schema: %v", err)
+	}
+	t.Cleanup(func() {
+		if _, err := adminPool.DB().ExecContext(ctx, "DROP SCHEMA "+schemaName+" CASCADE"); err != nil {
+			t.Errorf("drop test schema: %v", err)
+		}
+	})
+
+	cfg.MaxOpenConns = 4
+	schemaPool, err := dbpool.New(ctx, cfg, func(poolCfg *pgxpool.Config) {
+		poolCfg.ConnConfig.RuntimeParams["search_path"] = schemaName
+	})
+	if err != nil {
+		t.Fatalf("create schema database pool: %v", err)
+	}
+	t.Cleanup(schemaPool.Close)
+
+	if _, err := schemaPool.DB().ExecContext(ctx, "CREATE TABLE robot (id BIGSERIAL PRIMARY KEY)"); err != nil {
+		t.Fatalf("create robot dependency: %v", err)
+	}
+
+	path := authoritativeTestSchemaPath()
+	errCh := make(chan error, 2)
+	for range 2 {
+		go func() {
+			errCh <- applyAuthoritativeSchema(ctx, sqlSchemaDB{db: schemaPool.DB()}, path)
+		}()
+	}
+	for range 2 {
+		if err := <-errCh; err != nil {
+			t.Errorf("applyAuthoritativeSchema() concurrent run returned error: %v", err)
+		}
+	}
+
+	if err := applyAuthoritativeSchema(ctx, sqlSchemaDB{db: schemaPool.DB()}, path); err != nil {
+		t.Fatalf("applyAuthoritativeSchema() repeat run returned error: %v", err)
+	}
+
+	objects := []string{
+		"branding",
+		"identity_providers",
+		"robot_identity_providers",
+		"claim_rules",
+		"idx_claim_rules_lookup",
+		"idx_identity_providers_jwks_cache",
+	}
+	for _, object := range objects {
+		var exists bool
+		if err := schemaPool.DB().QueryRowContext(ctx, "SELECT to_regclass($1) IS NOT NULL", object).Scan(&exists); err != nil {
+			t.Errorf("look up %s: %v", object, err)
+			continue
+		}
+		if !exists {
+			t.Errorf("authoritative schema object %q does not exist", object)
+		}
+	}
+
+	columns := map[string][]string{
+		"branding": {
+			"id", "config", "update_time",
+		},
+		"identity_providers": {
+			"id", "name", "description", "issuer", "openid_config_url",
+			"offline_validation", "supported_algorithms", "claims_supported",
+			"jwks_uri", "jwks_keys", "jwks_cached_at", "jwks_expires_at",
+			"jwks_last_fetch_attempt", "project_id", "creation_time", "update_time",
+		},
+		"robot_identity_providers": {
+			"id", "identity_provider_id", "robot_id", "creation_time",
+		},
+		"claim_rules": {
+			"id", "identity_provider_id", "robot_id", "claim_path", "value", "creation_time",
+		},
+	}
+	for table, tableColumns := range columns {
+		for _, column := range tableColumns {
+			var exists bool
+			err := schemaPool.DB().QueryRowContext(ctx, `
+				SELECT EXISTS (
+					SELECT 1
+					FROM information_schema.columns
+					WHERE table_schema = current_schema()
+					  AND table_name = $1
+					  AND column_name = $2
+				)`, table, column).Scan(&exists)
+			if err != nil {
+				t.Errorf("look up column %s.%s: %v", table, column, err)
+				continue
+			}
+			if !exists {
+				t.Errorf("authoritative schema column %q does not exist", table+"."+column)
+			}
+		}
+	}
+}
+
+func authoritativeTestDatabaseConfig() *models.PostGreSQL {
+	port := 5432
+	if value := os.Getenv("POSTGRESQL_PORT"); value != "" {
+		if configuredPort, err := strconv.Atoi(value); err == nil {
+			port = configuredPort
+		}
+	}
+	return &models.PostGreSQL{
+		Host:     environmentOr("POSTGRESQL_HOST", "localhost"),
+		Port:     port,
+		Username: environmentOr("POSTGRESQL_USR", environmentOr("POSTGRESQL_USERNAME", "postgres")),
+		Password: environmentOr("POSTGRESQL_PWD", environmentOr("POSTGRESQL_PASSWORD", "root123")),
+		Database: environmentOr("POSTGRESQL_DATABASE", "registry"),
+		SSLMode:  "disable",
+	}
+}
+
+func authoritativeTestSchemaPath() string {
+	if dir := os.Getenv("POSTGRES_MIGRATION_SCRIPTS_PATH"); dir != "" {
+		return filepath.Join(dir, authoritativeSchemaFile)
+	}
+	return filepath.Join("..", "..", "make", "migrations", "postgresql", authoritativeSchemaFile)
+}
+
+func environmentOr(key, fallback string) string {
+	if value := os.Getenv(key); value != "" {
+		return value
+	}
+	return fallback
+}

--- a/src/migration/authoritative_test.go
+++ b/src/migration/authoritative_test.go
@@ -1,0 +1,213 @@
+// Copyright Project Harbor Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package migration
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+type fakeSchemaDB struct {
+	begin func(context.Context) (schemaTx, error)
+}
+
+func (d fakeSchemaDB) Begin(ctx context.Context) (schemaTx, error) {
+	return d.begin(ctx)
+}
+
+type fakeSchemaTx struct {
+	queries    []string
+	args       [][]any
+	execErrors map[int]error
+	commitErr  error
+	committed  bool
+	rolledBack bool
+}
+
+func (tx *fakeSchemaTx) Exec(_ context.Context, query string, args ...any) error {
+	tx.queries = append(tx.queries, query)
+	tx.args = append(tx.args, args)
+	return tx.execErrors[len(tx.queries)]
+}
+
+func (tx *fakeSchemaTx) Commit() error {
+	if tx.commitErr != nil {
+		return tx.commitErr
+	}
+	tx.committed = true
+	return nil
+}
+
+func (tx *fakeSchemaTx) Rollback() error {
+	tx.rolledBack = true
+	return nil
+}
+
+func TestAuthoritativeSchemaPath(t *testing.T) {
+	t.Run("default", func(t *testing.T) {
+		t.Setenv("POSTGRES_MIGRATION_SCRIPTS_PATH", "")
+		want := filepath.Join(defaultMigrationDir, authoritativeSchemaFile)
+		if got := authoritativeSchemaPath(); got != want {
+			t.Errorf("authoritativeSchemaPath() = %q, want %q", got, want)
+		}
+	})
+
+	t.Run("configured migration directory", func(t *testing.T) {
+		t.Setenv("POSTGRES_MIGRATION_SCRIPTS_PATH", "/test/migrations")
+		want := filepath.Join("/test/migrations", authoritativeSchemaFile)
+		if got := authoritativeSchemaPath(); got != want {
+			t.Errorf("authoritativeSchemaPath() = %q, want %q", got, want)
+		}
+	})
+}
+
+func TestApplyAuthoritativeSchemaIsRepeatable(t *testing.T) {
+	const schema = "CREATE TABLE IF NOT EXISTS example (id BIGINT PRIMARY KEY);\n"
+	path := writeSchema(t, schema)
+
+	var transactions []*fakeSchemaTx
+	db := fakeSchemaDB{begin: func(context.Context) (schemaTx, error) {
+		tx := &fakeSchemaTx{}
+		transactions = append(transactions, tx)
+		return tx, nil
+	}}
+
+	for i := 0; i < 2; i++ {
+		if err := applyAuthoritativeSchema(context.Background(), db, path); err != nil {
+			t.Fatalf("applyAuthoritativeSchema() run %d returned error: %v", i+1, err)
+		}
+	}
+
+	if got, want := len(transactions), 2; got != want {
+		t.Fatalf("transaction count = %d, want %d", got, want)
+	}
+	for i, tx := range transactions {
+		if !tx.committed {
+			t.Errorf("transaction %d was not committed", i+1)
+		}
+		if tx.rolledBack {
+			t.Errorf("transaction %d was rolled back", i+1)
+		}
+		if got, want := len(tx.queries), 2; got != want {
+			t.Fatalf("transaction %d query count = %d, want %d", i+1, got, want)
+		}
+		if got, want := tx.queries[0], "SELECT pg_advisory_xact_lock($1)"; got != want {
+			t.Errorf("transaction %d lock query = %q, want %q", i+1, got, want)
+		}
+		if got, want := tx.args[0][0], any(authoritativeSchemaLockID); got != want {
+			t.Errorf("transaction %d lock ID = %v, want %v", i+1, got, want)
+		}
+		if got := tx.queries[1]; got != schema {
+			t.Errorf("transaction %d schema query = %q, want %q", i+1, got, schema)
+		}
+	}
+}
+
+func TestApplyAuthoritativeSchemaErrors(t *testing.T) {
+	errBegin := errors.New("begin")
+	errLock := errors.New("lock")
+	errApply := errors.New("apply")
+	errCommit := errors.New("commit")
+
+	tests := []struct {
+		name         string
+		path         func(*testing.T) string
+		beginErr     error
+		execErrors   map[int]error
+		commitErr    error
+		wantErr      error
+		wantRollback bool
+	}{
+		{
+			name: "missing schema file",
+			path: func(t *testing.T) string {
+				return filepath.Join(t.TempDir(), "missing.sql")
+			},
+		},
+		{
+			name: "empty schema file",
+			path: func(t *testing.T) string {
+				return writeSchema(t, " \n\t")
+			},
+		},
+		{
+			name:     "begin transaction",
+			path:     func(t *testing.T) string { return writeSchema(t, "SELECT 1;") },
+			beginErr: errBegin,
+			wantErr:  errBegin,
+		},
+		{
+			name:         "acquire advisory lock",
+			path:         func(t *testing.T) string { return writeSchema(t, "SELECT 1;") },
+			execErrors:   map[int]error{1: errLock},
+			wantErr:      errLock,
+			wantRollback: true,
+		},
+		{
+			name:         "execute schema",
+			path:         func(t *testing.T) string { return writeSchema(t, "SELECT 1;") },
+			execErrors:   map[int]error{2: errApply},
+			wantErr:      errApply,
+			wantRollback: true,
+		},
+		{
+			name:         "commit transaction",
+			path:         func(t *testing.T) string { return writeSchema(t, "SELECT 1;") },
+			commitErr:    errCommit,
+			wantErr:      errCommit,
+			wantRollback: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tx := &fakeSchemaTx{execErrors: tt.execErrors, commitErr: tt.commitErr}
+			beginCalled := false
+			db := fakeSchemaDB{begin: func(context.Context) (schemaTx, error) {
+				beginCalled = true
+				if tt.beginErr != nil {
+					return nil, tt.beginErr
+				}
+				return tx, nil
+			}}
+
+			err := applyAuthoritativeSchema(context.Background(), db, tt.path(t))
+			if err == nil {
+				t.Fatal("applyAuthoritativeSchema() returned nil error")
+			}
+			if tt.wantErr != nil && !errors.Is(err, tt.wantErr) {
+				t.Errorf("applyAuthoritativeSchema() error = %v, want error wrapping %v", err, tt.wantErr)
+			}
+			if tt.wantErr == nil && beginCalled {
+				t.Error("database transaction began before schema validation completed")
+			}
+			if tx.rolledBack != tt.wantRollback {
+				t.Errorf("transaction rolledBack = %t, want %t", tx.rolledBack, tt.wantRollback)
+			}
+		})
+	}
+}
+
+func writeSchema(t *testing.T, contents string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), authoritativeSchemaFile)
+	if err := os.WriteFile(path, []byte(contents), 0o600); err != nil {
+		t.Fatalf("write schema fixture: %v", err)
+	}
+	return path
+}

--- a/src/migration/migration.go
+++ b/src/migration/migration.go
@@ -15,11 +15,16 @@
 package migration
 
 import (
+	"context"
+	"fmt"
+	"time"
+
 	"github.com/golang-migrate/migrate/v4"
 
 	"github.com/goharbor/harbor/src/common/dao"
 	"github.com/goharbor/harbor/src/common/models"
 	"github.com/goharbor/harbor/src/lib/log"
+	"github.com/goharbor/harbor/src/lib/metric"
 )
 
 // Migrate upgrades DB schema and do necessary transformation of the data in DB
@@ -35,5 +40,27 @@ func Migrate(database *models.Database) error {
 		return err
 	}
 	log.Debugf("current database schema version: %v", schemaVersion)
-	return dao.UpgradeSchema(database)
+	start := time.Now()
+	if err := dao.UpgradeSchema(database); err != nil {
+		return err
+	}
+	observeMigrationPhase("numbered", start)
+
+	pool := dao.GetPool()
+	if pool == nil {
+		return fmt.Errorf("apply authoritative Harbor Next schema: database pool is not initialized")
+	}
+	start = time.Now()
+	if err := applyAuthoritativeSchema(context.Background(), sqlSchemaDB{db: pool.DB()}, authoritativeSchemaPath()); err != nil {
+		return err
+	}
+	observeMigrationPhase("authoritative", start)
+	return nil
+}
+
+// observeMigrationPhase logs and records how long a migration phase took
+func observeMigrationPhase(phase string, start time.Time) {
+	elapsed := time.Since(start)
+	log.Infof("migration phase %q took %s", phase, elapsed)
+	metric.MigrationPhaseDuration.WithLabelValues(phase).Observe(elapsed.Seconds())
 }


### PR DESCRIPTION
Backports #711 and #722 to `release-2.15` in a single commit.

Cherry-picked commits:
- `5652b0806f` feat: Add authoritative Harbor Next schema reconciliation (#711)
- `a0880018fd` fix: Use canonical Apache license URL in authoritative.go header (#722) — folded in so `Go Lint` (goheader) passes

## Why

Root cause of the v2.15.7 startup failure reported in #414 ([comment](https://github.com/container-registry/harbor-next/issues/414#issuecomment-5423430169)): the upstream cherry-pick `9b2a0aba2027` (Y2K38 bigint fix, goharbor/harbor#23718) added `0181_2.15.3_schema.up.sql` to release-2.15 (first shipped in v2.15.7), which collides with the commercial branding patch's `0181_8gears_2.15_branding.up.sql`. golang-migrate refuses to open a source directory containing two files with the same version, so **core fatals at startup on both fresh installs and upgrades of v2.15.7** (verified live: fresh v2.15.7 and v2.15.0→v2.15.7 both crashloop with `duplicate migration file: 0181_8gears_2.15_branding.up.sql`; v2.15.0–v2.15.6 are unaffected). The `apply-patches` megamerge can't see this class of conflict — the filenames differ, only the version prefix collides.

The authoritative `harbor_next.sql` phase removes the need for the commercial patches to occupy numbered slots at all.

## Conflict resolution

One conflict: `src/lib/metric/collector.go` — release-2.15 doesn't have main's proxy-cache metrics (`TotalProxyReq`/`TotalProxyUpstreamReq`), so only `MigrationPhaseDuration` is added. Everything else applied cleanly (`dao.GetPool()` and `models.PostGreSQL.URL` both exist on release-2.15).

## Schema parity audit (transparency)

`harbor_next.sql` was diffed object-by-object against the two numbered migrations it replaces (`0181_8gears_2.15_branding.up.sql` from `release-2.15/0002-branding`, `0182_8gears_2.15_identity_providers.up.sql` from `release-2.15/0004-identity-providers`). **It creates no objects beyond what those two migrations created.** Two intentional deltas, both inherited from main:

1. `robot_identity_providers.robot_id` is `BIGINT` (numbered migration had `INT`). Affects **fresh installs only** — existing tables keep `INT` because the statement is `CREATE TABLE IF NOT EXISTS`, and an int→bigint FK reference is valid either way.
2. `CREATE INDEX idx_claim_rules_lookup` gains `IF NOT EXISTS` — required for idempotency since the authoritative file is executed on every startup.

## What this PR does NOT fix on its own

Being explicit about scope:

1. **v2.15.7 images remain broken** until the patch branches `release-2.15/0002-branding` and `release-2.15/0004-identity-providers` drop their numbered migration files (follow-up in the patches repo). Their DDL is covered by `harbor_next.sql` after this PR.
2. **Existing installs are at `schema_migrations.version = 182`** (from the old numbered 8gears migrations). Once the numbered files are dropped from the patches, golang-migrate's `readUp` → `versionExists(182)` will fail with `no migration found for version 182`, and those installs also never apply upstream's real `0181_2.15.3` (bigint) change. The follow-up must include a repair decision — e.g. resetting version 182→180 before the numbered phase so upstream `0181` applies, or an operational `migrate force 180` step. **The same latent gap exists on main** (main's tree has `0180`, `0181`, `0190` — no `0182`).

## Testing

- `go build` / `go vet` on `./migration/...`, `./common/dao/...`, `./lib/metric/...` — clean
- `go test ./migration/...` — pass (includes the new authoritative tests)
- `go test ./common/dao/ -run TestMigratorDSN` — pass (3/3)



## Release Notes

Harbor Next's own schema additions (branding, workload identity federation) are now reconciled via a single idempotent file after every migration, decoupled from upstream's numbered migration sequence — fixing a class of bug where a future upstream migration could silently be skipped because its number collided with one Harbor Next had already used internally.
