### PR TITLE
ci: Rename release-2.15 0004 patch to federated-robot-accounts

### DIFF
--- a/taskfile/commercial-patches
+++ b/taskfile/commercial-patches
@@ -2,6 +2,6 @@
 release-2.15/0001-commercial-feature-gate
 release-2.15/0002-branding
 release-2.15/0003-sftp-replication
-release-2.15/0004-identity-providers
+release-2.15/0004-federated-robot-accounts
 release-2.15/0005-pgx-monitoring
 release-2.15/0006-aws-rds-iam-auth


### PR DESCRIPTION
Follow-up to container-registry/harbor-next#769 for the release-2.15 patch set: renames the `0004` entry to `release-2.15/0004-federated-robot-accounts`.

- The renamed branch already exists on the patch remote at the same commit (`71ee753`) as `release-2.15/0004-identity-providers`
- After this merges, the old `release-2.15/0004-identity-providers` branch can be deleted
- Branch-name rename only — whether the naming changes inside the patch (container-registry/8gcr#356) get backported to release-2.15 is a separate decision

Taskfile-only change → `ci:`, no version bump.