### PR TITLE
fix: Reset retired commercial schema version 182 before migration

### DIFF
--- a/src/migration/authoritative.go
+++ b/src/migration/authoritative.go
@@ -73,12 +73,16 @@ func (t sqlSchemaTx) Rollback() error {
 	return t.tx.Rollback()
 }
 
-func authoritativeSchemaPath() string {
+func migrationSourceDir() string {
 	dir := os.Getenv("POSTGRES_MIGRATION_SCRIPTS_PATH")
 	if dir == "" {
 		dir = defaultMigrationDir
 	}
-	return filepath.Join(dir, authoritativeSchemaFile)
+	return dir
+}
+
+func authoritativeSchemaPath() string {
+	return filepath.Join(migrationSourceDir(), authoritativeSchemaFile)
 }
 
 func applyAuthoritativeSchema(ctx context.Context, db schemaDB, path string) error {

--- a/src/migration/authoritative_test.go
+++ b/src/migration/authoritative_test.go
@@ -19,7 +19,10 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"sync"
+	"sync/atomic"
 	"testing"
+	"time"
 )
 
 type fakeSchemaDB struct {
@@ -210,4 +213,96 @@ func writeSchema(t *testing.T, contents string) string {
 		t.Fatalf("write schema fixture: %v", err)
 	}
 	return path
+}
+
+// TestApplyAuthoritativeSchemaSerializesInstances simulates several core
+// replicas starting at once: the advisory-lock Exec blocks on a real mutex the
+// way pg_advisory_xact_lock blocks in PostgreSQL, released only by
+// Commit/Rollback. The schema statement must never run in two transactions at
+// the same time, and every instance must still apply successfully (idempotent
+// re-application, not skipping).
+func TestApplyAuthoritativeSchemaSerializesInstances(t *testing.T) {
+	const instances = 8
+	path := writeSchema(t, "CREATE TABLE IF NOT EXISTS example (id BIGINT PRIMARY KEY);\n")
+
+	var (
+		advisory sync.Mutex
+		inside   atomic.Int32
+		overlaps atomic.Int32
+		applied  atomic.Int32
+	)
+
+	newTx := func() schemaTx {
+		return &serializingTx{
+			lock: &advisory,
+			onSchema: func() {
+				if inside.Add(1) > 1 {
+					overlaps.Add(1)
+				}
+				time.Sleep(time.Millisecond)
+				inside.Add(-1)
+				applied.Add(1)
+			},
+		}
+	}
+	db := fakeSchemaDB{begin: func(context.Context) (schemaTx, error) { return newTx(), nil }}
+
+	var wg sync.WaitGroup
+	errs := make(chan error, instances)
+	for i := 0; i < instances; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			errs <- applyAuthoritativeSchema(context.Background(), db, path)
+		}()
+	}
+	wg.Wait()
+	close(errs)
+
+	for err := range errs {
+		if err != nil {
+			t.Errorf("applyAuthoritativeSchema() returned error: %v", err)
+		}
+	}
+	if got := overlaps.Load(); got != 0 {
+		t.Errorf("schema statement ran concurrently in %d transactions; advisory lock must serialize instances", got)
+	}
+	if got := applied.Load(); got != instances {
+		t.Errorf("schema applied %d times, want %d (every instance re-applies idempotently)", got, instances)
+	}
+}
+
+// serializingTx emulates PostgreSQL transaction-scoped advisory locking for
+// the fake schema DB: Exec of the lock statement blocks until the current
+// holder finishes its transaction.
+type serializingTx struct {
+	lock     *sync.Mutex
+	held     bool
+	onSchema func()
+}
+
+func (tx *serializingTx) Exec(_ context.Context, query string, _ ...any) error {
+	if query == "SELECT pg_advisory_xact_lock($1)" {
+		tx.lock.Lock()
+		tx.held = true
+		return nil
+	}
+	tx.onSchema()
+	return nil
+}
+
+func (tx *serializingTx) Commit() error {
+	if tx.held {
+		tx.held = false
+		tx.lock.Unlock()
+	}
+	return nil
+}
+
+func (tx *serializingTx) Rollback() error {
+	if tx.held {
+		tx.held = false
+		tx.lock.Unlock()
+	}
+	return nil
 }

