### PR TITLE
upstream: chore(deps): revert github.com/gorilla/csrf to v1.7.2 (goharbor/harbor#23759)

### DIFF
--- a/src/go.mod
+++ b/src/go.mod
@@ -36,7 +36,8 @@ require (
 	github.com/gomodule/redigo v2.0.0+incompatible
 	github.com/google/go-containerregistry v0.20.7
 	github.com/google/uuid v1.6.0
-	github.com/gorilla/csrf v1.7.3
+	// pin the github.com/gorilla/csrf to v1.7.2 because of issue https://github.com/goharbor/harbor/issues/22010
+	github.com/gorilla/csrf v1.7.2
 	github.com/gorilla/handlers v1.5.2
 	github.com/gorilla/mux v1.8.1
 	github.com/graph-gophers/dataloader v5.0.0+incompatible

--- a/src/go.sum
+++ b/src/go.sum
@@ -443,8 +443,8 @@ github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1/go.mod h1:wJfORR
 github.com/gopherjs/gopherjs v1.17.2 h1:fQnZVsXk8uxXIStYb0N4bGk7jeyTalG/wsZjQ25dO0g=
 github.com/gopherjs/gopherjs v1.17.2/go.mod h1:pRRIvn/QzFLrKfvEz3qUuEhtE/zLCWfreZ6J5gM2i+k=
 github.com/gorilla/context v1.1.1/go.mod h1:kBGZzfjB9CEq2AlWe17Uuf7NDRt0dE0s8S51q0aT7Yg=
-github.com/gorilla/csrf v1.7.3 h1:BHWt6FTLZAb2HtWT5KDBf6qgpZzvtbp9QWDRKZMXJC0=
-github.com/gorilla/csrf v1.7.3/go.mod h1:F1Fj3KG23WYHE6gozCmBAezKookxbIvUJT+121wTuLk=
+github.com/gorilla/csrf v1.7.2 h1:oTUjx0vyf2T+wkrx09Trsev1TE+/EbDAeHtSTbtC2eI=
+github.com/gorilla/csrf v1.7.2/go.mod h1:F1Fj3KG23WYHE6gozCmBAezKookxbIvUJT+121wTuLk=
 github.com/gorilla/handlers v1.5.2 h1:cLTUSsNkgcwhgRqvCNmdbRWG0A3N4F+M2nWKdScwyEE=
 github.com/gorilla/handlers v1.5.2/go.mod h1:dX+xVpaxdSw+q0Qek8SSsl3dfMk3jNddUkMzo0GtH0w=
 github.com/gorilla/mux v1.6.2/go.mod h1:1lud6UwP+6orDFRuTfBEV8e9/aOM/c4fVVCaMa2zaAs=

--- a/src/server/middleware/csrf/csrf_test.go
+++ b/src/server/middleware/csrf/csrf_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/goharbor/harbor/src/common"
+
 	"github.com/goharbor/harbor/src/common/utils/test"
 	"github.com/goharbor/harbor/src/lib/config"
 	_ "github.com/goharbor/harbor/src/pkg/config/inmemory"


### PR DESCRIPTION
Pin github.com/gorilla/csrf back to v1.7.2 because of
https://github.com/goharbor/harbor/issues/22010.

With v1.7.2 the library only performs its referer check when the request
URL scheme is https, which never happens for server-side requests, so
plaintext HTTP works out of the box. The CSRF_PLAINTEXT_HTTP escape
hatch from #401 (needed only for the v1.7.3 origin checking via
csrf.PlaintextHTTPRequest) is therefore removed along with its dev-env
plumbing and tests; the middleware body matches upstream again.

Backport of #657 to release-2.15; the CSRF_PLAINTEXT_HTTP removal in
taskfile/dev.yml is a no-op here since release-2.15 never had it.

Signed-off-by: stonezdj <stone.zhang@broadcom.com>

(cherry picked from commit dee0e1f27925e42a9e0022a26e4b804e5dc9d84c)

Upstream-Commit: dee0e1f27925e42a9e0022a26e4b804e5dc9d84c
Upstream-PR: goharbor/harbor#23759
Upstream-Author: @stonezdj
Cherry-Pick-Status: resolved
Signed-off-by: Prasanth Baskar <prasanth@8gears.com>
