### PR TITLE
ci: Run workflows on GitHub-hosted ubuntu-26.04 runners (backport #724)

### DIFF
--- a/.github/workflows/backport-suggestion.yml
+++ b/.github/workflows/backport-suggestion.yml
@@ -16,7 +16,7 @@ jobs:
         github.event.pull_request.merged == true &&
         github.event.pull_request.base.ref == 'main'
       }}
-    runs-on: ${{ vars.RUNNER || 'ubuntu-latest' }}
+    runs-on: ubuntu-26.04
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       GH_REPO: ${{ github.repository }}

--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -17,7 +17,7 @@ jobs:
         startsWith(github.event.comment.body, '/backport ') &&
         contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association)
       }}
-    runs-on: ${{ vars.RUNNER || 'ubuntu-latest' }}
+    runs-on: ubuntu-26.04
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       GH_REPO: ${{ github.repository }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,7 +24,7 @@ concurrency:
 jobs:
   build:
     name: Build Binaries
-    runs-on: ${{ (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository || contains(fromJSON('["OWNER","MEMBER"]'), github.event.pull_request.author_association)) && vars.RUNNER || 'ubuntu-latest' }}
+    runs-on: ubuntu-26.04
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 

--- a/.github/workflows/cache-cleanup.yml
+++ b/.github/workflows/cache-cleanup.yml
@@ -10,48 +10,6 @@ permissions:
   actions: write
 
 jobs:
-  cleanup-host:
-    name: Trim host caches
-    runs-on: ${{ vars.RUNNER || 'ubuntu-latest' }}
-    steps:
-      - name: Trim Go build cache (files not modified in 7 days)
-        run: |
-          if [ -z "$GOCACHE" ] || [ ! -d "$GOCACHE" ]; then
-            echo "No GOCACHE directory found at '${GOCACHE:-<unset>}'"
-            exit 0
-          fi
-          # Canonicalize to defeat traversal tricks like /home/../../etc
-          GOCACHE="$(realpath -m "$GOCACHE")"
-          case "$GOCACHE" in /home/*|/opt/ci-cache/*) ;; *)
-            echo "ERROR: GOCACHE='$GOCACHE' not under /home or /opt/ci-cache, skipping"; exit 0 ;; esac
-          echo "Build cache before: $(du -sh "$GOCACHE" | cut -f1)"
-          find "$GOCACHE" -type f -mtime +7 -delete 2>/dev/null || true
-          find "$GOCACHE" -type d -empty -delete 2>/dev/null || true
-          echo "Build cache after: $(du -sh "$GOCACHE" | cut -f1)"
-
-      - name: Check module cache size
-        run: |
-          if [ -z "$GOMODCACHE" ] || [ ! -d "$GOMODCACHE" ]; then
-            echo "No GOMODCACHE directory found at '${GOMODCACHE:-<unset>}'"
-            exit 0
-          fi
-          # Canonicalize to defeat traversal tricks like /home/../../etc
-          GOMODCACHE="$(realpath -m "$GOMODCACHE")"
-          case "$GOMODCACHE" in /home/*|/opt/ci-cache/*) ;; *)
-            echo "ERROR: GOMODCACHE='$GOMODCACHE' not under /home or /opt/ci-cache, skipping"; exit 0 ;; esac
-          size_mb=$(du -sm "$GOMODCACHE" | cut -f1)
-          echo "Module cache: ${size_mb}MB"
-          if [ "$size_mb" -gt 2048 ]; then
-            echo "Exceeds 2GB threshold, clearing..."
-            chmod -R u+w "$GOMODCACHE" && rm -rf "${GOMODCACHE:?}"/* 2>/dev/null || true
-          fi
-
-      - name: Report tool cache size
-        run: |
-          if [ -d "/opt/hostedtoolcache" ]; then
-            echo "Tool cache: $(du -sh /opt/hostedtoolcache | cut -f1)"
-          fi
-
   cleanup-github-cache:
     name: Purge stale GitHub Actions caches
     runs-on: ubuntu-latest

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -10,7 +10,7 @@ permissions:
 
 jobs:
   dependency-review:
-    runs-on: ${{ (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository || contains(fromJSON('["OWNER","MEMBER"]'), github.event.pull_request.author_association)) && vars.RUNNER || 'ubuntu-latest' }}
+    runs-on: ubuntu-26.04
     # Requires Dependency Graph to be enabled in repo settings
     if: github.event.repository.private == false || always()
     continue-on-error: true

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -10,7 +10,7 @@ permissions:
 
 jobs:
   labeler:
-    runs-on: ${{ vars.RUNNER || 'ubuntu-latest' }}
+    runs-on: ubuntu-26.04
     steps:
       - uses: actions/labeler@f27b608878404679385c85cfa523b85ccb86e213 # v6.1.0
         with:

--- a/.github/workflows/lint-actions.yml
+++ b/.github/workflows/lint-actions.yml
@@ -15,7 +15,7 @@ permissions:
 jobs:
   pinned-actions:
     name: Check Pinned Action SHAs
-    runs-on: ${{ (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository || contains(fromJSON('["OWNER","MEMBER"]'), github.event.pull_request.author_association)) && vars.RUNNER || 'ubuntu-latest' }}
+    runs-on: ubuntu-26.04
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 

--- a/.github/workflows/lint-go.yml
+++ b/.github/workflows/lint-go.yml
@@ -31,7 +31,7 @@ env:
 jobs:
   lint:
     name: Go Lint
-    runs-on: ${{ (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository || contains(fromJSON('["OWNER","MEMBER"]'), github.event.pull_request.author_association)) && vars.RUNNER || 'ubuntu-latest' }}
+    runs-on: ubuntu-26.04
     env:
       GOLANGCI_LINT_CACHE: ${{ github.workspace }}/.ci-cache/golangci-lint
       XDG_CACHE_HOME: ${{ github.workspace }}/.ci-cache/xdg

--- a/.github/workflows/lint-ui.yml
+++ b/.github/workflows/lint-ui.yml
@@ -32,7 +32,7 @@ env:
 jobs:
   lint:
     name: UI Lint
-    runs-on: ${{ (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository || contains(fromJSON('["OWNER","MEMBER"]'), github.event.pull_request.author_association)) && vars.RUNNER || 'ubuntu-latest' }}
+    runs-on: ubuntu-26.04
     env:
       CYPRESS_CACHE_FOLDER: ${{ github.workspace }}/.ci-cache/cypress
       CYPRESS_INSTALL_BINARY: "0"

--- a/.github/workflows/notify-fork-sync.yml
+++ b/.github/workflows/notify-fork-sync.yml
@@ -8,7 +8,7 @@ permissions: {}
 
 jobs:
   dispatch:
-    runs-on: ${{ vars.RUNNER || 'ubuntu-latest' }}
+    runs-on: ubuntu-26.04
     steps:
       - name: Generate GitHub App token
         id: app-token

--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -49,7 +49,7 @@ jobs:
         platform:
           - linux/amd64
           - linux/arm64
-    runs-on: ${{ vars.RUNNER || 'ubuntu-latest' }}
+    runs-on: ubuntu-26.04
     permissions:
       contents: read
     steps:
@@ -161,7 +161,7 @@ jobs:
       fail-fast: false
       matrix:
         component: [core, jobservice, registryctl, exporter, portal, registry, trivy-adapter]
-    runs-on: ${{ vars.RUNNER || 'ubuntu-latest' }}
+    runs-on: ubuntu-26.04
     permissions:
       contents: read
     steps:
@@ -210,7 +210,7 @@ jobs:
     name: Sign preview images
     if: ${{ github.event.pull_request.head.repo.full_name == github.repository && github.actor != 'dependabot[bot]' }}
     needs: [merge]
-    runs-on: ${{ vars.RUNNER || 'ubuntu-latest' }}
+    runs-on: ubuntu-26.04
     permissions:
       contents: read
       id-token: write
@@ -265,7 +265,7 @@ jobs:
     name: Comment preview image refs
     if: ${{ github.event.pull_request.head.repo.full_name == github.repository && github.actor != 'dependabot[bot]' }}
     needs: [sign]
-    runs-on: ${{ vars.RUNNER || 'ubuntu-latest' }}
+    runs-on: ubuntu-26.04
     permissions:
       issues: write
       pull-requests: write

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -9,7 +9,7 @@ permissions:
 
 jobs:
   lint:
-    runs-on: ${{ vars.RUNNER || 'ubuntu-latest' }}
+    runs-on: ubuntu-26.04
     steps:
       - uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50 # v6.1.1
         env:

--- a/.github/workflows/publish-images.yml
+++ b/.github/workflows/publish-images.yml
@@ -43,7 +43,7 @@ jobs:
         platform:
           - linux/amd64
           - linux/arm64
-    runs-on: ${{ vars.RUNNER || 'ubuntu-latest' }}
+    runs-on: ubuntu-26.04
     permissions:
       contents: read
     env:
@@ -202,7 +202,7 @@ jobs:
     strategy:
       matrix:
         component: [core, jobservice, registryctl, exporter, portal, registry, trivy-adapter]
-    runs-on: ${{ vars.RUNNER || 'ubuntu-latest' }}
+    runs-on: ubuntu-26.04
     permissions:
       contents: read
     env:
@@ -254,7 +254,7 @@ jobs:
   sign:
     name: Sign images
     needs: [merge]
-    runs-on: ${{ vars.RUNNER || 'ubuntu-latest' }}
+    runs-on: ubuntu-26.04
     permissions:
       contents: read
       id-token: write

--- a/.github/workflows/release-notes-engine.yml
+++ b/.github/workflows/release-notes-engine.yml
@@ -31,7 +31,7 @@ concurrency:
 jobs:
   update:
     name: Recreate ${{ inputs.tag_name || 'Release Preview' }} Notes
-    runs-on: ${{ vars.RUNNER || 'ubuntu-latest' }}
+    runs-on: ubuntu-26.04
     timeout-minutes: 15
     env:
       GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -23,7 +23,7 @@ env:
 jobs:
   validate-release-ref:
     name: Validate Release Ref
-    runs-on: ${{ vars.RUNNER || 'ubuntu-latest' }}
+    runs-on: ubuntu-26.04
     steps:
       - name: Allow only release refs
         run: |
@@ -37,7 +37,7 @@ jobs:
   release-please:
     needs: [validate-release-ref]
     if: ${{ github.event_name != 'workflow_dispatch' || inputs.finalize_tag == '' }}
-    runs-on: ${{ vars.RUNNER || 'ubuntu-latest' }}
+    runs-on: ubuntu-26.04
     outputs:
       release_created: ${{ steps.release.outputs.release_created }}
       tag_name: ${{ steps.release.outputs.tag_name }}
@@ -79,7 +79,7 @@ jobs:
         needs.release-please.outputs.release_created == 'true' &&
         needs.release-please.outputs.patch == '0'
       }}
-    runs-on: ${{ vars.RUNNER || 'ubuntu-latest' }}
+    runs-on: ubuntu-26.04
     permissions:
       contents: write
     env:
@@ -114,7 +114,7 @@ jobs:
         platform:
           - linux/amd64
           - linux/arm64
-    runs-on: ${{ vars.RUNNER || 'ubuntu-latest' }}
+    runs-on: ubuntu-26.04
     permissions:
       contents: read
     env:
@@ -276,7 +276,7 @@ jobs:
     strategy:
       matrix:
         component: [core, jobservice, registryctl, exporter, portal, registry, trivy-adapter]
-    runs-on: ${{ vars.RUNNER || 'ubuntu-latest' }}
+    runs-on: ubuntu-26.04
     permissions:
       contents: read
     env:
@@ -339,7 +339,7 @@ jobs:
           inputs.finalize_tag != ''
         )
       }}
-    runs-on: ${{ vars.RUNNER || 'ubuntu-latest' }}
+    runs-on: ubuntu-26.04
     permissions:
       contents: write
       id-token: write

--- a/.github/workflows/release-ready.yml
+++ b/.github/workflows/release-ready.yml
@@ -15,7 +15,7 @@ concurrency:
 jobs:
   release-ready:
     name: Validate Release Patches
-    runs-on: ${{ vars.RUNNER || 'ubuntu-latest' }}
+    runs-on: ubuntu-26.04
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:

--- a/.github/workflows/spellcheck.yml
+++ b/.github/workflows/spellcheck.yml
@@ -20,7 +20,7 @@ permissions:
 
 jobs:
   typos:
-    runs-on: ${{ (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository || contains(fromJSON('["OWNER","MEMBER"]'), github.event.pull_request.author_association)) && vars.RUNNER || 'ubuntu-latest' }}
+    runs-on: ubuntu-26.04
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,7 +27,7 @@ jobs:
   # --------------------------------------------------------------------------
   test-unit:
     name: Unit Tests (pure)
-    runs-on: ${{ (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository || contains(fromJSON('["OWNER","MEMBER"]'), github.event.pull_request.author_association)) && vars.RUNNER || 'ubuntu-latest' }}
+    runs-on: ubuntu-26.04
     env:
       CGO_ENABLED: "1"
       RACE_FLAGS: -race
@@ -58,7 +58,7 @@ jobs:
   # --------------------------------------------------------------------------
   test-db:
     name: Unit Tests (DB ${{ matrix.shard_name }})
-    runs-on: ${{ (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository || contains(fromJSON('["OWNER","MEMBER"]'), github.event.pull_request.author_association)) && vars.RUNNER || 'ubuntu-latest' }}
+    runs-on: ubuntu-26.04
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/vulnerability-check.yml
+++ b/.github/workflows/vulnerability-check.yml
@@ -18,7 +18,7 @@ env:
 jobs:
   govulncheck:
     name: govulncheck
-    runs-on: ${{ (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository || contains(fromJSON('["OWNER","MEMBER"]'), github.event.pull_request.author_association)) && vars.RUNNER || 'ubuntu-latest' }}
+    runs-on: ubuntu-26.04
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:

--- a/.github/workflows/welcome.yml
+++ b/.github/workflows/welcome.yml
@@ -12,7 +12,7 @@ permissions:
 
 jobs:
   welcome:
-    runs-on: ${{ vars.RUNNER || 'ubuntu-latest' }}
+    runs-on: ubuntu-26.04
     steps:
       - uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:

--- a/.github/workflows/zero-cve.yml
+++ b/.github/workflows/zero-cve.yml
@@ -43,7 +43,7 @@ env:
 jobs:
   scan-remediate:
     name: Scan, Remediate, and Report
-    runs-on: ${{ vars.RUNNER || 'ubuntu-latest' }}
+    runs-on: ubuntu-26.04
     env:
       GH_TOKEN: ${{ github.token }}
       TRIVY_PASSWORD: ${{ secrets.REGISTRY_PASSWORD || secrets.HARBOR_PASSWORD }}

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -219,7 +219,6 @@ Upstream-Author: @original-author
 
 | Name | Type | Required | Purpose |
 |------|------|----------|---------|
-| `RUNNER` | Variable | No | Custom runner label |
 | `REGISTRY_ADDRESS` | Variable | No | Registry host, defaults to `8gears.container-registry.com` |
 | `REGISTRY_PROJECT` | Variable | No | Registry project, defaults to `8gcr` |
 | `REGISTRY_USERNAME` | Variable | Yes | Registry push username |


### PR DESCRIPTION
Backports #724 to `release-2.15`. Source commit: 4eb618cc73

Applied as a mechanical re-application rather than a raw cherry-pick (10 of the workflow files had context conflicts from unrelated main-only drift):

- all 32 `runs-on: ${{ vars.RUNNER || ... }}` entries → `runs-on: ubuntu-26.04` (plain `ubuntu-latest` jobs left alone, matching main)
- `cache-cleanup.yml`: self-hosted `cleanup-host` job removed
- `RELEASE.md`: `RUNNER` variable row removed
- the `src/migration/authoritative.go` license hunk is omitted — that file does not exist on release-2.15 yet and arrives with the correct header via #733 
