### PR TITLE
fix: Make GIT_COMMIT override reach included taskfiles for build stamping

### DIFF
--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -95,7 +95,7 @@ jobs:
         env:
           COMPONENT: ${{ matrix.component }}
           PLATFORM_PAIR: ${{ env.PLATFORM_PAIR }}
-        run: task build:binary:${COMPONENT}:${PLATFORM_PAIR} GIT_COMMIT="${GITHUB_SHA:0:8}"
+        run: task build:binary:${COMPONENT}:${PLATFORM_PAIR} BASE_GIT_COMMIT="${GITHUB_SHA:0:8}"
 
       - name: Compile image helper binaries
         env:

--- a/.github/workflows/publish-images.yml
+++ b/.github/workflows/publish-images.yml
@@ -137,7 +137,7 @@ jobs:
           COMPONENT: ${{ matrix.component }}
           PLATFORM_PAIR: ${{ env.PLATFORM_PAIR }}
           CHECKOUT_REF: ${{ inputs.checkout_ref }}
-        run: task build:binary:${COMPONENT}:${PLATFORM_PAIR} GIT_COMMIT="$(git rev-parse --short=8 "$CHECKOUT_REF")"
+        run: task build:binary:${COMPONENT}:${PLATFORM_PAIR} BASE_GIT_COMMIT="$(git rev-parse --short=8 "$CHECKOUT_REF")"
 
       - name: Compile image helper binaries
         env:

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -10,8 +10,12 @@ dotenv:
   - versions.env
 
 vars:
-  GIT_COMMIT:
+  DEFAULT_GIT_COMMIT:
     sh: git rev-parse --short=8 HEAD || echo "unknown"
+  # CLI overrides of root-defined vars don't propagate into included
+  # taskfiles, so callers override via BASE_GIT_COMMIT (same pattern as
+  # RELEASE_VERSION → VERSION).
+  GIT_COMMIT: '{{.BASE_GIT_COMMIT | default .DEFAULT_GIT_COMMIT}}'
   DEFAULT_VERSION:
     sh: cat VERSION 2>/dev/null | tr -d '\n' || echo "dev"
   VERSION: '{{.RELEASE_VERSION | default .DEFAULT_VERSION}}'

--- a/taskfile/release-images-local.yml
+++ b/taskfile/release-images-local.yml
@@ -11,6 +11,10 @@ tasks:
     desc: "Build and push unsigned local release images, then verify both architectures"
     requires:
       vars: [RELEASE_VERSION, IMAGE_TAG]
+    vars:
+      # Base commit captured before apply-patches; jj-first since git HEAD is wrong in non-default jj workspaces.
+      BASE_GIT_COMMIT:
+        sh: jj log -r @- --no-graph -T 'commit_id.short(8)' 2>/dev/null || git rev-parse --short=8 HEAD || echo "unknown"
     preconditions:
       - sh: command -v task >/dev/null 2>&1
         msg: "Task is required"
@@ -28,6 +32,7 @@ tasks:
         task image:all-images
         RELEASE_VERSION="{{.RELEASE_VERSION}}"
         IMAGE_TAG="{{.IMAGE_TAG}}"
+        BASE_GIT_COMMIT="{{.BASE_GIT_COMMIT}}"
         REGISTRY_ADDRESS="{{.LOCAL_REGISTRY_ADDRESS}}"
         REGISTRY_PROJECT="{{.LOCAL_REGISTRY_PROJECT}}"
         PLATFORMS="{{.LOCAL_PLATFORMS}}"


### PR DESCRIPTION
## Problem

Harbor About page showed a commit hash resolving to the applied commercial-patch commit.

Two layers:

1. **CLI var overrides of root-defined vars do not propagate into included taskfiles** (Task 3.53.1). `GIT_COMMIT` is defined in root `Taskfile.yml` vars, so the `GIT_COMMIT=...` overrides in `publish-images.yml` (added 2026-07-28) and `pr-ci.yml` were **silently ignored** — `VERSION_LDFLAGS` in `taskfile/build.yml` always stamped `git rev-parse HEAD`, which after `apply-patches` sits on the patch commits. Reproducible: `task build:binary:core:linux-amd64 GIT_COMMIT=SENT --dry` stamps HEAD, not SENT; while a CLI var *not* defined at root (e.g. `RELEASE_VERSION`) propagates fine.
2. `task release-images-local` applied patches, then started a fresh task process for `image:all-images`, which re-resolved HEAD on top of the patch commits.

## Fix

- Root `Taskfile.yml`: `GIT_COMMIT: {{.BASE_GIT_COMMIT | default .DEFAULT_GIT_COMMIT}}` — override knob undefined at root, so it propagates into includes. Same pattern as `RELEASE_VERSION` → `VERSION`. Existing `GIT_COMMIT` → `VERSION_LDFLAGS` plumbing untouched.
- `publish-images.yml` / `pr-ci.yml`: pass `BASE_GIT_COMMIT=` instead of `GIT_COMMIT=`.
- `release-images-local.yml`: capture base commit before `apply-patches` (jj-first — raw git HEAD also resolves the *default* workspace in non-default jj workspaces — with git fallback) and pass it to `image:all-images`.

## Verification

- `task build:binary:core:linux-amd64 BASE_GIT_COMMIT=56398345` → ldflags `-X ...version.GitCommit=56398345`; `strings bin/linux-amd64/core` contains `56398345`.
- `task image:exporter BASE_GIT_COMMIT=... --dry` → `--build-arg git_commit=56398345`.
- `task release-images-local ... --dry` → passes `BASE_GIT_COMMIT="<pre-patch base>"` to `image:all-images`.