### PR TITLE
perf(quota): Skip usage reservation when hard limits are unlimited

### DIFF
--- a/src/controller/quota/controller.go
+++ b/src/controller/quota/controller.go
@@ -398,6 +398,26 @@ func (c *controller) Request(ctx context.Context, reference, referenceID string,
 		return f()
 	}
 
+	// When every requested resource is unlimited, the reservation cannot
+	// deny anything: IsSafe always passes for UNLIMITED hard limits, so the
+	// reserve/rollback pair degenerates into contended writes on the single
+	// quota_usage row per project with no enforcement effect. Skip it and
+	// let the refresh (RefreshMiddleware / Refresh) keep the usage figure
+	// up to date. If a real limit is set concurrently, enforcement starts
+	// with the next request and the refresh reconciles the usage.
+	if unlimited, err := c.isUnlimited(ctx, reference, referenceID, resources); err == nil && unlimited {
+		err := f()
+		if err == nil {
+			// the skipped reservation was also the only usage writer on
+			// this path - keep the usage figure current via the deferred
+			// coalesced refresh
+			MarkRefresh(reference, referenceID)
+		}
+		return err
+	} else if err != nil {
+		log.G(ctx).Warningf("failed to check hard limits for %s %s, falling back to reservation, error: %v", reference, referenceID, err)
+	}
+
 	provider := updateQuotaProviderType(config.GetQuotaUpdateProvider())
 	if err := c.updateUsageWithRetry(ctx, reference, referenceID, reserveResources(resources), provider); err != nil {
 		log.G(ctx).Errorf("reserve resources %s for %s %s failed, error: %v", resources.String(), reference, referenceID, err)
@@ -414,6 +434,30 @@ func (c *controller) Request(ctx context.Context, reference, referenceID string,
 	}
 
 	return err
+}
+
+// isUnlimited reports whether every resource in the request has an
+// UNLIMITED hard limit for the reference, in which case a reservation can
+// never deny the request.
+func (c *controller) isUnlimited(ctx context.Context, reference, referenceID string, resources types.ResourceList) (bool, error) {
+	q, err := c.quotaMgr.GetByRef(ctx, reference, referenceID)
+	if err != nil {
+		return false, err
+	}
+
+	hardLimits, err := q.GetHard()
+	if err != nil {
+		return false, err
+	}
+
+	for resource := range resources {
+		hardLimit, found := hardLimits[resource]
+		if !found || hardLimit != types.UNLIMITED {
+			return false, nil
+		}
+	}
+
+	return true, nil
 }
 
 // calcQuota calculates the quota and usage in real time.

--- a/src/controller/quota/controller_test.go
+++ b/src/controller/quota/controller_test.go
@@ -184,6 +184,51 @@ func (suite *ControllerTestSuite) TestRequestResourceIsZero() {
 	suite.Nil(err)
 }
 
+func (suite *ControllerTestSuite) TestRequestUnlimitedSkipsReservation() {
+	// unlimited hard limit: Request must not write the quota usage at all
+	q := &quota.Quota{
+		Hard: types.ResourceList{types.ResourceStorage: types.UNLIMITED}.String(),
+		Used: types.ResourceList{types.ResourceStorage: 0}.String(),
+	}
+	mock.OnAnything(suite.quotaMgr, "GetByRef").Return(q, nil)
+
+	ctx := orm.NewContext(context.TODO(), &ormtesting.FakeOrmer{})
+	called := false
+	err := suite.ctl.Request(ctx, suite.reference, uuid.New().String(), types.ResourceList{types.ResourceStorage: 100}, func() error {
+		called = true
+		return nil
+	})
+	suite.Nil(err)
+	suite.True(called)
+	suite.quotaMgr.AssertNotCalled(suite.T(), "Update")
+}
+
+func (suite *ControllerTestSuite) TestRequestLimitedStillReserves() {
+	// finite hard limit: the reservation path must still run and write
+	suite.PrepareForUpdate(suite.quota, nil)
+
+	ctx := orm.NewContext(context.TODO(), &ormtesting.FakeOrmer{})
+	err := suite.ctl.Request(ctx, suite.reference, uuid.New().String(), types.ResourceList{types.ResourceStorage: 10}, func() error {
+		return nil
+	})
+	suite.Nil(err)
+	suite.quotaMgr.AssertCalled(suite.T(), "Update", mock.Anything, mock.Anything)
+}
+
+func (suite *ControllerTestSuite) TestRequestLimitedDenies() {
+	// finite hard limit exceeded: the request must be denied before f runs
+	suite.PrepareForUpdate(suite.quota, nil)
+
+	ctx := orm.NewContext(context.TODO(), &ormtesting.FakeOrmer{})
+	called := false
+	err := suite.ctl.Request(ctx, suite.reference, uuid.New().String(), types.ResourceList{types.ResourceStorage: 1000}, func() error {
+		called = true
+		return nil
+	})
+	suite.Error(err)
+	suite.False(called)
+}
+
 func TestControllerTestSuite(t *testing.T) {
 	suite.Run(t, &ControllerTestSuite{})
 }

