### PR TITLE
fix: Reconcile in-place 0190 amendments in authoritative schema

### DIFF
--- a/make/migrations/postgresql/harbor_next.sql
+++ b/make/migrations/postgresql/harbor_next.sql
@@ -62,3 +62,44 @@ CREATE INDEX IF NOT EXISTS idx_claim_rules_lookup
 
 CREATE INDEX IF NOT EXISTS idx_identity_providers_jwks_cache
     ON identity_providers (id, jwks_expires_at, jwks_last_fetch_attempt);
+
+-- 0190_2.16.0 was amended in place (robot bigint IDs, audit client columns)
+-- after deployed databases had already recorded schema_migrations >= 190, so
+-- golang-migrate never replays it for them. Reconcile those amendments here;
+-- fresh installs run the same statements in 0190 and these no-op. The
+-- existence guards keep the file applicable to a bare schema (see
+-- authoritative_db_test.go).
+
+-- Robot account ID columns to bigint (upstream goharbor/harbor#23633)
+DO $$
+BEGIN
+    IF EXISTS (
+        SELECT 1 FROM information_schema.columns
+        WHERE table_schema = current_schema()
+          AND table_name = 'robot' AND column_name = 'creator_ref'
+          AND data_type <> 'bigint'
+    ) THEN
+        ALTER TABLE robot ALTER COLUMN id TYPE bigint;
+        ALTER TABLE robot ALTER COLUMN creator_ref TYPE bigint;
+        ALTER SEQUENCE robot_id_seq AS bigint MAXVALUE 9007199254740991;
+    END IF;
+    IF EXISTS (
+        SELECT 1 FROM information_schema.columns
+        WHERE table_schema = current_schema()
+          AND table_name = 'role_permission' AND column_name = 'role_id'
+          AND data_type <> 'bigint'
+    ) THEN
+        ALTER TABLE role_permission ALTER COLUMN role_id TYPE bigint;
+    END IF;
+END
+$$;
+
+-- Audit log client IP address / User-Agent columns
+DO $$
+BEGIN
+    IF to_regclass('audit_log_ext') IS NOT NULL THEN
+        ALTER TABLE audit_log_ext ADD COLUMN IF NOT EXISTS client_address varchar(255) DEFAULT '';
+        ALTER TABLE audit_log_ext ADD COLUMN IF NOT EXISTS user_agent varchar(1024) DEFAULT '';
+    END IF;
+END
+$$;

--- a/src/migration/authoritative_db_test.go
+++ b/src/migration/authoritative_db_test.go
@@ -59,8 +59,15 @@ func TestAuthoritativeSchemaAgainstPostgreSQL(t *testing.T) {
 	}
 	t.Cleanup(schemaPool.Close)
 
-	if _, err := schemaPool.DB().ExecContext(ctx, "CREATE TABLE robot (id BIGSERIAL PRIMARY KEY)"); err != nil {
+	// Stubs use the pre-amendment 0190 shapes so the reconciliation blocks run.
+	if _, err := schemaPool.DB().ExecContext(ctx, "CREATE TABLE robot (id BIGSERIAL PRIMARY KEY, creator_ref integer NOT NULL DEFAULT 0)"); err != nil {
 		t.Fatalf("create robot dependency: %v", err)
+	}
+	if _, err := schemaPool.DB().ExecContext(ctx, "CREATE TABLE role_permission (id SERIAL PRIMARY KEY, role_id integer NOT NULL)"); err != nil {
+		t.Fatalf("create role_permission dependency: %v", err)
+	}
+	if _, err := schemaPool.DB().ExecContext(ctx, "CREATE TABLE audit_log_ext (id BIGSERIAL PRIMARY KEY)"); err != nil {
+		t.Fatalf("create audit_log_ext dependency: %v", err)
 	}
 
 	path := authoritativeTestSchemaPath()
@@ -115,6 +122,9 @@ func TestAuthoritativeSchemaAgainstPostgreSQL(t *testing.T) {
 		"claim_rules": {
 			"id", "identity_provider_id", "robot_id", "claim_path", "value", "creation_time",
 		},
+		"audit_log_ext": {
+			"client_address", "user_agent",
+		},
 	}
 	for table, tableColumns := range columns {
 		for _, column := range tableColumns {
@@ -134,6 +144,28 @@ func TestAuthoritativeSchemaAgainstPostgreSQL(t *testing.T) {
 			if !exists {
 				t.Errorf("authoritative schema column %q does not exist", table+"."+column)
 			}
+		}
+	}
+
+	bigintColumns := [][2]string{
+		{"robot", "id"},
+		{"robot", "creator_ref"},
+		{"role_permission", "role_id"},
+	}
+	for _, tableColumn := range bigintColumns {
+		var dataType string
+		err := schemaPool.DB().QueryRowContext(ctx, `
+			SELECT data_type
+			FROM information_schema.columns
+			WHERE table_schema = current_schema()
+			  AND table_name = $1
+			  AND column_name = $2`, tableColumn[0], tableColumn[1]).Scan(&dataType)
+		if err != nil {
+			t.Errorf("look up column type %s.%s: %v", tableColumn[0], tableColumn[1], err)
+			continue
+		}
+		if dataType != "bigint" {
+			t.Errorf("column %s.%s is %q, want bigint", tableColumn[0], tableColumn[1], dataType)
 		}
 	}
 }


### PR DESCRIPTION
## Summary

Migration `0190_2.16.0_schema.up.sql` was amended in place twice after it had already merged and been applied on long-lived deployments:

- 2026-08-21 (`4c6306ed7d`): robot account ID columns/sequence to bigint (upstream goharbor/harbor#23633)
- 2026-08-25 (`1a2eb258b2`, #701): `audit_log_ext.client_address` / `user_agent` columns

Databases that had already recorded `schema_migrations >= 190` (e.g. 8gcr.container-registry.dev, initialized 2026-08-20) never replay 0190, so they silently miss both changes. The visible symptom on the dev instance: **every audit log listing returns HTTP 500** because the ORM selects `client_address`/`user_agent` columns that don't exist.

## Fix

Reconcile both amendments through `harbor_next.sql` (the authoritative schema from #711), which core re-applies idempotently on every startup:

- Robot bigint conversion wrapped in type guards so the table rewrite only runs when a column is still `integer`.
- Audit columns use `ADD COLUMN IF NOT EXISTS`, guarded by `to_regclass` so the file still applies to the bare schema used in tests.

Fresh installs get the same statements from 0190 first; the reconciliation then no-ops.

## Testing

Extended `TestAuthoritativeSchemaAgainstPostgreSQL` with pre-amendment stub shapes (`robot.creator_ref`/`role_permission.role_id` as `integer`, bare `audit_log_ext`) and assertions that the columns exist and are converted to `bigint`. Verified against PostgreSQL 17 (`go test -tags db`), including the concurrent and repeat application paths.