### PR TITLE
ci: Gate go.sum drift, scope Renovate to main, add 7d cooldown

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -4,10 +4,10 @@
     "config:recommended"
   ],
   "baseBranchPatterns": [
-    "main",
-    "release-2.15"
+    "main"
   ],
   "timezone": "Etc/UTC",
+  "minimumReleaseAge": "7 days",
   "dependencyDashboard": true,
   "configMigration": true,
   "semanticCommits": "enabled",
@@ -25,7 +25,8 @@
   "vulnerabilityAlerts": {
     "labels": [
       "security"
-    ]
+    ],
+    "minimumReleaseAge": null
   },
   "packageRules": [
     {

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -8,6 +8,7 @@
   ],
   "timezone": "Etc/UTC",
   "minimumReleaseAge": "7 days",
+  "minimumReleaseAgeBehaviour": "timestamp-optional",
   "dependencyDashboard": true,
   "configMigration": true,
   "semanticCommits": "enabled",

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -139,7 +139,7 @@
       "customType": "regex",
       "description": "Update versions.env Taskfile pins annotated with Renovate metadata",
       "managerFilePatterns": [
-        "//(^|/)versions\\.env$//"
+        "/(^|/)versions\\.env$/"
       ],
       "matchStrings": [
         "#\\s*renovate:\\s+datasource=(?<datasource>\\S+)\\s+depName=(?<depName>\\S+)(?:\\s+versioning=(?<versioning>\\S+))?(?:\\s+extractVersion=(?<extractVersion>\\S+))?\\s*\\n[A-Z_]+=(?<currentValue>\\S+)"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -200,7 +200,7 @@ jobs:
 
       - name: Check go.mod and go.sum are tidy
         run: |
-          if ! git diff --exit-code src/go.mod src/go.sum; then
+          if ! git diff --exit-code -- src/go.mod src/go.sum; then
             echo "::error::src/go.mod or src/go.sum is not tidy. Run 'task build:tidy' and commit the result."
             exit 1
           fi

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -168,3 +168,39 @@ jobs:
         run: |
           redis-cli -h localhost -p 6379 shutdown nosave 2>/dev/null || true
           docker rm -f "${SVC_PREFIX}-postgres" 2>/dev/null || true
+
+  # --------------------------------------------------------------------------
+  # go.mod / go.sum drift — the build path runs `task build:tidy` before
+  # compiling, so a stale go.sum is silently repaired on the runner and never
+  # committed. Without this gate a go.mod bump with no matching go.sum entry
+  # produces green image builds.
+  # --------------------------------------------------------------------------
+  go-mod-tidy:
+    name: go.mod / go.sum tidy
+    runs-on: ubuntu-26.04
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - uses: ./.github/actions/setup-go-cached
+        with:
+          go-version-file: src/go.mod
+          go-sum-path: src/go.sum
+
+      - uses: ./.github/actions/setup-task
+        with:
+          version: 3.49.1
+
+      # build:tidy depends on gen-apis. The generated swagger packages are
+      # gitignored, and without them `go mod tidy` demotes the go-openapi
+      # direct requirements to // indirect, which would fail this gate falsely.
+      - name: Run task build:tidy
+        run: task build:tidy
+
+      - name: Check go.mod and go.sum are tidy
+        run: |
+          if ! git diff --exit-code src/go.mod src/go.sum; then
+            echo "::error::src/go.mod or src/go.sum is not tidy. Run 'task build:tidy' and commit the result."
+            exit 1
+          fi


### PR DESCRIPTION
## Problem

Renovate's artifact step runs `go get -t ./...`, which fails because `src/server/v2.0/models/` and `src/server/v2.0/restapi/` are gitignored and only exist after `task build:gen-apis`. So Renovate opens gomod PRs with only `src/go.mod` and a stale `src/go.sum` (see #757, #759). Unit tests and govulncheck fail on those PRs, but all 14 image builds, merge, sign and preview-comment pass, because the build path runs `task build:tidy` first and silently repairs go.sum on the runner. A go.mod/go.sum mismatch cannot fail the build pipeline today.

Three more config issues: Renovate targets `release-2.15`, which is maintained by backport; new releases are adopted with no cooldown window; and PR #760's config migration doubled the regex delimiters in `customManagers[0].managerFilePatterns` (`//(^|/)versions\.env$//`), so the versions.env manager matches nothing. Verified with renovate 44.46.5: migrated pattern extracts 0 files, corrected pattern extracts 29 annotated pins. All of them have been unmanaged since that merge.

## Change

- New `go-mod-tidy` job: `task build:tidy`, then `git diff --exit-code -- src/go.mod src/go.sum` with an actionable failure message. `build:tidy` is used rather than bare `go mod tidy` because `go mod tidy -e` without the generated code demotes `go-openapi/loads`, `spec` and `validate` to `// indirect`, corrupting go.mod; `build:tidy` already depends on `gen-apis` and keeps the gate coupled to how the build tidies.
- `baseBranchPatterns` reduced to `["main"]`.
- `minimumReleaseAge: "7 days"` with `minimumReleaseAgeBehaviour: "timestamp-optional"`; the default `timestamp-required` marks releases without a timestamp pending indefinitely. `vulnerabilityAlerts.minimumReleaseAge: null` so security fixes are not delayed.
- versions.env regex delimiters fixed.

## Alternatives rejected

- Cooldown scoped to `gomod` only: Actions and base images are where recent supply chain compromises landed; `timestamp-optional` handles the suppression risk without shrinking coverage.
- `paths:` filter on the tidy job: hand-written go.mod drift usually starts in a `.go` file matching no such path. The job runs in 1m24s alongside longer jobs, adding no wall clock time.

## Consequences

- Renovate's artifact step is not fixed here. gomod PRs will keep arriving without go.sum and will now fail loudly at the gate. The real fix (`postUpgradeTasks` running `task build:tidy` in the Renovate container, with `allowedCommands` on the runner) is a separate PR.
- The restored versions.env manager will emit a burst of pin updates on its next run.
- #759 (release-2.15) becomes orphaned; it will not be rebased or closed automatically.

## Verification

- Gate is a no-op on a clean tree; with a `gorilla/csrf` bump and unchanged go.sum it produces a 2 line diff and exits 1. Ran green on this PR.
- Renovate 44.46.5 dry run (`--platform=local --dry-run=lookup`) still computes Actions and Go update branches; held releases show as `pendingVersions` rather than disappearing.