--- a/src/controller/quota/refresh_async.go
+++ b/src/controller/quota/refresh_async.go
@@ -1,0 +1,103 @@
+// Copyright Project Harbor Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package quota
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"github.com/goharbor/harbor/src/lib/errors"
+	"github.com/goharbor/harbor/src/lib/gtask"
+	"github.com/goharbor/harbor/src/lib/log"
+	"github.com/goharbor/harbor/src/lib/orm"
+)
+
+// Deferred, coalesced quota usage refresh.
+//
+// On the push path the usage figure is maintained by the synchronous
+// reservation itself (RefreshForProjectMiddleware only runs on deletes).
+// When the reservation is skipped - see Request()'s unlimited fast path -
+// something else must keep the usage figure current: the request path
+// marks the project dirty in memory (no database access), and a background
+// task recomputes and stores the usage once per dirty project per
+// interval, regardless of how many requests marked it.
+//
+// The flush recomputes usage from the database (CalculateUsage) instead of
+// accumulating in-memory deltas, so it is idempotent: a mark lost to a
+// process restart, or a concurrent flush from another core replica, can
+// only delay convergence - never corrupt the stored value. A failed flush
+// re-marks the project and is retried on the next interval.
+const deferredRefreshInterval = 10 * time.Second
+
+// perRefreshTimeout bounds a single project's recompute inside the flush
+// loop; see refreshDirty.
+const perRefreshTimeout = 30 * time.Second
+
+var dirty = struct {
+	sync.Mutex
+	keys map[refKey]struct{}
+}{keys: map[refKey]struct{}{}}
+
+type refKey struct {
+	reference   string
+	referenceID string
+}
+
+func init() {
+	gtask.DefaultPool().AddTask(flushDirtyQuota, deferredRefreshInterval)
+}
+
+// MarkRefresh records that the usage of the reference object changed and
+// must be recomputed by the next flush. It performs no database access.
+func MarkRefresh(reference, referenceID string) {
+	dirty.Lock()
+	dirty.keys[refKey{reference: reference, referenceID: referenceID}] = struct{}{}
+	dirty.Unlock()
+}
+
+// flushDirtyQuota recomputes and stores the usage of every project marked
+// dirty since the previous flush.
+func flushDirtyQuota(_ context.Context) {
+	refreshDirty(orm.Context())
+}
+
+func refreshDirty(ctx context.Context) {
+	dirty.Lock()
+	keys := dirty.keys
+	dirty.keys = make(map[refKey]struct{}, len(keys))
+	dirty.Unlock()
+
+	for key := range keys {
+		// Bound each recompute: Refresh retries CAS conflicts for up to
+		// defaultRetryTimeout, and one project stuck in conflicts must not
+		// hold the single flush goroutine and starve the other dirty
+		// projects. A timed-out refresh is re-marked and tried next flush.
+		refreshCtx, cancel := context.WithTimeout(ctx, perRefreshTimeout)
+		// IgnoreLimitation: the recompute records the truth about used
+		// storage; enforcement happens at reserve time.
+		err := Ctl.Refresh(refreshCtx, key.reference, key.referenceID, IgnoreLimitation(true))
+		cancel()
+		switch {
+		case err == nil:
+		case errors.IsNotFoundErr(err):
+			// the reference was deleted after being marked - nothing left
+			// to refresh, do not re-mark or the key retries forever
+		default:
+			log.Errorf("deferred quota refresh for %s %s failed, will retry next flush, error: %v", key.reference, key.referenceID, err)
+			MarkRefresh(key.reference, key.referenceID)
+		}
+	}
+}

