### PR TITLE
chore: Run gofmt on dao_test.go

### DIFF
--- a/src/common/dao/dao_test.go
+++ b/src/common/dao/dao_test.go
@@ -22,7 +22,7 @@ import (
 	"testing"
 
 	"github.com/beego/beego/v2/client/orm"
-	
+
 	"github.com/goharbor/harbor/src/common/models"
 	"github.com/goharbor/harbor/src/lib/log"
 	libOrm "github.com/goharbor/harbor/src/lib/orm"


### PR DESCRIPTION
Trivial cleanup: `gofmt -w src/common/dao/dao_test.go` — removes trailing whitespace on the blank import separator line (surfaced by a `gofmt -l` sweep while preparing #733).

The same drift exists on `main`; a matching chore PR fixes it there so it does not reappear through future backports.
