### PR TITLE
ci: Keep renovate[bot] in the preview-build skip list

### DIFF
--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -41,7 +41,7 @@ env:
 jobs:
   build:
     name: "${{ matrix.component }} (${{ matrix.platform }})"
-    if: ${{ github.event.pull_request.head.repo.full_name == github.repository && !contains(fromJSON('["8gcr-renovate[bot]", "8gcr-sync[bot]"]'), github.actor) }}
+    if: ${{ github.event.pull_request.head.repo.full_name == github.repository && !contains(fromJSON('["8gcr-renovate[bot]", "renovate[bot]", "8gcr-sync[bot]"]'), github.actor) }}
     strategy:
       fail-fast: false
       matrix:
@@ -157,7 +157,7 @@ jobs:
 
   merge:
     name: "Merge ${{ matrix.component }}"
-    if: ${{ github.event.pull_request.head.repo.full_name == github.repository && !contains(fromJSON('["8gcr-renovate[bot]", "8gcr-sync[bot]"]'), github.actor) }}
+    if: ${{ github.event.pull_request.head.repo.full_name == github.repository && !contains(fromJSON('["8gcr-renovate[bot]", "renovate[bot]", "8gcr-sync[bot]"]'), github.actor) }}
     needs: [build]
     strategy:
       fail-fast: false
@@ -210,7 +210,7 @@ jobs:
 
   sign:
     name: Sign preview images
-    if: ${{ github.event.pull_request.head.repo.full_name == github.repository && !contains(fromJSON('["8gcr-renovate[bot]", "8gcr-sync[bot]"]'), github.actor) }}
+    if: ${{ github.event.pull_request.head.repo.full_name == github.repository && !contains(fromJSON('["8gcr-renovate[bot]", "renovate[bot]", "8gcr-sync[bot]"]'), github.actor) }}
     needs: [merge]
     runs-on: ubuntu-26.04
     permissions:
@@ -267,7 +267,7 @@ jobs:
 
   pr-comment:
     name: Comment preview image refs
-    if: ${{ github.event.pull_request.head.repo.full_name == github.repository && !contains(fromJSON('["8gcr-renovate[bot]", "8gcr-sync[bot]"]'), github.actor) }}
+    if: ${{ github.event.pull_request.head.repo.full_name == github.repository && !contains(fromJSON('["8gcr-renovate[bot]", "renovate[bot]", "8gcr-sync[bot]"]'), github.actor) }}
     needs: [sign]
     runs-on: ubuntu-26.04
     permissions:


### PR DESCRIPTION

#756 replaced `renovate[bot]` with `8gcr-renovate[bot]` in the four `pr-ci.yml` actor skip conditions. The Mend hosted Renovate app is still installed on the org — installation `156863855`, `repository_selection: all`, not suspended. It has produced nothing so far, but if it activates, its PRs no longer match the skip list and would run the multi-arch preview build, the signing job (`id-token: write`) and the PR-comment job.

Raised by copilot-pull-request-reviewer on all four conditions in #756.

## Solution

List both slugs. `8gcr-renovate[bot]` is the app that actually opens PRs today; `renovate[bot]` covers the hosted app if it ever wakes up.

## Why this way

This is belt-and-braces, not the fix. Two Renovate installations on one repo means duplicate dependency PRs, which is the problem worth preventing — the preview builds are just the visible symptom. The real remedy is uninstalling the Mend app; this guard is what stands in until that happens, and it stays harmless afterwards.

## Not applied

cubic P3 on #756 asked for the slug to come from a repo variable (`RENOVATE_APP_SLUG`) rather than being hardcoded. Skipped:

- An unset or mistyped variable makes `fromJSON(vars.X)` empty, which fails *open* — the same silent mismatch the suggestion is trying to prevent, just with a different trigger.
- Its rationale was keeping `pr-ci.yml` and `renovate.yml` in sync, but `renovate.yml` authenticates by `client-id` and contains no slug to sync with.
- The scenario is already closed: the app exists with slug `8gcr-renovate`, and the skip is confirmed working — #757 reports all four jobs as `skipping`.