--- a/src/migration/legacy_version_test.go
+++ b/src/migration/legacy_version_test.go
@@ -1,0 +1,95 @@
+// Copyright Project Harbor Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package migration
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestNumberedMigrationExists(t *testing.T) {
+	dir := t.TempDir()
+	for _, name := range []string{
+		"0180_2.15.0_schema.up.sql",
+		"0181_2.15.3_schema.up.sql",
+		"harbor_next.sql",
+	} {
+		if err := os.WriteFile(filepath.Join(dir, name), []byte("-- test"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	t.Setenv("POSTGRES_MIGRATION_SCRIPTS_PATH", dir)
+
+	if numberedMigrationExists(legacyPatchVersion) {
+		t.Errorf("numberedMigrationExists(%d) = true; the legacy reset would be skipped", legacyPatchVersion)
+	}
+	if !numberedMigrationExists(181) {
+		t.Error("numberedMigrationExists(181) = false; want true for a present migration")
+	}
+
+	// A future backport occupying the legacy version must disable the reset.
+	if err := os.WriteFile(filepath.Join(dir, "0182_2.15.9_schema.up.sql"), []byte("-- test"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if !numberedMigrationExists(legacyPatchVersion) {
+		t.Errorf("numberedMigrationExists(%d) = false with 0182 file present; the reset would rewind a genuine database", legacyPatchVersion)
+	}
+}
+
+// TestShouldResetLegacyVersion pins the escape hatch to exactly 182: fresh
+// databases, upstream-migrated databases (181), and every other version must
+// never be rewound.
+func TestShouldResetLegacyVersion(t *testing.T) {
+	dir := t.TempDir()
+	for _, name := range []string{
+		"0180_2.15.0_schema.up.sql",
+		"0181_2.15.3_schema.up.sql",
+		"harbor_next.sql",
+	} {
+		if err := os.WriteFile(filepath.Join(dir, name), []byte("-- test"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	t.Setenv("POSTGRES_MIGRATION_SCRIPTS_PATH", dir)
+
+	cases := []struct {
+		name    string
+		version uint
+		want    bool
+	}{
+		{"fresh database (0)", 0, false},
+		{"old upstream (100)", 100, false},
+		{"pre-2.15.3 (180)", 180, false},
+		{"upstream-migrated OSS install (181)", 181, false},
+		{"retired commercial migrations (182)", 182, true},
+		{"beyond legacy (183)", 183, false},
+		{"future minor (190)", 190, false},
+	}
+	for _, tc := range cases {
+		if got := shouldResetLegacyVersion(tc.version); got != tc.want {
+			t.Errorf("%s: shouldResetLegacyVersion(%d) = %t, want %t", tc.name, tc.version, got, tc.want)
+		}
+	}
+
+	// Regression: once a real 0182 migration ships, 182 becomes a genuine
+	// version and the hatch must stay closed.
+	if err := os.WriteFile(filepath.Join(dir, "0182_2.15.9_schema.up.sql"), []byte("-- test"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if shouldResetLegacyVersion(182) {
+		t.Error("shouldResetLegacyVersion(182) = true with a real 0182 migration present; must not rewind")
+	}
+}

--- a/src/migration/migration.go
+++ b/src/migration/migration.go
@@ -17,6 +17,7 @@ package migration
 import (
 	"context"
 	"fmt"
+	"path/filepath"
 	"time"
 
 	"github.com/golang-migrate/migrate/v4"
@@ -25,6 +26,17 @@ import (
 	"github.com/goharbor/harbor/src/common/models"
 	"github.com/goharbor/harbor/src/lib/log"
 	"github.com/goharbor/harbor/src/lib/metric"
+)
+
+const (
+	// legacyPatchVersion is the schema_migrations value written by the retired
+	// 8gears numbered migrations (0181/0182); their DDL now lives in the
+	// authoritative harbor_next.sql, so the numbered chain ends below it and
+	// golang-migrate cannot orient itself on such databases.
+	legacyPatchVersion = 182
+	// legacyResetVersion is the last upstream migration those databases
+	// actually applied; resetting to it lets the upstream chain continue.
+	legacyResetVersion = 180
 )
 
 // Migrate upgrades DB schema and do necessary transformation of the data in DB
@@ -40,6 +52,12 @@ func Migrate(database *models.Database) error {
 		return err
 	}
 	log.Debugf("current database schema version: %v", schemaVersion)
+	if shouldResetLegacyVersion(schemaVersion) {
+		log.Infof("schema version %d stems from the retired commercial numbered migrations; resetting to %d so the upstream chain continues (no tables are touched, their DDL is reconciled via harbor_next.sql)", legacyPatchVersion, legacyResetVersion)
+		if err := resetLegacyVersion(context.Background()); err != nil {
+			return fmt.Errorf("reset legacy schema version %d to %d: %w", legacyPatchVersion, legacyResetVersion, err)
+		}
+	}
 	start := time.Now()
 	if err := dao.UpgradeSchema(database); err != nil {
 		return err
@@ -56,6 +74,45 @@ func Migrate(database *models.Database) error {
 	}
 	observeMigrationPhase("authoritative", start)
 	return nil
+}
+
+// resetLegacyVersion rewinds schema_migrations with a compare-and-set: the
+// WHERE clause makes it a no-op when a concurrent core instance already reset
+// the version or advanced past it, so a stale 182 read can never rewind a
+// database that has moved on (multi-replica startup safety).
+func resetLegacyVersion(ctx context.Context) error {
+	pool := dao.GetPool()
+	if pool == nil {
+		return fmt.Errorf("database pool is not initialized")
+	}
+	result, err := pool.DB().ExecContext(ctx,
+		"UPDATE schema_migrations SET version = $1, dirty = false WHERE version = $2",
+		legacyResetVersion, legacyPatchVersion)
+	if err != nil {
+		return err
+	}
+	if rows, err := result.RowsAffected(); err == nil && rows == 0 {
+		log.Infof("schema version already reset or advanced by another core instance, skipping")
+	}
+	return nil
+}
+
+// shouldResetLegacyVersion is true only for the exact version the retired
+// commercial numbered migrations wrote; anything else (including 181, where
+// upstream-migrated databases legitimately sit) is never rewound.
+func shouldResetLegacyVersion(version uint) bool {
+	return version == legacyPatchVersion && !numberedMigrationExists(legacyPatchVersion)
+}
+
+// numberedMigrationExists guards the legacy reset: a future release-2.15
+// backport may legitimately occupy the version, in which case the database
+// state is genuine and must not be rewound.
+func numberedMigrationExists(version uint) bool {
+	matches, err := filepath.Glob(filepath.Join(migrationSourceDir(), fmt.Sprintf("%04d_*.up.sql", version)))
+	if err != nil {
+		return false
+	}
+	return len(matches) > 0
 }
 
 // observeMigrationPhase logs and records how long a migration phase took


### PR DESCRIPTION
Escape hatch for release-2.15 upgrades, per the v2.15.8-dev test matrix.

## Problem

Every existing harbor-next 2.15.x install sits at `schema_migrations = 182`, written by the retired numbered commercial migrations (`0181_8gears_branding`, `0182_8gears_identity_providers`). The numbered chain now ends at `0181_2.15.3_schema.up.sql`, so golang-migrate cannot orient itself and core fatals at startup:

```
FATAL failed to migrate the database, error: no migration found for version 182: read down for version 182 .: file does not exist
```

Reproduced live (fresh CNPG + chart, seeded with users/projects/images/registries/replications) for both `v2.15.0 → v2.15.8-dev` and `v2.15.6 → v2.15.7 → v2.15.8-dev`.

## Fix

In `migration.Migrate`, after reading the schema version and before the numbered phase: if the version equals 182 **and no numbered migration file occupies that version**, reset the pointer to 180 via `migrator.Force(180)` — the last upstream migration those databases actually applied. The same boot then follows the usual route:

1. numbered phase applies `0181_2.15.3` (the Y2K38 bigint fix these installs had silently skipped)
2. authoritative `harbor_next.sql` reconciles the commercial DDL idempotently over the existing tables

The reset touches only the `schema_migrations` row — no tables are created, altered, or dropped by it. The file-existence guard means a future backport legitimately shipping `0182_*.up.sql` automatically disables the hatch instead of rewinding a genuine database.

Manually-executed equivalent (`UPDATE schema_migrations SET version=180, dirty=false` + core restart) was verified twice in the matrix: core healthy, DB at 181, seeded data byte-identical pre/post.

## Testing

- `TestNumberedMigrationExists` — glob guard incl. the future-0182 disable case
- migration package build/vet/tests/golangci-lint all clean


## Release Notes

Upgrades from any earlier 2.15.x release no longer fail at startup with `no migration found for version 182`. Databases stamped by the retired commercial migrations are detected and automatically re-pointed, so the upgrade proceeds normally — including a previously skipped schema fix — with no manual database intervention.
