### PR TITLE
ci: Add scheduled self-hosted Renovate workflow

### DIFF
--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -41,7 +41,7 @@ env:
 jobs:
   build:
     name: "${{ matrix.component }} (${{ matrix.platform }})"
-    if: ${{ github.event.pull_request.head.repo.full_name == github.repository && github.actor != 'renovate[bot]' }}
+    if: ${{ github.event.pull_request.head.repo.full_name == github.repository && !contains(fromJSON('["renovate[bot]", "8gcr-sync[bot]"]'), github.actor) }}
     strategy:
       fail-fast: false
       matrix:
@@ -157,7 +157,7 @@ jobs:
 
   merge:
     name: "Merge ${{ matrix.component }}"
-    if: ${{ github.event.pull_request.head.repo.full_name == github.repository && github.actor != 'renovate[bot]' }}
+    if: ${{ github.event.pull_request.head.repo.full_name == github.repository && !contains(fromJSON('["renovate[bot]", "8gcr-sync[bot]"]'), github.actor) }}
     needs: [build]
     strategy:
       fail-fast: false
@@ -210,7 +210,7 @@ jobs:
 
   sign:
     name: Sign preview images
-    if: ${{ github.event.pull_request.head.repo.full_name == github.repository && github.actor != 'renovate[bot]' }}
+    if: ${{ github.event.pull_request.head.repo.full_name == github.repository && !contains(fromJSON('["renovate[bot]", "8gcr-sync[bot]"]'), github.actor) }}
     needs: [merge]
     runs-on: ubuntu-26.04
     permissions:
@@ -267,7 +267,7 @@ jobs:
 
   pr-comment:
     name: Comment preview image refs
-    if: ${{ github.event.pull_request.head.repo.full_name == github.repository && github.actor != 'renovate[bot]' }}
+    if: ${{ github.event.pull_request.head.repo.full_name == github.repository && !contains(fromJSON('["renovate[bot]", "8gcr-sync[bot]"]'), github.actor) }}
     needs: [sign]
     runs-on: ubuntu-26.04
     permissions:

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -1,0 +1,44 @@
+name: Renovate
+
+on:
+  schedule:
+    # 01:00 UTC on odd days of month (~every 2 days), inside the 0-3 UTC
+    # windows in renovate.json; consecutive runs at 31st -> 1st are fine
+    - cron: "0 1 */2 * *"
+  workflow_dispatch:
+
+permissions: {}
+
+concurrency:
+  group: renovate
+  cancel-in-progress: false
+
+jobs:
+  renovate:
+    runs-on: ubuntu-26.04
+    timeout-minutes: 60
+    steps:
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          app-id: ${{ vars.SYNC_APP_ID }}
+          private-key: ${{ secrets.SYNC_APP_PRIVATE_KEY }}
+          owner: container-registry
+          repositories: harbor-next
+          permission-contents: write
+          permission-pull-requests: write
+          permission-issues: write
+          permission-statuses: write
+          permission-checks: read
+          permission-workflows: write
+          permission-vulnerability-alerts: read
+
+      - name: Run Renovate
+        uses: renovatebot/github-action@5402b206248e5a8c8427a15102702eb9c1793efc # v46.2.4
+        with:
+          token: ${{ steps.app-token.outputs.token }}
+          renovate-version: 44.46.5
+        env:
+          RENOVATE_REPOSITORIES: container-registry/harbor-next
+          LOG_LEVEL: info


### PR DESCRIPTION
## Summary

- add `.github/workflows/renovate.yml` running `renovatebot/github-action` (SHA-pinned, v46.2.4) with the Renovate container pinned to `44.46.5`
- schedule: `0 1 */2 * *` — 01:00 UTC on odd days of month (~every 2 days), inside the `0-3` UTC windows already defined in `.github/renovate.json`, plus `workflow_dispatch` for manual runs
- authenticates with the org sync GitHub App via `actions/create-github-app-token`, same pattern as `release-ready.yml`; the minted token is **downscoped** with explicit `permission-*` inputs (contents, PRs, issues, statuses write; checks, vulnerability-alerts read; workflows write)
- commit attribution is left to Renovate: with an app token it commits via the platform API (`platformCommit=auto`), so no `RENOVATE_GIT_AUTHOR`/`RENOVATE_USERNAME` overrides — a manual value without the numeric bot user id breaks branch-modified detection (verified in test runs)
- `permissions: {}`, single-flight concurrency group, 60 min timeout

## Why

Renovate config was merged in #548 but nothing executes it — no hosted Mend app installed, no runner workflow. Result: zero dependency PRs and no Dependency Dashboard since Aug 3.

## Setup required before merge

The sync GitHub App needs these permissions granted (and the updated permissions approved on the org installation), otherwise the downscoped token mint fails:

- Contents: read/write, Pull requests: read/write, Issues: read/write
- **Commit statuses: read/write** — verified hard blocker: test runs aborted with 403 on `POST /statuses` (`x-accepted-github-permissions: statuses=write`)
- Workflows: read/write (the `github-actions` manager updates pins in `.github/workflows/`)
- Dependabot alerts: read (for `vulnerabilityAlerts` in renovate.json)

## Verification so far

Test runs from this branch (temp `push` trigger, to be removed before merge): token mint OK, both base branches scanned (375 deps on `main`), 12 update branches computed, branch+commit pushed via API — then aborted on the missing `statuses` permission above.

## Notes

- Renovate PRs will be authored by `<app-slug>[bot]`, not `renovate[bot]` — the `github.actor` skip-conditions in `pr-ci.yml` will not match, so preview image builds will run on Renovate PRs. Follow-up can add the app slug to those conditions.
- cron `*/2` is day-of-month based: runs land on odd dates, so the 31st and the 1st are consecutive — accepted, exact 48 h cadence is not required.