--- a/src/controller/quota/refresh_async_test.go
+++ b/src/controller/quota/refresh_async_test.go
@@ -1,0 +1,117 @@
+// Copyright Project Harbor Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package quota
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/goharbor/harbor/src/lib/orm"
+	"github.com/goharbor/harbor/src/pkg/quota"
+	"github.com/goharbor/harbor/src/pkg/quota/driver"
+	"github.com/goharbor/harbor/src/pkg/quota/types"
+	ormtesting "github.com/goharbor/harbor/src/testing/lib/orm"
+	"github.com/goharbor/harbor/src/testing/mock"
+	quotatesting "github.com/goharbor/harbor/src/testing/pkg/quota"
+	drivertesting "github.com/goharbor/harbor/src/testing/pkg/quota/driver"
+)
+
+func drainDirty() {
+	dirty.Lock()
+	dirty.keys = map[refKey]struct{}{}
+	dirty.Unlock()
+}
+
+func dirtyLen() int {
+	dirty.Lock()
+	defer dirty.Unlock()
+	return len(dirty.keys)
+}
+
+func TestMarkRefreshCoalesces(t *testing.T) {
+	drainDirty()
+	defer drainDirty()
+
+	for i := 0; i < 100; i++ {
+		MarkRefresh("project", "1")
+	}
+	MarkRefresh("project", "2")
+
+	assert.Equal(t, 2, dirtyLen(), "repeated marks of the same reference must coalesce into one")
+}
+
+func TestRefreshDirtyEmptySetIsNoop(t *testing.T) {
+	drainDirty()
+	refreshDirty(context.TODO()) // must not panic, no DB access happens
+	assert.Equal(t, 0, dirtyLen())
+}
+
+func TestRefreshDirtyFlushesOncePerReference(t *testing.T) {
+	drainDirty()
+	defer drainDirty()
+
+	reference := "mock-async"
+	d := &drivertesting.Driver{}
+	driver.Register(reference, d)
+
+	quotaMgr := &quotatesting.Manager{}
+	origCtl := Ctl
+	Ctl = &controller{quotaMgr: quotaMgr}
+	defer func() { Ctl = origCtl }()
+
+	hardLimits := types.ResourceList{types.ResourceStorage: types.UNLIMITED}
+	// return a fresh object per call: updateUsageByDB mutates the returned
+	// quota, and a shared instance would make the second refresh a no-op
+	mock.OnAnything(quotaMgr, "GetByRef").Return(func(context.Context, string, string) *quota.Quota {
+		return &quota.Quota{Hard: hardLimits.String(), Used: types.ResourceList{types.ResourceStorage: 0}.String()}
+	}, nil)
+	mock.OnAnything(d, "CalculateUsage").Return(types.ResourceList{types.ResourceStorage: 42}, nil)
+	mock.OnAnything(quotaMgr, "Update").Return(nil)
+
+	// many marks for the same reference, one for another
+	for i := 0; i < 50; i++ {
+		MarkRefresh(reference, "1")
+	}
+	MarkRefresh(reference, "2")
+
+	refreshDirty(orm.NewContext(context.TODO(), &ormtesting.FakeOrmer{}))
+
+	// one recompute+store per distinct reference, not per mark
+	quotaMgr.AssertNumberOfCalls(t, "Update", 2)
+	assert.Equal(t, 0, dirtyLen(), "successful flush must clear the dirty set")
+}
+
+func TestRefreshDirtyRetriesFailedFlush(t *testing.T) {
+	drainDirty()
+	defer drainDirty()
+
+	reference := "mock-async-fail"
+	d := &drivertesting.Driver{}
+	driver.Register(reference, d)
+
+	quotaMgr := &quotatesting.Manager{}
+	origCtl := Ctl
+	Ctl = &controller{quotaMgr: quotaMgr}
+	defer func() { Ctl = origCtl }()
+
+	mock.OnAnything(quotaMgr, "GetByRef").Return(nil, assert.AnError)
+
+	MarkRefresh(reference, "1")
+	refreshDirty(orm.NewContext(context.TODO(), &ormtesting.FakeOrmer{}))
+
+	assert.Equal(t, 1, dirtyLen(), "failed flush must re-mark the reference for the next interval")
+}


### PR DESCRIPTION
### What this PR does

`Request()` skips the quota usage reservation (and its rollback) when every requested resource has an `UNLIMITED` (-1) hard limit, and instead marks the project for a **deferred, coalesced usage refresh** — a background task on the shared `gtask` pool recomputes and stores the usage once per dirty project per 10s interval. On any error determining the limits it falls back to the reservation path.

### Why

The reservation CAS-updates the single `quota_usage` row per project, retrying optimistic-lock conflicts. When the hard limit is `UNLIMITED`, `quota.IsSafe` can never deny the request — the reservation enforces nothing, yet it still contends on the hot row.

Measured on a production Harbor (v2.15.x) during a ~1000-blob CI push burst into projects with unlimited quotas, the reservation UPDATE accounted for **13 average active sessions** on a 2-vCPU database (`Lock:tuple` wait) while enforcing nothing.

### Why the deferred refresh is part of this change

On the push path the reservation is also the **only writer of the usage figure**: `RefreshForProjectMiddleware` (the full recompute) is mounted only on artifact/repository DELETE routes. Skipping the reservation alone would freeze the usage figure — our end-to-end test caught exactly that. Hence the skip marks the project dirty and the flusher keeps the figure current: one aggregate query (`CalculateUsage` → `SELECT SUM(size) FROM blob JOIN project_blob ...`) per project per interval instead of 2 CAS writes per push.

The flush **recomputes from the database rather than accumulating deltas**, so it is idempotent: a mark lost to a process restart, or a concurrent flush from another core replica, can only delay convergence — never corrupt the stored value. Failed flushes re-mark and retry.

### Consequences

- UI, quota API and exporter metric stay current to within one flush interval (10s).
- If an administrator sets a real limit while requests are in flight, enforcement starts with the next request and the deferred refresh reconciles the usage.
- The unlimited check reads the quota row once — a read the reservation path performed anyway.

Tests: unlimited requests bypass the CAS and mark for deferred refresh; limited requests still reserve; over-limit requests are still denied before the wrapped operation runs; flusher coalescing, one-flush-per-reference, empty-set noop and failed-flush re-mark. An e2e suite exercising a concurrent shared-base-layer push burst against a live instance accompanies the stack.


> [!NOTE]
> Replaces #718, which was auto-closed when the branch of the superseded #717 (merged to main as #397) was deleted; GitHub's stack feature prevented retargeting its base. Same head branch and review context apply.
