### PR TITLE
fix(ci): Stop Renovate bumping past the gorilla/csrf pin

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -31,6 +31,16 @@
   },
   "packageRules": [
     {
+      "description": "gorilla/csrf 1.7.3 tightens Referer validation and breaks logins over plain HTTP (goharbor/harbor#22010). Upstream shipped it in 2.12.3 and reverted to 1.7.2 in 2.13.0; src/go.mod carries the pin. Hold the pin until the deployment story for HTTP-only installs is settled.",
+      "matchDatasources": [
+        "go"
+      ],
+      "matchPackageNames": [
+        "github.com/gorilla/csrf"
+      ],
+      "allowedVersions": "<=1.7.2"
+    },
+    {
       "description": "Update Go dependencies daily for non-major releases",
       "matchManagers": [
         "gomod"


### PR DESCRIPTION
## Problem

`src/go.mod` pins `github.com/gorilla/csrf` to v1.7.2 with a comment pointing at goharbor/harbor#22010. Renovate has no rule respecting that pin, so a vulnerability alert for GHSA-rq77-p4h8-4crw made it open #757 against `main` and #759 against `release-2.15`, both bumping to v1.7.3.

The pin is load-bearing, not stale. Upstream go.mod history:

- harbor v2.12.2: `gorilla/csrf v1.7.2`
- harbor v2.12.3: `gorilla/csrf v1.7.3`, and issue #22010 reports logins failing over plain HTTP
- harbor v2.13.0: back to `v1.7.2`, with the comment this repo still carries

The fix in v1.7.3 is stricter Referer validation, which is exactly what breaks logins on HTTP-only installs. Taking the security fix means taking the regression upstream already reverted.

v1.7.3 is not a clean landing spot in any case: GHSA-82ff-hg59-8x73 covers `<= 1.7.3` and has no patched version, so the package stays vulnerable either way.

## Change

A packageRule with `allowedVersions: "<=1.7.2"` for `github.com/gorilla/csrf`, carrying the reasoning in its `description` so the next person does not have to reconstruct it.

## Consequences

Renovate stops proposing this upgrade, including from vulnerability alerts, so GHSA-rq77-p4h8-4crw stays unpatched here by choice. That is the same position upstream Harbor holds today. Once merged, Renovate should close #757 on its next run; #759 targets `release-2.15`, which #763 removed from `baseBranchPatterns`, so it will not be touched and should be closed by hand.

Lifting the pin is a real decision, not a version bump: it needs HTTP-only deployments either dropped or documented as unsupported first. The rule is the place to record that when it happens.

## Verification

Local dry run (`--platform=local --dry-run=lookup`, renovate 44.46.5) reports `"updates": []` for `github.com/gorilla/csrf` at `currentValue: v1.7.2`. Config passes `renovate-config-validator`.
