### PR TITLE
ci: Run Renovate daily and let it update its own version

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -2,9 +2,11 @@ name: Renovate
 
 on:
   schedule:
-    # 01:00 UTC on odd days of month (~every 2 days), inside the 0-3 UTC
-    # windows in renovate.json; consecutive runs at 31st -> 1st are fine
-    - cron: "0 1 */2 * *"
+    # Daily at 01:00 UTC. Cadence is owned by the schedules in renovate.json,
+    # which all sit in the 0-3 UTC window; this only has to open that window.
+    # A day-of-month cron (*/2) lands on odd dates, so the Monday-scheduled
+    # rules there would have fired on only half the Mondays in a year.
+    - cron: "0 1 * * *"
   workflow_dispatch:
 
 permissions: {}
@@ -18,6 +20,13 @@ jobs:
     runs-on: ubuntu-26.04
     timeout-minutes: 60
     steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Load versions
+        run: grep -E '^[A-Z_]+=' versions.env >> "$GITHUB_ENV"
+
       # Dedicated Renovate app, not 8gcr-sync: the sync app declares only
       # actions/checks/statuses read + contents/pull-requests write, so the
       # downscope below can never be satisfied by it. The app installed for
@@ -44,7 +53,7 @@ jobs:
         uses: renovatebot/github-action@5402b206248e5a8c8427a15102702eb9c1793efc # v46.2.4
         with:
           token: ${{ steps.app-token.outputs.token }}
-          renovate-version: 44.46.5
+          renovate-version: ${{ env.RENOVATE_VERSION }}
         env:
           RENOVATE_REPOSITORIES: container-registry/harbor-next
           LOG_LEVEL: info

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -19,13 +19,23 @@ jobs:
   renovate:
     runs-on: ubuntu-26.04
     timeout-minutes: 60
+    # Only to read versions.env. Renovate itself acts through the app token
+    # minted below, never through GITHUB_TOKEN.
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
 
-      - name: Load versions
-        run: grep -E '^[A-Z_]+=' versions.env >> "$GITHUB_ENV"
+      # Read as a step output rather than into GITHUB_ENV: anything exported
+      # as RENOVATE_* would be picked up by Renovate as a config override.
+      - name: Read Renovate version
+        id: versions
+        run: |
+          version="$(grep -E '^RENOVATE_VERSION=' versions.env | cut -d= -f2)"
+          test -n "${version}" || { echo "::error::RENOVATE_VERSION missing from versions.env"; exit 1; }
+          echo "renovate=${version}" >> "$GITHUB_OUTPUT"
 
       # Dedicated Renovate app, not 8gcr-sync: the sync app declares only
       # actions/checks/statuses read + contents/pull-requests write, so the
@@ -53,7 +63,7 @@ jobs:
         uses: renovatebot/github-action@5402b206248e5a8c8427a15102702eb9c1793efc # v46.2.4
         with:
           token: ${{ steps.app-token.outputs.token }}
-          renovate-version: ${{ env.RENOVATE_VERSION }}
+          renovate-version: ${{ steps.versions.outputs.renovate }}
         env:
           RENOVATE_REPOSITORIES: container-registry/harbor-next
           LOG_LEVEL: info

--- a/versions.env
+++ b/versions.env
@@ -67,3 +67,7 @@ TRIVY_BASE_IMAGE_VERSION=0.72.0
 HARBOR_SCANNER_TRIVY_VERSION=v0.39.1
 # renovate: datasource=docker depName=ghcr.io/fivexl/lprobe versioning=docker
 LPROBE_VERSION=0.1.9
+
+# CI tooling
+# renovate: datasource=npm depName=renovate
+RENOVATE_VERSION=44.46.5


### PR DESCRIPTION
## Problem

Two defects in how the Renovate runner is scheduled and versioned, both found by running renovate 44.46.5 locally against this repo.

The workflow cron was `0 1 */2 * *`. A day-of-month step lands on odd dates, and four packageRules in `renovate.json` are scheduled `* 0-3 * * 1`, Mondays only: Go majors, versions.env majors, GitHub Actions and Docker. A Monday has to coincide with an odd date for any of them to be evaluated. Over the coming year that is 26 of 52 Mondays, with gaps of up to 21 days, so those four rules ran at roughly half their intended cadence and irregularly.

`renovate-version: 44.46.5` was a bare workflow input carrying no `# renovate:` annotation, and there were no such annotations anywhere in `.github/workflows/`. The `renovatebot/github-action` SHA is kept current by the github-actions manager, but the Renovate version it installs was frozen at whatever was typed in #750. It is now five minors behind.

## Change

`cron: "0 1 * * *"`. The schedules in `renovate.json` all sit in the 0-3 UTC window, so the workflow only has to open that window daily and let the config own the cadence. That is what those schedules are for.

`RENOVATE_VERSION` moves to `versions.env` with a `datasource=npm depName=renovate` annotation, picked up by the custom manager already defined in `renovate.json` and restored in #763. The workflow gains a checkout plus the same `Load versions` step `pr-ci.yml` uses, and reads `${{ env.RENOVATE_VERSION }}`.

## Consequences

The runner goes from every other day to daily. On a public repo the Actions minutes are free, and a run is roughly 3 minutes.

Renovate now proposes its own upgrades, so a bad Renovate release can arrive by PR. The 7 day cooldown from #763 applies to it like any other dependency, and the PR is reviewable before merge.

## Verification

Local dry run (`--platform=local`) against this branch, renovate 44.46.5:

- Extraction picks up `depName: renovate` from `versions.env` via the regex manager.
- Lookup proposes `44.46.5 -> 44.51.0`, `updateType: minor`.
- zizmor is unchanged from `main` on this file: no findings, 2 suppressed.
