### PR TITLE
ci: Rename 0004-identity-providers patch to 0004-federated-robot-accounts

### DIFF
--- a/taskfile/commercial-patches
+++ b/taskfile/commercial-patches
@@ -2,7 +2,7 @@
 0001-commercial-feature-gate
 0002-branding
 0003-sftp-replication
-0004-identity-providers
+0004-federated-robot-accounts
 0005-pgx-monitoring
 0006-aws-rds-iam-auth
 0007-multi-format-artifacts


### PR DESCRIPTION
Renames the `0004` commercial patch entry to match the feature naming: the feature is **federated robot accounts**; the federated identity provider connection is the means to create them.

- `0004-federated-robot-accounts` already exists on the patch remote at the same commit (`eb3d6fc`) as `0004-identity-providers`, so `task apply-patches` / `task release-ready` keep working with either entry
- The naming rename inside the patch itself is container-registry/8gcr#356 (base already retargeted to the new branch)
- After this merges, the old `0004-identity-providers` and `release-2.15/0004-identity-providers` branches can be cleaned up (release-2.15 branch rename to be handled with its own commercial-patches file if applicable)

Taskfile-only change → `ci:`, no version bump.