### PR TITLE
fix: Harden migrator DSN parsing and bound authoritative schema locking

### DIFF
--- a/src/common/dao/migrator_dsn_test.go
+++ b/src/common/dao/migrator_dsn_test.go
@@ -29,12 +29,8 @@ func TestMigratorDSNFromFields(t *testing.T) {
 		Database: "registry",
 		SSLMode:  "disable",
 	}
-	got, err := migratorDSN(cfg)
-	if err != nil {
-		t.Fatalf("migratorDSN() error = %v", err)
-	}
 	want := "pgx5://postgres:root123@db.internal:5432/registry?sslmode=disable"
-	if got != want {
+	if got := migratorDSN(cfg); got != want {
 		t.Errorf("migratorDSN() = %q, want %q", got, want)
 	}
 }
@@ -42,19 +38,36 @@ func TestMigratorDSNFromFields(t *testing.T) {
 func TestMigratorDSNHonorsURL(t *testing.T) {
 	// e.g. an RDS IAM auth token embedded as the password, per 0006-aws-rds-iam-auth
 	cfg := &models.PostGreSQL{URL: "postgres://iam-user:rds-token@rds.example.com:5432/registry?sslmode=require"}
-	got, err := migratorDSN(cfg)
-	if err != nil {
-		t.Fatalf("migratorDSN() error = %v", err)
-	}
 	want := "pgx5://iam-user:rds-token@rds.example.com:5432/registry?sslmode=require"
-	if got != want {
+	if got := migratorDSN(cfg); got != want {
 		t.Errorf("migratorDSN() = %q, want %q — URL field must take precedence over individual fields", got, want)
 	}
 }
 
-func TestMigratorDSNInvalidURL(t *testing.T) {
-	cfg := &models.PostGreSQL{URL: "://not a url"}
-	if _, err := migratorDSN(cfg); err == nil {
-		t.Error("migratorDSN() with an invalid URL returned nil error")
+func TestMigratorDSNFallsBackToFields(t *testing.T) {
+	tests := []struct {
+		name string
+		url  string
+	}{
+		{"libpq key-value DSN", "host=db.internal port=5432 user=postgres password=root123 dbname=registry sslmode=disable"},
+		{"empty-scheme URL", "//db.internal:5432/registry?sslmode=disable"},
+		{"unparsable URL", "://not a url"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := &models.PostGreSQL{
+				URL:      tt.url,
+				Host:     "db.internal",
+				Port:     5432,
+				Username: "postgres",
+				Password: "root123",
+				Database: "registry",
+				SSLMode:  "disable",
+			}
+			want := "pgx5://postgres:root123@db.internal:5432/registry?sslmode=disable"
+			if got := migratorDSN(cfg); got != want {
+				t.Errorf("migratorDSN() = %q, want %q — non-URL DSNs must fall back to the individual fields", got, want)
+			}
+		})
 	}
 }

--- a/src/common/dao/pgsql.go
+++ b/src/common/dao/pgsql.go
@@ -109,10 +109,7 @@ func (p *pgsql) UpgradeSchema() error {
 // golang-migrate's pgx/v5 driver registers under that name (not "pgx", which
 // is the v4 driver).
 func NewMigrator(database *models.PostGreSQL) (*migrate.Migrate, error) {
-	dsn, err := migratorDSN(database)
-	if err != nil {
-		return nil, err
-	}
+	dsn := migratorDSN(database)
 
 	// For UT
 	path := os.Getenv("POSTGRES_MIGRATION_SCRIPTS_PATH")
@@ -133,21 +130,20 @@ func NewMigrator(database *models.PostGreSQL) (*migrate.Migrate, error) {
 // cloud-managed databases like RDS IAM auth, where the DSN carries a token
 // that Host/Username/Password alone can't reconstruct) so the numbered and
 // authoritative migration phases always target the same database.
-func migratorDSN(database *models.PostGreSQL) (string, error) {
-	if database.URL == "" {
-		dbURL := url.URL{
-			Scheme:   "pgx5",
-			User:     url.UserPassword(database.Username, database.Password),
-			Host:     net.JoinHostPort(database.Host, strconv.Itoa(database.Port)),
-			Path:     database.Database,
-			RawQuery: fmt.Sprintf("sslmode=%s", database.SSLMode),
+func migratorDSN(database *models.PostGreSQL) string {
+	if database.URL != "" {
+		// libpq key-value DSNs parse without error but with an empty scheme — fall back to fields.
+		if u, err := url.Parse(database.URL); err == nil && u.Scheme != "" {
+			u.Scheme = "pgx5"
+			return u.String()
 		}
-		return dbURL.String(), nil
 	}
-	u, err := url.Parse(database.URL)
-	if err != nil {
-		return "", fmt.Errorf("parse database URL: %w", err)
+	dbURL := url.URL{
+		Scheme:   "pgx5",
+		User:     url.UserPassword(database.Username, database.Password),
+		Host:     net.JoinHostPort(database.Host, strconv.Itoa(database.Port)),
+		Path:     database.Database,
+		RawQuery: fmt.Sprintf("sslmode=%s", database.SSLMode),
 	}
-	u.Scheme = "pgx5"
-	return u.String(), nil
+	return dbURL.String()
 }

--- a/src/lib/dbpool/pool_integration_test.go
+++ b/src/lib/dbpool/pool_integration_test.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"database/sql"
 	"errors"
-	"os"
 	"strconv"
 	"sync"
 	"sync/atomic"
@@ -35,39 +34,12 @@ import (
 
 	"github.com/goharbor/harbor/src/common/models"
 	harborORM "github.com/goharbor/harbor/src/lib/orm"
+	"github.com/goharbor/harbor/src/testing/dbenv"
 )
 
-// testCfg returns a PostGreSQL config from environment.
-// Accepts both the existing test convention (POSTGRESQL_USR / POSTGRESQL_PWD)
-// and the Harbor config convention (POSTGRESQL_USERNAME / POSTGRESQL_PASSWORD),
-// with devenv defaults as fallback.
+// testCfg returns the shared PostGreSQL test-environment config.
 func testCfg() *models.PostGreSQL {
-	host := envOr("POSTGRESQL_HOST", "localhost")
-	port := 5432
-	if p := os.Getenv("POSTGRESQL_PORT"); p != "" {
-		if v, err := strconv.Atoi(p); err == nil {
-			port = v
-		}
-	}
-	user := envOr("POSTGRESQL_USR", envOr("POSTGRESQL_USERNAME", "postgres"))
-	pwd := envOr("POSTGRESQL_PWD", envOr("POSTGRESQL_PASSWORD", "root123"))
-	db := envOr("POSTGRESQL_DATABASE", "registry")
-
-	return &models.PostGreSQL{
-		Host:     host,
-		Port:     port,
-		Username: user,
-		Password: pwd,
-		Database: db,
-		SSLMode:  "disable",
-	}
-}
-
-func envOr(key, fallback string) string {
-	if v := os.Getenv(key); v != "" {
-		return v
-	}
-	return fallback
+	return dbenv.PostgreSQLConfig()
 }
 
 // mustPool creates a pool or fails the test.

--- a/src/migration/authoritative.go
+++ b/src/migration/authoritative.go
@@ -21,6 +21,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/goharbor/harbor/src/lib/log"
 )
@@ -32,6 +33,9 @@ const (
 	// authoritativeSchemaLockID is the ASCII encoding of "HNEXTSCH". It
 	// serializes reconciliation when multiple core replicas start together.
 	authoritativeSchemaLockID int64 = 0x484e455854534348
+
+	// authoritativeSchemaTimeout bounds startup blocking when a peer holds the advisory lock.
+	authoritativeSchemaTimeout = 10 * time.Minute
 )
 
 type schemaDB interface {

--- a/src/migration/authoritative_db_test.go
+++ b/src/migration/authoritative_db_test.go
@@ -21,19 +21,18 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"strconv"
 	"testing"
 	"time"
 
 	"github.com/jackc/pgx/v5/pgxpool"
 
-	"github.com/goharbor/harbor/src/common/models"
 	"github.com/goharbor/harbor/src/lib/dbpool"
+	"github.com/goharbor/harbor/src/testing/dbenv"
 )
 
 func TestAuthoritativeSchemaAgainstPostgreSQL(t *testing.T) {
 	ctx := context.Background()
-	cfg := authoritativeTestDatabaseConfig()
+	cfg := dbenv.PostgreSQLConfig()
 	adminPool, err := dbpool.New(ctx, cfg)
 	if err != nil {
 		t.Fatalf("create admin database pool: %v", err)
@@ -138,33 +137,9 @@ func TestAuthoritativeSchemaAgainstPostgreSQL(t *testing.T) {
 	}
 }
 
-func authoritativeTestDatabaseConfig() *models.PostGreSQL {
-	port := 5432
-	if value := os.Getenv("POSTGRESQL_PORT"); value != "" {
-		if configuredPort, err := strconv.Atoi(value); err == nil {
-			port = configuredPort
-		}
-	}
-	return &models.PostGreSQL{
-		Host:     environmentOr("POSTGRESQL_HOST", "localhost"),
-		Port:     port,
-		Username: environmentOr("POSTGRESQL_USR", environmentOr("POSTGRESQL_USERNAME", "postgres")),
-		Password: environmentOr("POSTGRESQL_PWD", environmentOr("POSTGRESQL_PASSWORD", "root123")),
-		Database: environmentOr("POSTGRESQL_DATABASE", "registry"),
-		SSLMode:  "disable",
-	}
-}
-
 func authoritativeTestSchemaPath() string {
 	if dir := os.Getenv("POSTGRES_MIGRATION_SCRIPTS_PATH"); dir != "" {
 		return filepath.Join(dir, authoritativeSchemaFile)
 	}
 	return filepath.Join("..", "..", "make", "migrations", "postgresql", authoritativeSchemaFile)
-}
-
-func environmentOr(key, fallback string) string {
-	if value := os.Getenv(key); value != "" {
-		return value
-	}
-	return fallback
 }

--- a/src/migration/authoritative_test.go
+++ b/src/migration/authoritative_test.go
@@ -20,6 +20,7 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 )
 
 type fakeSchemaDB struct {
@@ -200,6 +201,44 @@ func TestApplyAuthoritativeSchemaErrors(t *testing.T) {
 				t.Errorf("transaction rolledBack = %t, want %t", tx.rolledBack, tt.wantRollback)
 			}
 		})
+	}
+}
+
+// blockingSchemaTx simulates a peer holding the advisory lock: Exec blocks until ctx is done.
+type blockingSchemaTx struct {
+	rolledBack bool
+}
+
+func (tx *blockingSchemaTx) Exec(ctx context.Context, _ string, _ ...any) error {
+	<-ctx.Done()
+	return ctx.Err()
+}
+
+func (tx *blockingSchemaTx) Commit() error {
+	return nil
+}
+
+func (tx *blockingSchemaTx) Rollback() error {
+	tx.rolledBack = true
+	return nil
+}
+
+func TestApplyAuthoritativeSchemaHonorsContextDeadline(t *testing.T) {
+	path := writeSchema(t, "SELECT 1;")
+	tx := &blockingSchemaTx{}
+	db := fakeSchemaDB{begin: func(context.Context) (schemaTx, error) {
+		return tx, nil
+	}}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+
+	err := applyAuthoritativeSchema(ctx, db, path)
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("applyAuthoritativeSchema() error = %v, want error wrapping %v", err, context.DeadlineExceeded)
+	}
+	if !tx.rolledBack {
+		t.Error("transaction was not rolled back after the deadline expired")
 	}
 }
 

--- a/src/migration/migration.go
+++ b/src/migration/migration.go
@@ -51,7 +51,9 @@ func Migrate(database *models.Database) error {
 		return fmt.Errorf("apply authoritative Harbor Next schema: database pool is not initialized")
 	}
 	start = time.Now()
-	if err := applyAuthoritativeSchema(context.Background(), sqlSchemaDB{db: pool.DB()}, authoritativeSchemaPath()); err != nil {
+	ctx, cancel := context.WithTimeout(context.Background(), authoritativeSchemaTimeout)
+	defer cancel()
+	if err := applyAuthoritativeSchema(ctx, sqlSchemaDB{db: pool.DB()}, authoritativeSchemaPath()); err != nil {
 		return err
 	}
 	observeMigrationPhase("authoritative", start)

--- a/src/testing/dbenv/dbenv.go
+++ b/src/testing/dbenv/dbenv.go
@@ -1,0 +1,51 @@
+// Copyright Project Harbor Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package dbenv exposes the PostgreSQL test-environment configuration shared by db-tagged tests.
+package dbenv
+
+import (
+	"os"
+	"strconv"
+
+	"github.com/goharbor/harbor/src/common/models"
+)
+
+// PostgreSQLConfig returns a PostGreSQL config from environment.
+// Accepts both the existing test convention (POSTGRESQL_USR / POSTGRESQL_PWD)
+// and the Harbor config convention (POSTGRESQL_USERNAME / POSTGRESQL_PASSWORD),
+// with devenv defaults as fallback.
+func PostgreSQLConfig() *models.PostGreSQL {
+	port := 5432
+	if p := os.Getenv("POSTGRESQL_PORT"); p != "" {
+		if v, err := strconv.Atoi(p); err == nil {
+			port = v
+		}
+	}
+	return &models.PostGreSQL{
+		Host:     envOr("POSTGRESQL_HOST", "localhost"),
+		Port:     port,
+		Username: envOr("POSTGRESQL_USR", envOr("POSTGRESQL_USERNAME", "postgres")),
+		Password: envOr("POSTGRESQL_PWD", envOr("POSTGRESQL_PASSWORD", "root123")),
+		Database: envOr("POSTGRESQL_DATABASE", "registry"),
+		SSLMode:  "disable",
+	}
+}
+
+func envOr(key, fallback string) string {
+	if v := os.Getenv(key); v != "" {
+		return v
+	}
+	return fallback
+}


### PR DESCRIPTION
Three hardening fixes from the review threads on #733, tracked in #743.

## Changes

1. **Migrator DSN fallback** (`src/common/dao/pgsql.go`): `migratorDSN` forced `pgx5` onto whatever `url.Parse` returned. A libpq key-value DSN (e.g. `host=localhost port=5432 user=x`) parses without error but with an empty scheme, producing the unusable `pgx5:host=localhost...`. The function now falls back to building the DSN from the individual database fields whenever `database.URL` does not parse as a URL with a scheme. New table-driven cases in `migrator_dsn_test.go` cover the key-value DSN, empty-scheme URL, and unparsable URL paths.

2. **Bounded authoritative schema locking** (`src/migration/`): the authoritative phase took `pg_advisory_xact_lock` with no deadline, so a stalled peer could block core startup forever. `Migrate` now wraps the context passed to `applyAuthoritativeSchema` with a 10-minute timeout (`authoritativeSchemaTimeout`), which flows into `BeginTx`/`ExecContext`. A deterministic unit test with a blocking fake tx asserts the call returns `context.DeadlineExceeded` and rolls back.

3. **Consolidated test-env config** (`src/testing/dbenv/`): `authoritativeTestDatabaseConfig`/`environmentOr` duplicated `testCfg`/`envOr` from the dbpool integration tests. Both db-tagged test files now use the new shared `dbenv.PostgreSQLConfig()` helper (same `POSTGRESQL_*` env vars and devenv defaults, behavior unchanged).

Fixes #743

## Verification

- `go build` / `go vet` (incl. `-tags db`) on `common/dao`, `migration`, `lib/dbpool`, `testing/dbenv`
- `go test ./common/dao/ -run TestMigratorDSN` and `go test ./migration/` pass
- `gofmt -l` clean; `golangci-lint` 0 issues on touched packages