### PR TITLE
ci: Fix Renovate token mint with a dedicated app

### DIFF
--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -41,7 +41,7 @@ env:
 jobs:
   build:
     name: "${{ matrix.component }} (${{ matrix.platform }})"
-    if: ${{ github.event.pull_request.head.repo.full_name == github.repository && !contains(fromJSON('["renovate[bot]", "8gcr-sync[bot]"]'), github.actor) }}
+    if: ${{ github.event.pull_request.head.repo.full_name == github.repository && !contains(fromJSON('["8gcr-renovate[bot]", "8gcr-sync[bot]"]'), github.actor) }}
     strategy:
       fail-fast: false
       matrix:
@@ -157,7 +157,7 @@ jobs:
 
   merge:
     name: "Merge ${{ matrix.component }}"
-    if: ${{ github.event.pull_request.head.repo.full_name == github.repository && !contains(fromJSON('["renovate[bot]", "8gcr-sync[bot]"]'), github.actor) }}
+    if: ${{ github.event.pull_request.head.repo.full_name == github.repository && !contains(fromJSON('["8gcr-renovate[bot]", "8gcr-sync[bot]"]'), github.actor) }}
     needs: [build]
     strategy:
       fail-fast: false
@@ -210,7 +210,7 @@ jobs:
 
   sign:
     name: Sign preview images
-    if: ${{ github.event.pull_request.head.repo.full_name == github.repository && !contains(fromJSON('["renovate[bot]", "8gcr-sync[bot]"]'), github.actor) }}
+    if: ${{ github.event.pull_request.head.repo.full_name == github.repository && !contains(fromJSON('["8gcr-renovate[bot]", "8gcr-sync[bot]"]'), github.actor) }}
     needs: [merge]
     runs-on: ubuntu-26.04
     permissions:
@@ -267,7 +267,7 @@ jobs:
 
   pr-comment:
     name: Comment preview image refs
-    if: ${{ github.event.pull_request.head.repo.full_name == github.repository && !contains(fromJSON('["renovate[bot]", "8gcr-sync[bot]"]'), github.actor) }}
+    if: ${{ github.event.pull_request.head.repo.full_name == github.repository && !contains(fromJSON('["8gcr-renovate[bot]", "8gcr-sync[bot]"]'), github.actor) }}
     needs: [sign]
     runs-on: ubuntu-26.04
     permissions:

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -18,21 +18,27 @@ jobs:
     runs-on: ubuntu-26.04
     timeout-minutes: 60
     steps:
+      # Dedicated Renovate app, not 8gcr-sync: the sync app declares only
+      # actions/checks/statuses read + contents/pull-requests write, so the
+      # downscope below can never be satisfied by it. The app installed for
+      # this workflow must grant every permission requested here, or the
+      # mint fails with 422 "permissions requested are not granted".
       - name: Generate GitHub App token
         id: app-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
-          app-id: ${{ vars.SYNC_APP_ID }}
-          private-key: ${{ secrets.SYNC_APP_PRIVATE_KEY }}
+          client-id: ${{ vars.RENOVATE_APP_CLIENT_ID }}
+          private-key: ${{ secrets.RENOVATE_APP_PRIVATE_KEY }}
           owner: container-registry
           repositories: harbor-next
           permission-contents: write
           permission-pull-requests: write
-          permission-issues: write
+          permission-issues: write # dependencyDashboard
           permission-statuses: write
           permission-checks: read
-          permission-workflows: write
-          permission-vulnerability-alerts: read
+          permission-administration: read # GET /branches/{b}/protection
+          permission-workflows: write # github-actions manager edits .github/workflows/
+          permission-vulnerability-alerts: read # GET /dependabot/alerts
 
       - name: Run Renovate
         uses: renovatebot/github-action@5402b206248e5a8c8427a15102702eb9c1793efc # v46.2.4


### PR DESCRIPTION

Every run of `.github/workflows/renovate.yml` since it merged fails in ~10s at token mint:

```
422 The permissions requested are not granted to this installation.
```

The workflow mints from `vars.SYNC_APP_ID` → app **`8gcr-sync`**, whose app definition declares only `actions:read, checks:read, contents:write, metadata:read, pull_requests:write, statuses:read`. The downscope asks for `statuses:write`, `issues:write`, `workflows:write` and `vulnerability-alerts:read` — none of which that app has. Not fixable by approving the installation; the app itself would have to change.

Net effect: zero dependency PRs since 2026-08-03, no Dependency Dashboard.

## Solution

- Mint from a **dedicated Renovate app** (`vars.RENOVATE_APP_CLIENT_ID` / `secrets.RENOVATE_APP_PRIVATE_KEY`) instead of `8gcr-sync`.
- Add `permission-administration: read`. The 2026-08-26 test run (33006630780) shows a 403 on `GET /repos/.../branches/main/protection`.
- Use `client-id` rather than `app-id` — that run logs `Input 'app-id' has been deprecated`.
- `pr-ci.yml` skip-conditions now list `8gcr-renovate[bot]`, the slug of the new app.

## Why this way

`8gcr-sync` is the repo-sync credential. Widening it with `workflows:write` + `issues:write` + `statuses:write` would grow a credential that exists for an unrelated purpose. A dedicated app keeps Renovate's grant scoped to Renovate.

**Alternative considered and dismissed:** drop the self-hosted runner and use the Mend hosted Renovate app, which is already installed org-wide (installation `156863855`, `repository_selection: all`, since 2026-08-27) with the full documented permission set. Dismissed because it holds standing `contents:write` + `workflows:write` on all org repos with no way to scope it to this one, it moves Renovate's version out of our control, and it has produced nothing anywhere in the org in the two days since install — it fails silently, where a workflow fails visibly.

## Not applied

`checks: write` (cubic P1, coderabbit Major): Renovate reads check runs and writes commit *statuses*; the test run ran with `checks: read` and never 403'd on a checks call. Left at `read`; happy to raise it if a run proves otherwise.

`RENOVATE_USERNAME` / `RENOVATE_GIT_AUTHOR` (cubic P2): deliberate, see #750 — with an app token Renovate commits via the platform API and a manual author value without the numeric bot user id breaks branch-modified detection.

## Blocked on

Register the app (suggested name **8gcr Renovate** → slug `8gcr-renovate`), grant it exactly the permissions the workflow requests, install it on `harbor-next`, and set `RENOVATE_APP_CLIENT_ID` + `RENOVATE_APP_PRIVATE_KEY`. Then `workflow_dispatch` to verify. If you pick a different app name, the slug in `pr-ci.yml` needs to match.

Separately: `renovate/main-github.com-beego-i18n-digest` is a leftover branch from the 2026-08-26 test run and can be deleted.
