### PR TITLE
chore: Update Go & Delve versions (backport #698)

### DIFF
--- a/versions.env
+++ b/versions.env
@@ -3,7 +3,9 @@
 # Tools are patch-pinned; base images are minor-pinned for automatic patch updates
 
 # Go toolchain and build tools
+# renovate: datasource=golang-version depName=golang versioning=semver extractVersion=^go(?<version>.*)$
 GO_VERSION=1.26.5
+# renovate: datasource=github-tags depName=go-swagger/go-swagger
 SWAGGER_VERSION=v0.33.1
 GOLANGCILINT_VERSION=v2.12.2
 GOVULNCHECK_VERSION=v1.4.0
@@ -11,7 +13,9 @@ GH_CLI_VERSION=2.83.1
 
 # Dev tools
 AIR_VERSION=v1.61.5
-DELVE_VERSION=v1.25.1
+# renovate: datasource=github-tags depName=go-delve/delve
+DELVE_VERSION=v1.27.1
+# renovate: datasource=docker depName=oven/bun versioning=docker
 BUN_VERSION=1.2.13
 SPECTRAL_VERSION=6.14.2
 


### PR DESCRIPTION
Backports #698 to `release-2.15`. Cherry-picked commit: ac6b7fbfb2fe

Conflict resolution: `GO_VERSION` is already `1.26.5` on release-2.15, so the effective change is `DELVE_VERSION` `v1.25.1` → `v1.27.1` plus the renovate tracking comments for golang, go-swagger, and delve.
