### PR TITLE
feat: Replace ValidateHTTPURL with schema-aware ValidateURL

### DIFF
--- a/src/controller/registry/controller.go
+++ b/src/controller/registry/controller.go
@@ -92,7 +92,7 @@ func (c *controller) validate(ctx context.Context, registry *model.Registry) err
 	if len(registry.Name) > 64 {
 		return errors.New(nil).WithCode(errors.BadRequestCode).WithMessage("the max length of name is 64")
 	}
-	url, err := lib.ValidateHTTPURL(registry.URL)
+	url, err := lib.ValidateURL(registry.URL)
 	if err != nil {
 		return err
 	}

--- a/src/controller/registry/controller_test.go
+++ b/src/controller/registry/controller_test.go
@@ -68,13 +68,15 @@ func (r *registryTestSuite) TestValidate() {
 	err = r.ctl.validate(nil, registry)
 	r.NotNil(err)
 
-	// invalid HTTP URL
+	// URL with FTP scheme
 	registry = &model.Registry{
 		Name: "endpoint01",
 		URL:  "ftp://example.com",
 	}
+	mock.OnAnything(r.regMgr, "CreateAdapter").Return(r.adapter, nil)
+	mock.OnAnything(r.adapter, "HealthCheck").Return(model.Healthy, nil)
 	err = r.ctl.validate(nil, registry)
-	r.NotNil(err)
+	r.Nil(err)
 
 	// URL without scheme
 	registry = &model.Registry{

--- a/src/lib/endpoint.go
+++ b/src/lib/endpoint.go
@@ -17,14 +17,18 @@ package lib
 import (
 	"fmt"
 	"net/url"
+	"slices"
 	"strings"
 
 	"github.com/goharbor/harbor/src/lib/errors"
 )
 
-// ValidateHTTPURL checks whether the provided string is a valid HTTP URL.
-// If it is, return the URL in format "scheme://host:port" to avoid the SSRF
-func ValidateHTTPURL(s string) (string, error) {
+// ValidateURL checks whether the provided string is a valid URL whose scheme
+// is in allowedSchemes (default: http, https, s3, sftp, ftp — pass schemes
+// explicitly to restrict, e.g. ValidateURL(s, "http", "https")). A scheme-less
+// input is treated as http. On success the URL is returned normalized to
+// "scheme://host:port" to avoid the SSRF
+func ValidateURL(s string, allowedSchemes ...string) (string, error) {
 	s = strings.Trim(s, " ")
 	s = strings.TrimRight(s, "/")
 	if len(s) == 0 {
@@ -33,13 +37,16 @@ func ValidateHTTPURL(s string) (string, error) {
 	if !strings.Contains(s, "://") {
 		s = "http://" + s
 	}
-	url, err := url.Parse(s)
+	parsedURL, err := url.Parse(s)
 	if err != nil {
 		return "", errors.New(nil).WithCode(errors.BadRequestCode).WithMessagef("invalid URL: %s", err.Error())
 	}
-	if url.Scheme != "http" && url.Scheme != "https" {
-		return "", errors.New(nil).WithCode(errors.BadRequestCode).WithMessagef("invalid HTTP scheme: %s", url.Scheme)
+	if len(allowedSchemes) == 0 {
+		allowedSchemes = []string{"http", "https", "s3", "sftp", "ftp"}
+	}
+	if !slices.Contains(allowedSchemes, parsedURL.Scheme) {
+		return "", errors.New(nil).WithCode(errors.BadRequestCode).WithMessagef("invalid scheme: %s", parsedURL.Scheme)
 	}
 	// To avoid SSRF security issue, refer to #3755 for more detail
-	return fmt.Sprintf("%s://%s%s", url.Scheme, url.Host, url.Path), nil
+	return fmt.Sprintf("%s://%s%s", parsedURL.Scheme, parsedURL.Host, parsedURL.Path), nil
 }

--- a/src/lib/endpoint_test.go
+++ b/src/lib/endpoint_test.go
@@ -44,19 +44,45 @@ var testcases = []struct {
 	{"http://10.0.0.1/test.txt#/api/version", "http://10.0.0.1/test.txt", true},
 }
 
-func TestValidateHTTPURL(t *testing.T) {
+func TestValidateURL(t *testing.T) {
 	for _, test := range testcases {
-		url, err := ValidateHTTPURL(test.url)
+		url, err := ValidateURL(test.url)
 		if test.valid {
 			if err != nil {
-				t.Errorf("ValidateHTTPURL:%q gave err %v; want no error", test.url, err)
+				t.Errorf("ValidateURL:%q gave err %v; want no error", test.url, err)
 			}
 			if url != test.expectedUrl {
-				t.Errorf("ValidateHTTPURL:%q gave %s; want %s", test.url, url, test.expectedUrl)
+				t.Errorf("ValidateURL:%q gave %s; want %s", test.url, url, test.expectedUrl)
 			}
 		} else if !test.valid && err == nil {
-			t.Errorf("ValidateHTTPURL:%q gave <nil> error; want some error", test.url)
+			t.Errorf("ValidateURL:%q gave <nil> error; want some error", test.url)
 		}
 	}
+}
 
+func TestValidateURLSchemes(t *testing.T) {
+	schemeCases := []struct {
+		url     string
+		schemes []string
+		valid   bool
+	}{
+		{"sftp://harbor.foo.com", nil, true},
+		{"s3://bucket/prefix", nil, true},
+		{"ftp://harbor.foo.com", nil, true},
+		{"gopher://harbor.foo.com", nil, false},
+		{"file:///etc/passwd", nil, false},
+		{"sftp://harbor.foo.com", []string{"http", "https"}, false},
+		{"s3://bucket/prefix", []string{"http", "https"}, false},
+		{"http://harbor.foo.com", []string{"http", "https"}, true},
+		{"harbor.foo.com", []string{"http", "https"}, true},
+	}
+	for _, test := range schemeCases {
+		_, err := ValidateURL(test.url, test.schemes...)
+		if test.valid && err != nil {
+			t.Errorf("ValidateURL:%q schemes %v gave err %v; want no error", test.url, test.schemes, err)
+		}
+		if !test.valid && err == nil {
+			t.Errorf("ValidateURL:%q schemes %v gave <nil> error; want some error", test.url, test.schemes)
+		}
+	}
 }

--- a/src/pkg/p2p/preheat/provider/dragonfly.go
+++ b/src/pkg/p2p/preheat/provider/dragonfly.go
@@ -199,7 +199,7 @@ func (dd *DragonflyDriver) GetHealth() (*DriverStatus, error) {
 	}
 
 	url := fmt.Sprintf("%s%s", strings.TrimSuffix(dd.instance.Endpoint, "/"), dragonflyHealthPath)
-	url, err := lib.ValidateHTTPURL(url)
+	url, err := lib.ValidateURL(url, "http", "https")
 	if err != nil {
 		return nil, err
 	}

--- a/src/pkg/p2p/preheat/provider/kraken.go
+++ b/src/pkg/p2p/preheat/provider/kraken.go
@@ -60,7 +60,7 @@ func (kd *KrakenDriver) GetHealth() (*DriverStatus, error) {
 	}
 
 	url := fmt.Sprintf("%s%s", strings.TrimSuffix(kd.instance.Endpoint, "/"), krakenHealthPath)
-	url, err := lib.ValidateHTTPURL(url)
+	url, err := lib.ValidateURL(url, "http", "https")
 	if err != nil {
 		return nil, err
 	}

--- a/src/pkg/scan/dao/scanner/model.go
+++ b/src/pkg/scan/dao/scanner/model.go
@@ -106,7 +106,7 @@ func (r *Registration) Validate(checkUUID bool) error {
 		return errors.New("missing registration name")
 	}
 
-	url, err := lib.ValidateHTTPURL(r.URL)
+	url, err := lib.ValidateURL(r.URL, "http", "https")
 	if err != nil {
 		return errors.Wrap(err, "scanner registration validate")
 	}

--- a/src/server/v2.0/handler/registry.go
+++ b/src/server/v2.0/handler/registry.go
@@ -174,7 +174,7 @@ func (r *registryAPI) UpdateRegistry(ctx context.Context, params operation.Updat
 			registry.Credential.AccessSecret = *params.Registry.AccessSecret
 		}
 		if registry.URL != storedURL && params.Registry.AccessSecret == nil {
-			normalizedURL, err := lib.ValidateHTTPURL(registry.URL)
+			normalizedURL, err := lib.ValidateURL(registry.URL)
 			if err != nil {
 				return r.SendError(ctx, err)
 			}
@@ -256,7 +256,7 @@ func (r *registryAPI) PingRegistry(ctx context.Context, params operation.PingReg
 		// authoritative; ignore url/insecure/ca overrides so the ping (and the saved
 		// credentials it sends) can't be redirected to or MITM'd via an untrusted endpoint
 		if params.Registry.URL != nil && params.Registry.ID == nil {
-			url, err := lib.ValidateHTTPURL(*params.Registry.URL)
+			url, err := lib.ValidateURL(*params.Registry.URL)
 			if err != nil {
 				return r.SendError(ctx, err)
 			}

--- a/src/server/v2.0/handler/registry_test.go
+++ b/src/server/v2.0/handler/registry_test.go
@@ -102,6 +102,21 @@ func (suite *RegistryTestSuite) TestPingRegistryInlineUsesSuppliedURL() {
 	suite.Equal("https://inline.example.com", pinged.URL)
 }
 
+// TestPingRegistryInlineInvalidSchemeRejected guards the inline ping path against
+// URLs outside the scheme allowlist reaching the health check.
+func (suite *RegistryTestSuite) TestPingRegistryInlineInvalidSchemeRejected() {
+	suite.Security.On("IsAuthenticated").Return(true).Once()
+	suite.Security.On("Can", mock.Anything, mock.Anything, mock.Anything).Return(true).Once()
+
+	res, err := suite.PostJSON("/registries/ping", &models.RegistryPing{
+		Type: suite.ptrStr("harbor"),
+		URL:  suite.ptrStr("gopher://attacker.example.com"),
+	})
+	suite.NoError(err)
+	suite.Equal(400, res.StatusCode)
+	suite.regCtl.AssertNotCalled(suite.T(), "IsHealthy", testifymock.Anything, testifymock.Anything)
+}
+
 // TestUpdateRegistryID0ReturnsNotFound guards against updating synthetic local registry ID 0,
 // asserting the NotFound response and that controller's Get and Update methods are not called.
 func (suite *RegistryTestSuite) TestUpdateRegistryID0ReturnsNotFound() {
@@ -149,23 +164,65 @@ func (suite *RegistryTestSuite) TestUpdateRegistryClearsAccessSecretOnURLChange(
 // TestUpdateRegistryInvalidURLReturnsError tests that updating a registry with an invalid
 // URL returns BadRequest error and does not update the registry.
 func (suite *RegistryTestSuite) TestUpdateRegistryInvalidURLReturnsError() {
-	suite.Security.On("IsAuthenticated").Return(true).Once()
-	suite.Security.On("Can", mock.Anything, mock.Anything, mock.Anything).Return(true).Once()
+	for _, invalidURL := range []string{
+		"gopher://invalid.example.com",
+		"file:///etc/passwd",
+		"http://127.0.0.%31/",
+	} {
+		suite.SetupTest()
+		suite.Security.On("IsAuthenticated").Return(true).Once()
+		suite.Security.On("Can", mock.Anything, mock.Anything, mock.Anything).Return(true).Once()
 
-	saved := &model.Registry{
-		ID:         1,
-		Type:       "harbor",
-		URL:        "https://registry.example.com",
-		Credential: &model.Credential{Type: "basic", AccessKey: "admin", AccessSecret: "secret123"},
+		saved := &model.Registry{
+			ID:         1,
+			Type:       "harbor",
+			URL:        "https://registry.example.com",
+			Credential: &model.Credential{Type: "basic", AccessKey: "admin", AccessSecret: "secret123"},
+		}
+		mock.OnAnything(suite.regCtl, "Get").Return(saved, nil).Once()
+
+		res, err := suite.PutJSON("/registries/1", &models.RegistryUpdate{
+			URL: suite.ptrStr(invalidURL),
+		})
+		suite.NoError(err)
+		suite.Equal(400, res.StatusCode, "URL %q must be rejected", invalidURL)
+		suite.regCtl.AssertNotCalled(suite.T(), "Update", testifymock.Anything, testifymock.Anything)
 	}
-	mock.OnAnything(suite.regCtl, "Get").Return(saved, nil).Once()
+}
 
-	res, err := suite.PutJSON("/registries/1", &models.RegistryUpdate{
-		URL: suite.ptrStr("ftp://invalid.example.com"),
-	})
-	suite.NoError(err)
-	suite.Equal(400, res.StatusCode)
-	suite.regCtl.AssertNotCalled(suite.T(), "Update", testifymock.Anything, testifymock.Anything)
+// TestUpdateRegistryStorageSchemeURLAccepted documents that schema-aware validation
+// accepts storage-backed registry URLs (sftp/s3) on update, and that changing to one
+// still clears the stored AccessSecret like any other URL change.
+func (suite *RegistryTestSuite) TestUpdateRegistryStorageSchemeURLAccepted() {
+	for _, newURL := range []string{
+		"sftp://storage.example.com",
+		"s3://bucket.example.com",
+	} {
+		suite.SetupTest()
+		suite.Security.On("IsAuthenticated").Return(true).Once()
+		suite.Security.On("Can", mock.Anything, mock.Anything, mock.Anything).Return(true).Once()
+
+		saved := &model.Registry{
+			ID:         1,
+			Type:       "harbor",
+			URL:        "https://registry.example.com",
+			Credential: &model.Credential{Type: "basic", AccessKey: "admin", AccessSecret: "secret123"},
+		}
+		mock.OnAnything(suite.regCtl, "Get").Return(saved, nil).Once()
+
+		var updated *model.Registry
+		suite.regCtl.On("Update", mock.Anything, mock.Anything).Return(nil).Once().
+			Run(func(args testifymock.Arguments) { updated = args.Get(1).(*model.Registry) })
+
+		res, err := suite.PutJSON("/registries/1", &models.RegistryUpdate{
+			URL: suite.ptrStr(newURL),
+		})
+		suite.NoError(err)
+		suite.Equal(200, res.StatusCode, "URL %q must be accepted", newURL)
+		suite.Require().NotNil(updated)
+		suite.Equal(newURL, updated.URL)
+		suite.Empty(updated.Credential.AccessSecret)
+	}
 }
 
 func TestRegistryTestSuite(t *testing.T) {


### PR DESCRIPTION
Promotes `ValidateURL(s, allowedSchemes...)` from the `0003-sftp-replication` commercial patch into harbor-next proper, replacing `ValidateHTTPURL` everywhere.

## Why

The sftp-replication patch needs registry endpoints to accept `sftp://`/`s3://` URLs, so it carried its own `ValidateURL` in `src/lib/endpoint.go` plus call-site swaps in `handler/registry.go`, `controller/registry/controller.go`, the p2p providers, and the scanner model. Moving the validator into the tree shrinks the patch to pure SFTP feature code and removes URL-validation ownership from the patch series entirely.

## Behavior

- `ValidateURL(s)` — default allowlist `http, https, s3, sftp, ftp`
- `ValidateURL(s, "http", "https")` — explicit restriction, exact `ValidateHTTPURL` semantics
- Trim/`http://`-prepend/normalized `scheme://host[path]` output identical to `ValidateHTTPURL` — **every previously accepted URL validates identically** (backwards compatible for valid inputs)

Call-site decisions (deliberately not a blanket default swap):

| Site | Schemes | Rationale |
|---|---|---|
| `controller/registry` validate | default | replication targets may be storage-backed (s3/sftp) |
| `handler/registry.go` ping + proxy-filter normalize | default | same |
| p2p preheat providers (dragonfly, kraken) | `http, https` | HTTP APIs, no reason to widen |
| scanner adapter URL (`scan/dao/scanner`) | `http, https` | HTTP APIs, no reason to widen |

Note: the patch's own swaps used the bare default at ALL sites — this PR is stricter than the patch it replaces at the p2p/scanner sites.

Registry endpoints accepting `ftp://` matches the patch's explicit test expectation (`TestValidate` mocks a successful adapter health-check for `ftp://example.com`); on OSS builds unknown adapter types are still rejected by the type/allowlist checks downstream.

## Testing

- `TestValidateURL` (ported) + new `TestValidateURLSchemes` (default vs restricted allowlists, `gopher://`/`file://` rejected)
- registry controller `TestValidate` updated to the patch's expectation (ftp reaches adapter health-check)
- build + golangci-lint + `go test` green on all touched packages

## Follow-up

After this merges, `0003-sftp-replication` (main + release-2.15 sets) drops its `endpoint.go`, `endpoint_test.go`, and all `ValidateHTTPURL` swap hunks. A release-2.15 backport of this commit will be needed so the r215 patch can shrink the same way.

## Release Notes

Registry endpoint URL validation is now scheme-aware: replication targets accept `http`, `https`, `s3`, `sftp`, and `ftp` URLs, while p2p preheat providers and scanner adapters remain restricted to `http`/`https`. All previously valid URLs continue to validate unchanged.
