### PR TITLE
build: Tidy go.sum before compiling Harbor binaries

### DIFF
--- a/taskfile/build.yml
+++ b/taskfile/build.yml
@@ -35,6 +35,17 @@ tasks:
 
   # --- Internal Go Build ---
 
+  tidy:
+    desc: "Sync src/go.sum with the source tree before compiling"
+    # Commercial patch branches add go.mod requirements without go.sum
+    # entries (patches carry no go.sum by policy), so the megamerged tree
+    # only builds after a tidy. No-op on an already-tidy tree.
+    run: once
+    deps: [gen-apis]
+    dir: src
+    cmds:
+      - go mod tidy
+
   _go-build:
     internal: true
     run: when_changed
@@ -72,7 +83,7 @@ tasks:
       - src/go.sum
     generates:
       - bin/{{index .MATCH 0}}/core
-    deps: [gen-apis]
+    deps: [gen-apis, tidy]
     cmds:
       - task: _go-build
         vars:
@@ -90,6 +101,7 @@ tasks:
       - src/go.sum
     generates:
       - bin/{{index .MATCH 0}}/jobservice
+    deps: [tidy]
     cmds:
       - task: _go-build
         vars:
@@ -107,6 +119,7 @@ tasks:
       - src/go.sum
     generates:
       - bin/{{index .MATCH 0}}/registryctl
+    deps: [tidy]
     cmds:
       - task: _go-build
         vars:
@@ -124,6 +137,7 @@ tasks:
       - src/go.sum
     generates:
       - bin/{{index .MATCH 0}}/harbor-exporter
+    deps: [tidy]
     cmds:
       - task: _go-build
         vars:


### PR DESCRIPTION
Adds a run-once `build:tidy` task and wires it into the four Harbor-source binary builds (`core`, `jobservice`, `registryctl`, `exporter`).

## Why

Commercial patch branches now carry go.mod requirements but **no go.sum** (by policy — go.sum is derived state). The release pipeline had no tidy step for the Harbor source itself (the existing `go mod tidy -e` calls are for the third-party distribution/lprobe/trivy clones), so the megamerged release tree failed every binary build with `missing go.sum entry`. This surfaced while rehearsing the v2.15.8-dev release build from a fresh clone.

## Ordering

`tidy` depends on `gen-apis`: `go mod tidy` resolves the generated `server/v2.0/restapi` imports, and without the generated code it goes looking for `github.com/goharbor/harbor` as an external module (verified empirically). On an already-tidy tree (plain CI builds without patches) the step is a no-op.

Backport to `release-2.15` follows so the local release workflow works there too.