### PR TITLE
refactor: Rename Helm chart from harbor-next to harbor

### DIFF
--- a/.github/workflows/publish-chart.yml
+++ b/.github/workflows/publish-chart.yml
@@ -167,7 +167,7 @@ jobs:
         # contains a sha256 digest the capture below would happily match.
         run: |
           set -euo pipefail
-          helm push "dist/harbor-next-${VERSION}.tgz" \
+          helm push "dist/harbor-${VERSION}.tgz" \
             "oci://${REGISTRY_ADDRESS}/${REGISTRY_PROJECT}/charts" 2>&1 | tee push.log
           digest=$(grep -o 'sha256:[a-f0-9]\{64\}' push.log | head -1)
           if [ -z "$digest" ]; then
@@ -181,7 +181,7 @@ jobs:
           CHART_DIGEST: ${{ steps.push.outputs.digest }}
         run: |
           cosign sign --yes \
-            "${REGISTRY_ADDRESS}/${REGISTRY_PROJECT}/charts/harbor-next@${CHART_DIGEST}"
+            "${REGISTRY_ADDRESS}/${REGISTRY_PROJECT}/charts/harbor@${CHART_DIGEST}"
 
       - name: Install oras
         uses: oras-project/setup-oras@1d808f7d7f6995cc68b7bf507bfe5c5446e1dc9d # v2.0.1
@@ -195,6 +195,6 @@ jobs:
         # verified publisher. See deploy/chart/artifacthub-repo.yml.
         working-directory: deploy/chart
         run: |
-          oras push "${REGISTRY_ADDRESS}/${REGISTRY_PROJECT}/charts/harbor-next:artifacthub.io" \
+          oras push "${REGISTRY_ADDRESS}/${REGISTRY_PROJECT}/charts/harbor:artifacthub.io" \
             --config /dev/null:application/vnd.cncf.artifacthub.config.v1+yaml \
             artifacthub-repo.yml:application/vnd.cncf.artifacthub.repository-metadata.layer.v1.yaml

--- a/deploy/chart/CONTRIBUTING.md
+++ b/deploy/chart/CONTRIBUTING.md
@@ -309,7 +309,7 @@ The chart releases on its own line, independent of the app (repo)
 version. A dedicated release-please instance, configured by
 `release-please-config-chart.json` and `.release-please-manifest-chart.json`,
 watches commits scoped to `deploy/chart/` and opens a
-`chore: release harbor-next chart X.Y.Z` PR (labelled `chart-release:
+`chore: release harbor chart X.Y.Z` PR (labelled `chart-release:
 pending`). Merging that PR tags `chart-vX.Y.Z`, writes the new `version`
 into `Chart.yaml`, updates `deploy/chart/CHANGELOG.md`, and triggers the
 `chart` job in `release-please.yml`, which packages, pushes, cosign-signs,

--- a/deploy/chart/Chart.yaml
+++ b/deploy/chart/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-name: harbor-next
+name: harbor
 description: A modern, production-ready Helm chart for [Harbor
   Next](https://github.com/container-registry/harbor-next) - the cloud-native
   container registry for Kubernetes.

--- a/deploy/chart/README.md
+++ b/deploy/chart/README.md
@@ -1,4 +1,4 @@
-# harbor-next
+# harbor
 
 ![Version: 2.0.0](https://img.shields.io/badge/Version-2.0.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v2.15.0](https://img.shields.io/badge/AppVersion-v2.15.0-informational?style=flat-square)
 
@@ -11,7 +11,7 @@ A modern, production-ready Helm chart for [Harbor Next](https://github.com/conta
 kubectl create secret generic my-harbor-db \
   --from-literal=POSTGRESQL_PASSWORD='your-strong-password'
 
-helm install my-harbor oci://8gears.container-registry.com/8gcr/charts/harbor-next \
+helm install my-harbor oci://8gears.container-registry.com/8gcr/charts/harbor \
   --set externalURL=https://harbor.example.com \
   --set database.host=my-postgres.example.com \
   --set database.existingSecret=my-harbor-db
@@ -147,7 +147,7 @@ kubectl -n harbor create secret generic my-harbor-db \
 kubectl -n harbor create secret generic my-harbor-admin \
   --from-literal=HARBOR_ADMIN_PASSWORD='your-strong-admin-password'
 
-helm install my-harbor oci://8gears.container-registry.com/8gcr/charts/harbor-next \
+helm install my-harbor oci://8gears.container-registry.com/8gcr/charts/harbor \
   --namespace harbor \
   --set externalURL=https://harbor.example.com \
   --set database.host=postgres.example.com \
@@ -158,7 +158,7 @@ helm install my-harbor oci://8gears.container-registry.com/8gcr/charts/harbor-ne
 ### With Values File
 
 ```bash
-helm install my-harbor oci://8gears.container-registry.com/8gcr/charts/harbor-next \
+helm install my-harbor oci://8gears.container-registry.com/8gcr/charts/harbor \
   --namespace harbor \
   --create-namespace \
   -f values-production.yaml

--- a/deploy/chart/README.md.gotmpl
+++ b/deploy/chart/README.md.gotmpl
@@ -12,7 +12,7 @@
 kubectl create secret generic my-harbor-db \
   --from-literal=POSTGRESQL_PASSWORD='your-strong-password'
 
-helm install my-harbor oci://8gears.container-registry.com/8gcr/charts/harbor-next \
+helm install my-harbor oci://8gears.container-registry.com/8gcr/charts/harbor \
   --set externalURL=https://harbor.example.com \
   --set database.host=my-postgres.example.com \
   --set database.existingSecret=my-harbor-db
@@ -148,7 +148,7 @@ kubectl -n harbor create secret generic my-harbor-db \
 kubectl -n harbor create secret generic my-harbor-admin \
   --from-literal=HARBOR_ADMIN_PASSWORD='your-strong-admin-password'
 
-helm install my-harbor oci://8gears.container-registry.com/8gcr/charts/harbor-next \
+helm install my-harbor oci://8gears.container-registry.com/8gcr/charts/harbor \
   --namespace harbor \
   --set externalURL=https://harbor.example.com \
   --set database.host=postgres.example.com \
@@ -159,7 +159,7 @@ helm install my-harbor oci://8gears.container-registry.com/8gcr/charts/harbor-ne
 ### With Values File
 
 ```bash
-helm install my-harbor oci://8gears.container-registry.com/8gcr/charts/harbor-next \
+helm install my-harbor oci://8gears.container-registry.com/8gcr/charts/harbor \
   --namespace harbor \
   --create-namespace \
   -f values-production.yaml

--- a/deploy/chart/artifacthub-repo.yml
+++ b/deploy/chart/artifacthub-repo.yml
@@ -4,12 +4,12 @@
 # NOT part of the chart package (.helmignore). The release pipeline
 # pushes it as a separate OCI artifact next to the chart:
 #
-#   oras push <registry>/8gcr/charts/harbor-next:artifacthub.io \
+#   oras push <registry>/8gcr/charts/harbor:artifacthub.io \
 #     --config /dev/null:application/vnd.cncf.artifacthub.config.v1+yaml \
 #     artifacthub-repo.yml:application/vnd.cncf.artifacthub.repository-metadata.layer.v1.yaml
 #
 # After adding the repository on artifacthub.io (kind: Helm, URL:
-# oci://8gears.container-registry.com/8gcr/charts/harbor-next) under the
+# oci://8gears.container-registry.com/8gcr/charts/harbor) under the
 # container-registry organization, set repositoryID to the ID Artifact
 # Hub assigns to enable ownership metadata / the verified publisher badge.
 #

--- a/deploy/chart/docs/MIGRATION.md
+++ b/deploy/chart/docs/MIGRATION.md
@@ -1,3 +1,30 @@
+# Migration
+
+## Chart rename: `harbor-next` → `harbor` (chart v3.0.0)
+
+As of chart 3.0.0 the chart artifact is named `harbor`. This affects existing
+users of this chart (installed as `harbor-next` ≤ 2.0.0):
+
+- **OCI reference changed.** The chart now publishes to
+  `oci://8gears.container-registry.com/8gcr/charts/harbor`. The old
+  `.../charts/harbor-next` path receives no further releases — update any
+  `helm install`/`helm upgrade` commands, Flux `OCIRepository` URLs, and
+  automation that pins the old path.
+- **Default resource names and selector labels changed.** Resource names and
+  the `app.kubernetes.io/name` label derive from the chart name, and label
+  selectors are immutable in Kubernetes. A plain `helm upgrade` of an existing
+  `harbor-next` release with the renamed chart is therefore rejected. To
+  upgrade in place, pin the old identity:
+
+  ```bash
+  helm upgrade <release> oci://8gears.container-registry.com/8gcr/charts/harbor \
+    --set nameOverride=harbor-next -f your-values.yaml
+  ```
+
+  `nameOverride: harbor-next` keeps every rendered name, label, and selector
+  identical to chart 2.0.0. Without it, plan a fresh install plus data
+  migration.
+
 # Migrating from goharbor/harbor-helm (v1.x)
 
 This guide covers migrating from the legacy

--- a/deploy/chart/docs/guide/k3s.md
+++ b/deploy/chart/docs/guide/k3s.md
@@ -21,14 +21,14 @@ Pull the Harbor Helm chart from the OCI registry.
 1. Pull the chart:
 
    ```bash
-   helm pull oci://8gears.container-registry.com/8gcr/charts/harbor-next
+   helm pull oci://8gears.container-registry.com/8gcr/charts/harbor
    ```
 
 2. Decompress the downloaded chart:
 
    ```bash
    tar xzvf harbor-*.tgz
-   cd harbor-next
+   cd harbor
    ```
 
 ## Prepare a Values File

--- a/deploy/chart/docs/guide/nutanix-kp.md
+++ b/deploy/chart/docs/guide/nutanix-kp.md
@@ -131,7 +131,7 @@ helm registry login 8gears.container-registry.com
 Pull the chart using the OCI reference:
 
 ```bash
-helm pull oci://8gears.container-registry.com/8gcr/charts/harbor-next
+helm pull oci://8gears.container-registry.com/8gcr/charts/harbor
 ```
 
 Decompress the downloaded chart:

--- a/deploy/chart/docs/guide/rancher.md
+++ b/deploy/chart/docs/guide/rancher.md
@@ -90,14 +90,14 @@ helm registry login 8gears.container-registry.com
 We pull the chart using the OCI reference:
 
 ```bash
-helm pull oci://8gears.container-registry.com/8gcr/charts/harbor-next
+helm pull oci://8gears.container-registry.com/8gcr/charts/harbor
 ```
 
 Decompress the downloaded chart:
 
 ```bash
 tar xzvf harbor-*.tgz
-cd harbor-next
+cd harbor
 ```
 
 The chart ships an RKE2/Rancher values file at

--- a/deploy/chart/example/airlock-microgateway/README.md
+++ b/deploy/chart/example/airlock-microgateway/README.md
@@ -62,7 +62,7 @@ kubectl -n harbor get gateway harbor -w
 ```
 
 The operator provisions an Envoy Deployment and a `LoadBalancer` Service named
-`harbor` in the `harbor` namespace. The chart's HTTPRoute (`harbor-harbor-next`)
+`harbor` in the `harbor` namespace. The chart's HTTPRoute (`harbor`)
 attaches to it and routes `/api/`, `/service/`, `/v2/`, `/c/`, `/chartrepo/` and `/`
 to `harbor-core`.
 

--- a/deploy/chart/example/airlock-microgateway/waf-premium.yaml
+++ b/deploy/chart/example/airlock-microgateway/waf-premium.yaml
@@ -27,4 +27,4 @@ spec:
   targetRefs:
     - group: gateway.networking.k8s.io
       kind: HTTPRoute
-      name: harbor-harbor-next   # the HTTPRoute emitted by the chart (release-name-core route)
+      name: harbor   # the HTTPRoute emitted by the chart (release-name-core route)

--- a/deploy/chart/example/aws-eks-irsa/README.md
+++ b/deploy/chart/example/aws-eks-irsa/README.md
@@ -51,12 +51,12 @@ All scripts accept these overrides:
 | `AWS_REGION` | `eu-central-1` | AWS region |
 | `CLUSTER_NAME` | `harbor-next-irsa` | EKS cluster name |
 | `NAMESPACE` | `harbor` | Kubernetes namespace |
-| `RELEASE_NAME` | `harbor-next` | Helm release name |
+| `RELEASE_NAME` | `harbor` | Helm release name |
 | `BUCKET_NAME` | `harbor-next-irsa-<ACCOUNT_ID>` | S3 bucket name |
 | `DB_CLUSTER_ID` | `harbor-next-aurora` | Aurora cluster identifier |
 | `DB_MASTER_PASSWORD` | (random) | Aurora master password |
 | `CHART_VERSION` | `2.0.0` | Helm chart version |
-| `CHART_REF` | `oci://8gears.container-registry.com/8gcr/charts/harbor-next` | Chart OCI reference |
+| `CHART_REF` | `oci://8gears.container-registry.com/8gcr/charts/harbor` | Chart OCI reference |
 | `KUBECONFIG_PATH` | `~/.kube/<CLUSTER_NAME>.yaml` | Kubeconfig file path |
 
 ## Quick Start
@@ -146,7 +146,7 @@ ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT ALL ON SEQUENCES TO harbor_iam_u
 ### 7. Deploy Harbor
 
 ```bash
-helm install harbor-next oci://8gears.container-registry.com/8gcr/charts/harbor-next \
+helm install harbor oci://8gears.container-registry.com/8gcr/charts/harbor \
   --version 2.0.0 -n harbor --create-namespace \
   -f values-aws-irsa.yaml \
   --set database.host=<AURORA_ENDPOINT> \
@@ -160,7 +160,7 @@ helm install harbor-next oci://8gears.container-registry.com/8gcr/charts/harbor-
 
 ```bash
 # Port-forward
-kubectl port-forward -n harbor svc/harbor-next-core 8443:443 &
+kubectl port-forward -n harbor svc/harbor-core 8443:443 &
 
 # Push/pull
 docker login localhost:8443 -u admin -p Harbor12345

--- a/deploy/chart/example/aws-eks-irsa/setup.sh
+++ b/deploy/chart/example/aws-eks-irsa/setup.sh
@@ -16,7 +16,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 AWS_REGION="${AWS_REGION:-eu-central-1}"
 CLUSTER_NAME="${CLUSTER_NAME:-harbor-next-irsa}"
 NAMESPACE="${NAMESPACE:-harbor}"
-RELEASE_NAME="${RELEASE_NAME:-harbor-next}"
+RELEASE_NAME="${RELEASE_NAME:-harbor}"
 
 DB_CLUSTER_ID="${DB_CLUSTER_ID:-harbor-next-aurora}"
 DB_INSTANCE_ID="${DB_INSTANCE_ID:-harbor-next-aurora-1}"
@@ -30,7 +30,7 @@ IAM_POLICY_NAME="${IAM_POLICY_NAME:-harbor-next-irsa}"
 IAM_ROLE_NAME="${IAM_ROLE_NAME:-harbor-next-irsa}"
 
 CHART_VERSION="${CHART_VERSION:-3.0.0}"
-CHART_REF="${CHART_REF:-oci://8gears.container-registry.com/8gcr/charts/harbor-next}"
+CHART_REF="${CHART_REF:-oci://8gears.container-registry.com/8gcr/charts/harbor}"
 
 KUBECONFIG_PATH="${KUBECONFIG_PATH:-${HOME}/.kube/${CLUSTER_NAME}.yaml}"
 export KUBECONFIG="${KUBECONFIG_PATH}"

--- a/deploy/chart/example/aws-eks-irsa/teardown.sh
+++ b/deploy/chart/example/aws-eks-irsa/teardown.sh
@@ -11,7 +11,7 @@ set -euo pipefail
 AWS_REGION="${AWS_REGION:-eu-central-1}"
 CLUSTER_NAME="${CLUSTER_NAME:-harbor-next-irsa}"
 NAMESPACE="${NAMESPACE:-harbor}"
-RELEASE_NAME="${RELEASE_NAME:-harbor-next}"
+RELEASE_NAME="${RELEASE_NAME:-harbor}"
 DB_CLUSTER_ID="${DB_CLUSTER_ID:-harbor-next-aurora}"
 DB_INSTANCE_ID="${DB_INSTANCE_ID:-harbor-next-aurora-1}"
 IAM_POLICY_NAME="${IAM_POLICY_NAME:-harbor-next-irsa}"

--- a/deploy/chart/example/aws-eks-irsa/values-aws-irsa.yaml
+++ b/deploy/chart/example/aws-eks-irsa/values-aws-irsa.yaml
@@ -7,7 +7,7 @@
 #   - IRSA role with S3 + rds-db:connect permissions
 #
 # Usage:
-#   helm install harbor-next oci://8gears.container-registry.com/8gcr/charts/harbor-next \
+#   helm install harbor oci://8gears.container-registry.com/8gcr/charts/harbor \
 #     --version 2.0.0 -n harbor --create-namespace \
 #     -f values-aws-irsa.yaml \
 #     --set database.host=<AURORA_ENDPOINT> \
@@ -19,7 +19,7 @@
 # Or skip --set-json by editing the `registry.config.storage.s3.bucket` field
 # directly in this file before installing.
 
-# Access via kubectl port-forward svc/harbor-next-core 8443:443 -n harbor
+# Access via kubectl port-forward svc/harbor-core 8443:443 -n harbor
 externalURL: "https://localhost:8443"
 # Demo password. For production, use `existingSecretAdminPassword` with a
 # Secret from AWS Secrets Manager, external-secrets, or SOPS.

--- a/deploy/chart/example/aws-eks-irsa/verify.sh
+++ b/deploy/chart/example/aws-eks-irsa/verify.sh
@@ -10,7 +10,7 @@ set -euo pipefail
 AWS_REGION="${AWS_REGION:-eu-central-1}"
 CLUSTER_NAME="${CLUSTER_NAME:-harbor-next-irsa}"
 NAMESPACE="${NAMESPACE:-harbor}"
-RELEASE_NAME="${RELEASE_NAME:-harbor-next}"
+RELEASE_NAME="${RELEASE_NAME:-harbor}"
 LOCAL_PORT="${LOCAL_PORT:-8443}"
 
 KUBECONFIG_PATH="${KUBECONFIG_PATH:-${HOME}/.kube/${CLUSTER_NAME}.yaml}"

--- a/deploy/chart/example/flux/README.md
+++ b/deploy/chart/example/flux/README.md
@@ -1,6 +1,6 @@
 # FluxCD (GitOps)
 
-End-to-end Flux setup for the `harbor-next` chart: `GitRepository` source,
+End-to-end Flux setup for the `harbor` chart: `GitRepository` source,
 `HelmRelease` with drift detection, and the secret-pinning values that make
 rendering **byte-for-byte deterministic** — the property GitOps engines
 need to avoid perpetual drift and surprise rollouts.

--- a/deploy/chart/example/flux/source.yaml
+++ b/deploy/chart/example/flux/source.yaml
@@ -22,10 +22,10 @@ spec:
 # apiVersion: source.toolkit.fluxcd.io/v1
 # kind: OCIRepository
 # metadata:
-#   name: harbor-next
+#   name: harbor
 #   namespace: harbor
 # spec:
 #   interval: 10m
-#   url: oci://8gears.container-registry.com/8gcr/charts/harbor-next
+#   url: oci://8gears.container-registry.com/8gcr/charts/harbor
 #   ref:
-#     semver: ">=2.0.0 <3.0.0"
+#     semver: ">=3.0.0 <4.0.0"

--- a/deploy/chart/example/openshift/README.md
+++ b/deploy/chart/example/openshift/README.md
@@ -28,7 +28,7 @@ PostgreSQL is included in the values file via `extraManifests` and will be deplo
 ```bash
 cd deploy/chart
 helm dependency build
-helm install harbor-next . -n vad1mo-dev -f example/openshift/values.yaml
+helm install harbor . -n vad1mo-dev -f example/openshift/values.yaml
 ```
 
 ## 3. Verify
@@ -41,7 +41,7 @@ oc get pods -n vad1mo-dev
 oc get route -n vad1mo-dev
 
 # Wait for all pods to be ready
-oc wait -n vad1mo-dev --for=condition=ready pod -l app.kubernetes.io/instance=harbor-next --timeout=300s
+oc wait -n vad1mo-dev --for=condition=ready pod -l app.kubernetes.io/instance=harbor --timeout=300s
 ```
 
 ## 4. Test Push and Pull
@@ -78,10 +78,10 @@ curl -s -u "admin:${HARBOR_ADMIN_PASSWORD}" \
 ## Cleanup
 
 ```bash
-helm uninstall harbor-next -n vad1mo-dev
+helm uninstall harbor -n vad1mo-dev
 # PVCs are not deleted by helm uninstall — clean up manually
 oc delete pvc -n vad1mo-dev postgres-data
-oc delete pvc -l app.kubernetes.io/instance=harbor-next -n vad1mo-dev
+oc delete pvc -l app.kubernetes.io/instance=harbor -n vad1mo-dev
 ```
 
 ## Troubleshooting
@@ -107,7 +107,7 @@ ttl.sh images expire after 1 hour for tags without a duration suffix. If pods sh
 
 ```bash
 task image:all-images IMAGE_REGISTRY=ttl.sh IMAGE_NAMESPACE=harbor-next
-oc delete pods -n vad1mo-dev -l app.kubernetes.io/instance=harbor-next
+oc delete pods -n vad1mo-dev -l app.kubernetes.io/instance=harbor
 ```
 
 ### Database Connection

--- a/deploy/chart/example/openshift/values.yaml
+++ b/deploy/chart/example/openshift/values.yaml
@@ -5,7 +5,7 @@
 #   - Images pushed to ttl.sh (or another accessible registry)
 #
 # Usage:
-#   helm install harbor-next . -n vad1mo-dev -f example/openshift/values.yaml
+#   helm install harbor . -n vad1mo-dev -f example/openshift/values.yaml
 
 # -- External URL (OpenShift route)
 externalURL: "https://harbor-next-vad1mo-dev.apps.rm1.0a51.p1.openshiftapps.com"

--- a/deploy/chart/tests/__snapshot__/snapshots_test.yaml.snap
+++ b/deploy/chart/tests/__snapshot__/snapshots_test.yaml.snap
@@ -6,19 +6,19 @@
       CHART_CACHE_DRIVER: redis
       CONFIG_PATH: /etc/core/app.conf
       CORE_LOCAL_URL: http://127.0.0.1:8080
-      CORE_URL: http://harbor-harbor-next-core
+      CORE_URL: http://harbor-core
       DATABASE_TYPE: postgresql
       EXT_ENDPOINT: https://harbor.example.com
       GDPR_AUDIT_LOGS: "false"
       GDPR_DELETE_USER: "false"
       HTTP_PROXY: ""
       HTTPS_PROXY: ""
-      JOBSERVICE_URL: http://harbor-harbor-next-jobservice
+      JOBSERVICE_URL: http://harbor-jobservice
       LOG_LEVEL: info
-      NO_PROXY: harbor-harbor-next-core,harbor-harbor-next-jobservice,harbor-harbor-next-database,harbor-harbor-next-registry,harbor-harbor-next-portal,harbor-harbor-next-trivy,harbor-harbor-next-exporter,127.0.0.1,localhost,.local,.internal
+      NO_PROXY: harbor-core,harbor-jobservice,harbor-database,harbor-registry,harbor-portal,harbor-trivy,harbor-exporter,127.0.0.1,localhost,.local,.internal
       PERMITTED_REGISTRY_TYPES_FOR_PROXY_CACHE: docker-hub,harbor,azure-acr,ali-acr,aws-ecr,google-gcr,docker-registry,github-ghcr,jfrog-artifactory
       PORT: "8080"
-      PORTAL_URL: http://harbor-harbor-next-portal
+      PORTAL_URL: http://harbor-portal
       POSTGRESQL_CONN_MAX_IDLE_TIME: 300s
       POSTGRESQL_CONN_MAX_LIFETIME: 30m
       POSTGRESQL_DATABASE: registry
@@ -29,13 +29,13 @@
       POSTGRESQL_SSLMODE: disable
       POSTGRESQL_USERNAME: postgres
       QUOTA_UPDATE_PROVIDER: db
-      REGISTRY_CONTROLLER_URL: http://harbor-harbor-next-registry:8080
+      REGISTRY_CONTROLLER_URL: http://harbor-registry:8080
       REGISTRY_CREDENTIAL_USERNAME: harbor_registry_user
       REGISTRY_STORAGE_PROVIDER_NAME: filesystem
-      REGISTRY_URL: http://harbor-harbor-next-registry:5000
+      REGISTRY_URL: http://harbor-registry:5000
       REPLICATION_ADAPTER_WHITELIST: ali-acr,aws-ecr,azure-acr,docker-hub,docker-registry,github-ghcr,google-gcr,harbor,huawei-SWR,jfrog-artifactory,tencent-tcr,volcengine-cr,sftp,harbor-satellite
-      TOKEN_SERVICE_URL: http://harbor-harbor-next-core/service/token
-      TRIVY_ADAPTER_URL: http://harbor-harbor-next-trivy:8080
+      TOKEN_SERVICE_URL: http://harbor-core/service/token
+      TRIVY_ADAPTER_URL: http://harbor-trivy:8080
       WITH_TRIVY: "false"
       app.conf: |
         appname = Harbor
@@ -50,10 +50,10 @@
         app.kubernetes.io/component: core
         app.kubernetes.io/instance: harbor
         app.kubernetes.io/managed-by: Helm
-        app.kubernetes.io/name: harbor-next
+        app.kubernetes.io/name: harbor
         app.kubernetes.io/version: v2.15.0
-        helm.sh/chart: harbor-next-2.0.0
-      name: harbor-harbor-next-core
+        helm.sh/chart: harbor-2.0.0
+      name: harbor-core
   2: |
     apiVersion: v1
     kind: Service
@@ -62,10 +62,10 @@
         app.kubernetes.io/component: core
         app.kubernetes.io/instance: harbor
         app.kubernetes.io/managed-by: Helm
-        app.kubernetes.io/name: harbor-next
+        app.kubernetes.io/name: harbor
         app.kubernetes.io/version: v2.15.0
-        helm.sh/chart: harbor-next-2.0.0
-      name: harbor-harbor-next-core
+        helm.sh/chart: harbor-2.0.0
+      name: harbor-core
     spec:
       ports:
         - name: http-web
@@ -79,7 +79,7 @@
       selector:
         app.kubernetes.io/component: core
         app.kubernetes.io/instance: harbor
-        app.kubernetes.io/name: harbor-next
+        app.kubernetes.io/name: harbor
       type: ClusterIP
   3: |
     apiVersion: v1
@@ -89,10 +89,10 @@
         app.kubernetes.io/component: exporter
         app.kubernetes.io/instance: harbor
         app.kubernetes.io/managed-by: Helm
-        app.kubernetes.io/name: harbor-next
+        app.kubernetes.io/name: harbor
         app.kubernetes.io/version: v2.15.0
-        helm.sh/chart: harbor-next-2.0.0
-      name: harbor-harbor-next-exporter
+        helm.sh/chart: harbor-2.0.0
+      name: harbor-exporter
     spec:
       ports:
         - name: http-metrics
@@ -102,7 +102,7 @@
       selector:
         app.kubernetes.io/component: exporter
         app.kubernetes.io/instance: harbor
-        app.kubernetes.io/name: harbor-next
+        app.kubernetes.io/name: harbor
       type: ClusterIP
   4: |
     apiVersion: networking.k8s.io/v1
@@ -111,10 +111,10 @@
       labels:
         app.kubernetes.io/instance: harbor
         app.kubernetes.io/managed-by: Helm
-        app.kubernetes.io/name: harbor-next
+        app.kubernetes.io/name: harbor
         app.kubernetes.io/version: v2.15.0
-        helm.sh/chart: harbor-next-2.0.0
-      name: harbor-harbor-next
+        helm.sh/chart: harbor-2.0.0
+      name: harbor
     spec:
       rules:
         - host: harbor.example.com
@@ -122,42 +122,42 @@
             paths:
               - backend:
                   service:
-                    name: harbor-harbor-next-core
+                    name: harbor-core
                     port:
                       number: 80
                 path: /api/
                 pathType: Prefix
               - backend:
                   service:
-                    name: harbor-harbor-next-core
+                    name: harbor-core
                     port:
                       number: 80
                 path: /service/
                 pathType: Prefix
               - backend:
                   service:
-                    name: harbor-harbor-next-core
+                    name: harbor-core
                     port:
                       number: 80
                 path: /v2/
                 pathType: Prefix
               - backend:
                   service:
-                    name: harbor-harbor-next-core
+                    name: harbor-core
                     port:
                       number: 80
                 path: /chartrepo/
                 pathType: Prefix
               - backend:
                   service:
-                    name: harbor-harbor-next-core
+                    name: harbor-core
                     port:
                       number: 80
                 path: /c/
                 pathType: Prefix
               - backend:
                   service:
-                    name: harbor-harbor-next-portal
+                    name: harbor-portal
                     port:
                       number: 80
                 path: /
@@ -166,25 +166,25 @@
     apiVersion: v1
     data:
       CACHE_ENABLED: "false"
-      CORE_URL: http://harbor-harbor-next-core
+      CORE_URL: http://harbor-core
       HTTP_PROXY: ""
       HTTPS_PROXY: ""
       LOG_LEVEL: info
-      NO_PROXY: harbor-harbor-next-core,harbor-harbor-next-jobservice,harbor-harbor-next-database,harbor-harbor-next-registry,harbor-harbor-next-portal,harbor-harbor-next-trivy,harbor-harbor-next-exporter,127.0.0.1,localhost,.local,.internal
-      REGISTRY_CONTROLLER_URL: http://harbor-harbor-next-registry:8080
+      NO_PROXY: harbor-core,harbor-jobservice,harbor-database,harbor-registry,harbor-portal,harbor-trivy,harbor-exporter,127.0.0.1,localhost,.local,.internal
+      REGISTRY_CONTROLLER_URL: http://harbor-registry:8080
       REGISTRY_CREDENTIAL_USERNAME: harbor_registry_user
-      REGISTRY_URL: http://harbor-harbor-next-registry:5000
-      TOKEN_SERVICE_URL: http://harbor-harbor-next-core/service/token
+      REGISTRY_URL: http://harbor-registry:5000
+      TOKEN_SERVICE_URL: http://harbor-core/service/token
     kind: ConfigMap
     metadata:
       labels:
         app.kubernetes.io/component: jobservice
         app.kubernetes.io/instance: harbor
         app.kubernetes.io/managed-by: Helm
-        app.kubernetes.io/name: harbor-next
+        app.kubernetes.io/name: harbor
         app.kubernetes.io/version: v2.15.0
-        helm.sh/chart: harbor-next-2.0.0
-      name: harbor-harbor-next-jobservice-env
+        helm.sh/chart: harbor-2.0.0
+      name: harbor-jobservice-env
   6: |
     apiVersion: v1
     data:
@@ -218,10 +218,10 @@
       labels:
         app.kubernetes.io/instance: harbor
         app.kubernetes.io/managed-by: Helm
-        app.kubernetes.io/name: harbor-next
+        app.kubernetes.io/name: harbor
         app.kubernetes.io/version: v2.15.0
-        helm.sh/chart: harbor-next-2.0.0
-      name: harbor-harbor-next-jobservice
+        helm.sh/chart: harbor-2.0.0
+      name: harbor-jobservice
   7: |
     apiVersion: v1
     kind: Service
@@ -230,10 +230,10 @@
         app.kubernetes.io/component: jobservice
         app.kubernetes.io/instance: harbor
         app.kubernetes.io/managed-by: Helm
-        app.kubernetes.io/name: harbor-next
+        app.kubernetes.io/name: harbor
         app.kubernetes.io/version: v2.15.0
-        helm.sh/chart: harbor-next-2.0.0
-      name: harbor-harbor-next-jobservice
+        helm.sh/chart: harbor-2.0.0
+      name: harbor-jobservice
     spec:
       ports:
         - name: http-jobservice
@@ -247,7 +247,7 @@
       selector:
         app.kubernetes.io/component: jobservice
         app.kubernetes.io/instance: harbor
-        app.kubernetes.io/name: harbor-next
+        app.kubernetes.io/name: harbor
       type: ClusterIP
   8: |
     apiVersion: v1
@@ -291,10 +291,10 @@
       labels:
         app.kubernetes.io/instance: harbor
         app.kubernetes.io/managed-by: Helm
-        app.kubernetes.io/name: harbor-next
+        app.kubernetes.io/name: harbor
         app.kubernetes.io/version: v2.15.0
-        helm.sh/chart: harbor-next-2.0.0
-      name: harbor-harbor-next-portal
+        helm.sh/chart: harbor-2.0.0
+      name: harbor-portal
   9: |
     apiVersion: v1
     kind: Service
@@ -303,10 +303,10 @@
         app.kubernetes.io/component: portal
         app.kubernetes.io/instance: harbor
         app.kubernetes.io/managed-by: Helm
-        app.kubernetes.io/name: harbor-next
+        app.kubernetes.io/name: harbor
         app.kubernetes.io/version: v2.15.0
-        helm.sh/chart: harbor-next-2.0.0
-      name: harbor-harbor-next-portal
+        helm.sh/chart: harbor-2.0.0
+      name: harbor-portal
     spec:
       ports:
         - name: http
@@ -316,7 +316,7 @@
       selector:
         app.kubernetes.io/component: portal
         app.kubernetes.io/instance: harbor
-        app.kubernetes.io/name: harbor-next
+        app.kubernetes.io/name: harbor
       type: ClusterIP
   10: |
     apiVersion: v1
@@ -378,10 +378,10 @@
       labels:
         app.kubernetes.io/instance: harbor
         app.kubernetes.io/managed-by: Helm
-        app.kubernetes.io/name: harbor-next
+        app.kubernetes.io/name: harbor
         app.kubernetes.io/version: v2.15.0
-        helm.sh/chart: harbor-next-2.0.0
-      name: harbor-harbor-next-registry
+        helm.sh/chart: harbor-2.0.0
+      name: harbor-registry
   11: |
     apiVersion: v1
     kind: Service
@@ -390,10 +390,10 @@
         app.kubernetes.io/component: registry
         app.kubernetes.io/instance: harbor
         app.kubernetes.io/managed-by: Helm
-        app.kubernetes.io/name: harbor-next
+        app.kubernetes.io/name: harbor
         app.kubernetes.io/version: v2.15.0
-        helm.sh/chart: harbor-next-2.0.0
-      name: harbor-harbor-next-registry
+        helm.sh/chart: harbor-2.0.0
+      name: harbor-registry
     spec:
       ports:
         - name: http-registry
@@ -411,7 +411,7 @@
       selector:
         app.kubernetes.io/component: registry
         app.kubernetes.io/instance: harbor
-        app.kubernetes.io/name: harbor-next
+        app.kubernetes.io/name: harbor
       type: ClusterIP
   12: |
     apiVersion: v1
@@ -422,10 +422,10 @@
       labels:
         app.kubernetes.io/instance: harbor
         app.kubernetes.io/managed-by: Helm
-        app.kubernetes.io/name: harbor-next
+        app.kubernetes.io/name: harbor
         app.kubernetes.io/version: v2.15.0
-        helm.sh/chart: harbor-next-2.0.0
-      name: harbor-harbor-next-registryctl
+        helm.sh/chart: harbor-2.0.0
+      name: harbor-registryctl
   13: |
     apiVersion: v1
     automountServiceAccountToken: false
@@ -435,10 +435,10 @@
         app.kubernetes.io/component: core
         app.kubernetes.io/instance: harbor
         app.kubernetes.io/managed-by: Helm
-        app.kubernetes.io/name: harbor-next
+        app.kubernetes.io/name: harbor
         app.kubernetes.io/version: v2.15.0
-        helm.sh/chart: harbor-next-2.0.0
-      name: harbor-harbor-next-core
+        helm.sh/chart: harbor-2.0.0
+      name: harbor-core
   14: |
     apiVersion: v1
     automountServiceAccountToken: false
@@ -448,10 +448,10 @@
         app.kubernetes.io/component: exporter
         app.kubernetes.io/instance: harbor
         app.kubernetes.io/managed-by: Helm
-        app.kubernetes.io/name: harbor-next
+        app.kubernetes.io/name: harbor
         app.kubernetes.io/version: v2.15.0
-        helm.sh/chart: harbor-next-2.0.0
-      name: harbor-harbor-next-exporter
+        helm.sh/chart: harbor-2.0.0
+      name: harbor-exporter
   15: |
     apiVersion: v1
     automountServiceAccountToken: false
@@ -461,10 +461,10 @@
         app.kubernetes.io/component: jobservice
         app.kubernetes.io/instance: harbor
         app.kubernetes.io/managed-by: Helm
-        app.kubernetes.io/name: harbor-next
+        app.kubernetes.io/name: harbor
         app.kubernetes.io/version: v2.15.0
-        helm.sh/chart: harbor-next-2.0.0
-      name: harbor-harbor-next-jobservice
+        helm.sh/chart: harbor-2.0.0
+      name: harbor-jobservice
   16: |
     apiVersion: v1
     automountServiceAccountToken: false
@@ -474,10 +474,10 @@
         app.kubernetes.io/component: portal
         app.kubernetes.io/instance: harbor
         app.kubernetes.io/managed-by: Helm
-        app.kubernetes.io/name: harbor-next
+        app.kubernetes.io/name: harbor
         app.kubernetes.io/version: v2.15.0
-        helm.sh/chart: harbor-next-2.0.0
-      name: harbor-harbor-next-portal
+        helm.sh/chart: harbor-2.0.0
+      name: harbor-portal
   17: |
     apiVersion: v1
     automountServiceAccountToken: false
@@ -487,10 +487,10 @@
         app.kubernetes.io/component: registry
         app.kubernetes.io/instance: harbor
         app.kubernetes.io/managed-by: Helm
-        app.kubernetes.io/name: harbor-next
+        app.kubernetes.io/name: harbor
         app.kubernetes.io/version: v2.15.0
-        helm.sh/chart: harbor-next-2.0.0
-      name: harbor-harbor-next-registry
+        helm.sh/chart: harbor-2.0.0
+      name: harbor-registry
 2. valkey with auth enabled:
   1: |
     apiVersion: v1
@@ -499,19 +499,19 @@
       CHART_CACHE_DRIVER: redis
       CONFIG_PATH: /etc/core/app.conf
       CORE_LOCAL_URL: http://127.0.0.1:8080
-      CORE_URL: http://harbor-harbor-next-core
+      CORE_URL: http://harbor-core
       DATABASE_TYPE: postgresql
       EXT_ENDPOINT: https://harbor.example.com
       GDPR_AUDIT_LOGS: "false"
       GDPR_DELETE_USER: "false"
       HTTP_PROXY: ""
       HTTPS_PROXY: ""
-      JOBSERVICE_URL: http://harbor-harbor-next-jobservice
+      JOBSERVICE_URL: http://harbor-jobservice
       LOG_LEVEL: info
-      NO_PROXY: harbor-harbor-next-core,harbor-harbor-next-jobservice,harbor-harbor-next-database,harbor-harbor-next-registry,harbor-harbor-next-portal,harbor-harbor-next-trivy,harbor-harbor-next-exporter,127.0.0.1,localhost,.local,.internal
+      NO_PROXY: harbor-core,harbor-jobservice,harbor-database,harbor-registry,harbor-portal,harbor-trivy,harbor-exporter,127.0.0.1,localhost,.local,.internal
       PERMITTED_REGISTRY_TYPES_FOR_PROXY_CACHE: docker-hub,harbor,azure-acr,ali-acr,aws-ecr,google-gcr,docker-registry,github-ghcr,jfrog-artifactory
       PORT: "8080"
-      PORTAL_URL: http://harbor-harbor-next-portal
+      PORTAL_URL: http://harbor-portal
       POSTGRESQL_CONN_MAX_IDLE_TIME: 300s
       POSTGRESQL_CONN_MAX_LIFETIME: 30m
       POSTGRESQL_DATABASE: registry
@@ -522,13 +522,13 @@
       POSTGRESQL_SSLMODE: disable
       POSTGRESQL_USERNAME: postgres
       QUOTA_UPDATE_PROVIDER: db
-      REGISTRY_CONTROLLER_URL: http://harbor-harbor-next-registry:8080
+      REGISTRY_CONTROLLER_URL: http://harbor-registry:8080
       REGISTRY_CREDENTIAL_USERNAME: harbor_registry_user
       REGISTRY_STORAGE_PROVIDER_NAME: filesystem
-      REGISTRY_URL: http://harbor-harbor-next-registry:5000
+      REGISTRY_URL: http://harbor-registry:5000
       REPLICATION_ADAPTER_WHITELIST: ali-acr,aws-ecr,azure-acr,docker-hub,docker-registry,github-ghcr,google-gcr,harbor,huawei-SWR,jfrog-artifactory,tencent-tcr,volcengine-cr,sftp,harbor-satellite
-      TOKEN_SERVICE_URL: http://harbor-harbor-next-core/service/token
-      TRIVY_ADAPTER_URL: http://harbor-harbor-next-trivy:8080
+      TOKEN_SERVICE_URL: http://harbor-core/service/token
+      TRIVY_ADAPTER_URL: http://harbor-trivy:8080
       WITH_TRIVY: "false"
       app.conf: |
         appname = Harbor
@@ -543,10 +543,10 @@
         app.kubernetes.io/component: core
         app.kubernetes.io/instance: harbor
         app.kubernetes.io/managed-by: Helm
-        app.kubernetes.io/name: harbor-next
+        app.kubernetes.io/name: harbor
         app.kubernetes.io/version: v2.15.0
-        helm.sh/chart: harbor-next-2.0.0
-      name: harbor-harbor-next-core
+        helm.sh/chart: harbor-2.0.0
+      name: harbor-core
   2: |
     apiVersion: v1
     kind: Service
@@ -555,10 +555,10 @@
         app.kubernetes.io/component: core
         app.kubernetes.io/instance: harbor
         app.kubernetes.io/managed-by: Helm
-        app.kubernetes.io/name: harbor-next
+        app.kubernetes.io/name: harbor
         app.kubernetes.io/version: v2.15.0
-        helm.sh/chart: harbor-next-2.0.0
-      name: harbor-harbor-next-core
+        helm.sh/chart: harbor-2.0.0
+      name: harbor-core
     spec:
       ports:
         - name: http-web
@@ -572,7 +572,7 @@
       selector:
         app.kubernetes.io/component: core
         app.kubernetes.io/instance: harbor
-        app.kubernetes.io/name: harbor-next
+        app.kubernetes.io/name: harbor
       type: ClusterIP
   3: |
     apiVersion: v1
@@ -582,10 +582,10 @@
         app.kubernetes.io/component: exporter
         app.kubernetes.io/instance: harbor
         app.kubernetes.io/managed-by: Helm
-        app.kubernetes.io/name: harbor-next
+        app.kubernetes.io/name: harbor
         app.kubernetes.io/version: v2.15.0
-        helm.sh/chart: harbor-next-2.0.0
-      name: harbor-harbor-next-exporter
+        helm.sh/chart: harbor-2.0.0
+      name: harbor-exporter
     spec:
       ports:
         - name: http-metrics
@@ -595,7 +595,7 @@
       selector:
         app.kubernetes.io/component: exporter
         app.kubernetes.io/instance: harbor
-        app.kubernetes.io/name: harbor-next
+        app.kubernetes.io/name: harbor
       type: ClusterIP
   4: |
     apiVersion: networking.k8s.io/v1
@@ -604,10 +604,10 @@
       labels:
         app.kubernetes.io/instance: harbor
         app.kubernetes.io/managed-by: Helm
-        app.kubernetes.io/name: harbor-next
+        app.kubernetes.io/name: harbor
         app.kubernetes.io/version: v2.15.0
-        helm.sh/chart: harbor-next-2.0.0
-      name: harbor-harbor-next
+        helm.sh/chart: harbor-2.0.0
+      name: harbor
     spec:
       rules:
         - host: harbor.example.com
@@ -615,42 +615,42 @@
             paths:
               - backend:
                   service:
-                    name: harbor-harbor-next-core
+                    name: harbor-core
                     port:
                       number: 80
                 path: /api/
                 pathType: Prefix
               - backend:
                   service:
-                    name: harbor-harbor-next-core
+                    name: harbor-core
                     port:
                       number: 80
                 path: /service/
                 pathType: Prefix
               - backend:
                   service:
-                    name: harbor-harbor-next-core
+                    name: harbor-core
                     port:
                       number: 80
                 path: /v2/
                 pathType: Prefix
               - backend:
                   service:
-                    name: harbor-harbor-next-core
+                    name: harbor-core
                     port:
                       number: 80
                 path: /chartrepo/
                 pathType: Prefix
               - backend:
                   service:
-                    name: harbor-harbor-next-core
+                    name: harbor-core
                     port:
                       number: 80
                 path: /c/
                 pathType: Prefix
               - backend:
                   service:
-                    name: harbor-harbor-next-portal
+                    name: harbor-portal
                     port:
                       number: 80
                 path: /
@@ -659,25 +659,25 @@
     apiVersion: v1
     data:
       CACHE_ENABLED: "false"
-      CORE_URL: http://harbor-harbor-next-core
+      CORE_URL: http://harbor-core
       HTTP_PROXY: ""
       HTTPS_PROXY: ""
       LOG_LEVEL: info
-      NO_PROXY: harbor-harbor-next-core,harbor-harbor-next-jobservice,harbor-harbor-next-database,harbor-harbor-next-registry,harbor-harbor-next-portal,harbor-harbor-next-trivy,harbor-harbor-next-exporter,127.0.0.1,localhost,.local,.internal
-      REGISTRY_CONTROLLER_URL: http://harbor-harbor-next-registry:8080
+      NO_PROXY: harbor-core,harbor-jobservice,harbor-database,harbor-registry,harbor-portal,harbor-trivy,harbor-exporter,127.0.0.1,localhost,.local,.internal
+      REGISTRY_CONTROLLER_URL: http://harbor-registry:8080
       REGISTRY_CREDENTIAL_USERNAME: harbor_registry_user
-      REGISTRY_URL: http://harbor-harbor-next-registry:5000
-      TOKEN_SERVICE_URL: http://harbor-harbor-next-core/service/token
+      REGISTRY_URL: http://harbor-registry:5000
+      TOKEN_SERVICE_URL: http://harbor-core/service/token
     kind: ConfigMap
     metadata:
       labels:
         app.kubernetes.io/component: jobservice
         app.kubernetes.io/instance: harbor
         app.kubernetes.io/managed-by: Helm
-        app.kubernetes.io/name: harbor-next
+        app.kubernetes.io/name: harbor
         app.kubernetes.io/version: v2.15.0
-        helm.sh/chart: harbor-next-2.0.0
-      name: harbor-harbor-next-jobservice-env
+        helm.sh/chart: harbor-2.0.0
+      name: harbor-jobservice-env
   6: |
     apiVersion: v1
     data:
@@ -711,10 +711,10 @@
       labels:
         app.kubernetes.io/instance: harbor
         app.kubernetes.io/managed-by: Helm
-        app.kubernetes.io/name: harbor-next
+        app.kubernetes.io/name: harbor
         app.kubernetes.io/version: v2.15.0
-        helm.sh/chart: harbor-next-2.0.0
-      name: harbor-harbor-next-jobservice
+        helm.sh/chart: harbor-2.0.0
+      name: harbor-jobservice
   7: |
     apiVersion: v1
     kind: Service
@@ -723,10 +723,10 @@
         app.kubernetes.io/component: jobservice
         app.kubernetes.io/instance: harbor
         app.kubernetes.io/managed-by: Helm
-        app.kubernetes.io/name: harbor-next
+        app.kubernetes.io/name: harbor
         app.kubernetes.io/version: v2.15.0
-        helm.sh/chart: harbor-next-2.0.0
-      name: harbor-harbor-next-jobservice
+        helm.sh/chart: harbor-2.0.0
+      name: harbor-jobservice
     spec:
       ports:
         - name: http-jobservice
@@ -740,7 +740,7 @@
       selector:
         app.kubernetes.io/component: jobservice
         app.kubernetes.io/instance: harbor
-        app.kubernetes.io/name: harbor-next
+        app.kubernetes.io/name: harbor
       type: ClusterIP
   8: |
     apiVersion: v1
@@ -784,10 +784,10 @@
       labels:
         app.kubernetes.io/instance: harbor
         app.kubernetes.io/managed-by: Helm
-        app.kubernetes.io/name: harbor-next
+        app.kubernetes.io/name: harbor
         app.kubernetes.io/version: v2.15.0
-        helm.sh/chart: harbor-next-2.0.0
-      name: harbor-harbor-next-portal
+        helm.sh/chart: harbor-2.0.0
+      name: harbor-portal
   9: |
     apiVersion: v1
     kind: Service
@@ -796,10 +796,10 @@
         app.kubernetes.io/component: portal
         app.kubernetes.io/instance: harbor
         app.kubernetes.io/managed-by: Helm
-        app.kubernetes.io/name: harbor-next
+        app.kubernetes.io/name: harbor
         app.kubernetes.io/version: v2.15.0
-        helm.sh/chart: harbor-next-2.0.0
-      name: harbor-harbor-next-portal
+        helm.sh/chart: harbor-2.0.0
+      name: harbor-portal
     spec:
       ports:
         - name: http
@@ -809,7 +809,7 @@
       selector:
         app.kubernetes.io/component: portal
         app.kubernetes.io/instance: harbor
-        app.kubernetes.io/name: harbor-next
+        app.kubernetes.io/name: harbor
       type: ClusterIP
   10: |
     apiVersion: v1
@@ -871,10 +871,10 @@
       labels:
         app.kubernetes.io/instance: harbor
         app.kubernetes.io/managed-by: Helm
-        app.kubernetes.io/name: harbor-next
+        app.kubernetes.io/name: harbor
         app.kubernetes.io/version: v2.15.0
-        helm.sh/chart: harbor-next-2.0.0
-      name: harbor-harbor-next-registry
+        helm.sh/chart: harbor-2.0.0
+      name: harbor-registry
   11: |
     apiVersion: v1
     kind: Service
@@ -883,10 +883,10 @@
         app.kubernetes.io/component: registry
         app.kubernetes.io/instance: harbor
         app.kubernetes.io/managed-by: Helm
-        app.kubernetes.io/name: harbor-next
+        app.kubernetes.io/name: harbor
         app.kubernetes.io/version: v2.15.0
-        helm.sh/chart: harbor-next-2.0.0
-      name: harbor-harbor-next-registry
+        helm.sh/chart: harbor-2.0.0
+      name: harbor-registry
     spec:
       ports:
         - name: http-registry
@@ -904,7 +904,7 @@
       selector:
         app.kubernetes.io/component: registry
         app.kubernetes.io/instance: harbor
-        app.kubernetes.io/name: harbor-next
+        app.kubernetes.io/name: harbor
       type: ClusterIP
   12: |
     apiVersion: v1
@@ -915,10 +915,10 @@
       labels:
         app.kubernetes.io/instance: harbor
         app.kubernetes.io/managed-by: Helm
-        app.kubernetes.io/name: harbor-next
+        app.kubernetes.io/name: harbor
         app.kubernetes.io/version: v2.15.0
-        helm.sh/chart: harbor-next-2.0.0
-      name: harbor-harbor-next-registryctl
+        helm.sh/chart: harbor-2.0.0
+      name: harbor-registryctl
   13: |
     apiVersion: v1
     automountServiceAccountToken: false
@@ -928,10 +928,10 @@
         app.kubernetes.io/component: core
         app.kubernetes.io/instance: harbor
         app.kubernetes.io/managed-by: Helm
-        app.kubernetes.io/name: harbor-next
+        app.kubernetes.io/name: harbor
         app.kubernetes.io/version: v2.15.0
-        helm.sh/chart: harbor-next-2.0.0
-      name: harbor-harbor-next-core
+        helm.sh/chart: harbor-2.0.0
+      name: harbor-core
   14: |
     apiVersion: v1
     automountServiceAccountToken: false
@@ -941,10 +941,10 @@
         app.kubernetes.io/component: exporter
         app.kubernetes.io/instance: harbor
         app.kubernetes.io/managed-by: Helm
-        app.kubernetes.io/name: harbor-next
+        app.kubernetes.io/name: harbor
         app.kubernetes.io/version: v2.15.0
-        helm.sh/chart: harbor-next-2.0.0
-      name: harbor-harbor-next-exporter
+        helm.sh/chart: harbor-2.0.0
+      name: harbor-exporter
   15: |
     apiVersion: v1
     automountServiceAccountToken: false
@@ -954,10 +954,10 @@
         app.kubernetes.io/component: jobservice
         app.kubernetes.io/instance: harbor
         app.kubernetes.io/managed-by: Helm
-        app.kubernetes.io/name: harbor-next
+        app.kubernetes.io/name: harbor
         app.kubernetes.io/version: v2.15.0
-        helm.sh/chart: harbor-next-2.0.0
-      name: harbor-harbor-next-jobservice
+        helm.sh/chart: harbor-2.0.0
+      name: harbor-jobservice
   16: |
     apiVersion: v1
     automountServiceAccountToken: false
@@ -967,10 +967,10 @@
         app.kubernetes.io/component: portal
         app.kubernetes.io/instance: harbor
         app.kubernetes.io/managed-by: Helm
-        app.kubernetes.io/name: harbor-next
+        app.kubernetes.io/name: harbor
         app.kubernetes.io/version: v2.15.0
-        helm.sh/chart: harbor-next-2.0.0
-      name: harbor-harbor-next-portal
+        helm.sh/chart: harbor-2.0.0
+      name: harbor-portal
   17: |
     apiVersion: v1
     automountServiceAccountToken: false
@@ -980,10 +980,10 @@
         app.kubernetes.io/component: registry
         app.kubernetes.io/instance: harbor
         app.kubernetes.io/managed-by: Helm
-        app.kubernetes.io/name: harbor-next
+        app.kubernetes.io/name: harbor
         app.kubernetes.io/version: v2.15.0
-        helm.sh/chart: harbor-next-2.0.0
-      name: harbor-harbor-next-registry
+        helm.sh/chart: harbor-2.0.0
+      name: harbor-registry
 3. external Redis with TLS + sentinel + password:
   1: |
     apiVersion: v1
@@ -992,19 +992,19 @@
       CHART_CACHE_DRIVER: redis
       CONFIG_PATH: /etc/core/app.conf
       CORE_LOCAL_URL: http://127.0.0.1:8080
-      CORE_URL: http://harbor-harbor-next-core
+      CORE_URL: http://harbor-core
       DATABASE_TYPE: postgresql
       EXT_ENDPOINT: https://harbor.example.com
       GDPR_AUDIT_LOGS: "false"
       GDPR_DELETE_USER: "false"
       HTTP_PROXY: ""
       HTTPS_PROXY: ""
-      JOBSERVICE_URL: http://harbor-harbor-next-jobservice
+      JOBSERVICE_URL: http://harbor-jobservice
       LOG_LEVEL: info
-      NO_PROXY: harbor-harbor-next-core,harbor-harbor-next-jobservice,harbor-harbor-next-database,harbor-harbor-next-registry,harbor-harbor-next-portal,harbor-harbor-next-trivy,harbor-harbor-next-exporter,127.0.0.1,localhost,.local,.internal
+      NO_PROXY: harbor-core,harbor-jobservice,harbor-database,harbor-registry,harbor-portal,harbor-trivy,harbor-exporter,127.0.0.1,localhost,.local,.internal
       PERMITTED_REGISTRY_TYPES_FOR_PROXY_CACHE: docker-hub,harbor,azure-acr,ali-acr,aws-ecr,google-gcr,docker-registry,github-ghcr,jfrog-artifactory
       PORT: "8080"
-      PORTAL_URL: http://harbor-harbor-next-portal
+      PORTAL_URL: http://harbor-portal
       POSTGRESQL_CONN_MAX_IDLE_TIME: 300s
       POSTGRESQL_CONN_MAX_LIFETIME: 30m
       POSTGRESQL_DATABASE: registry
@@ -1015,13 +1015,13 @@
       POSTGRESQL_SSLMODE: disable
       POSTGRESQL_USERNAME: postgres
       QUOTA_UPDATE_PROVIDER: db
-      REGISTRY_CONTROLLER_URL: http://harbor-harbor-next-registry:8080
+      REGISTRY_CONTROLLER_URL: http://harbor-registry:8080
       REGISTRY_CREDENTIAL_USERNAME: harbor_registry_user
       REGISTRY_STORAGE_PROVIDER_NAME: filesystem
-      REGISTRY_URL: http://harbor-harbor-next-registry:5000
+      REGISTRY_URL: http://harbor-registry:5000
       REPLICATION_ADAPTER_WHITELIST: ali-acr,aws-ecr,azure-acr,docker-hub,docker-registry,github-ghcr,google-gcr,harbor,huawei-SWR,jfrog-artifactory,tencent-tcr,volcengine-cr,sftp,harbor-satellite
-      TOKEN_SERVICE_URL: http://harbor-harbor-next-core/service/token
-      TRIVY_ADAPTER_URL: http://harbor-harbor-next-trivy:8080
+      TOKEN_SERVICE_URL: http://harbor-core/service/token
+      TRIVY_ADAPTER_URL: http://harbor-trivy:8080
       WITH_TRIVY: "false"
       app.conf: |
         appname = Harbor
@@ -1036,10 +1036,10 @@
         app.kubernetes.io/component: core
         app.kubernetes.io/instance: harbor
         app.kubernetes.io/managed-by: Helm
-        app.kubernetes.io/name: harbor-next
+        app.kubernetes.io/name: harbor
         app.kubernetes.io/version: v2.15.0
-        helm.sh/chart: harbor-next-2.0.0
-      name: harbor-harbor-next-core
+        helm.sh/chart: harbor-2.0.0
+      name: harbor-core
   2: |
     apiVersion: v1
     kind: Service
@@ -1048,10 +1048,10 @@
         app.kubernetes.io/component: core
         app.kubernetes.io/instance: harbor
         app.kubernetes.io/managed-by: Helm
-        app.kubernetes.io/name: harbor-next
+        app.kubernetes.io/name: harbor
         app.kubernetes.io/version: v2.15.0
-        helm.sh/chart: harbor-next-2.0.0
-      name: harbor-harbor-next-core
+        helm.sh/chart: harbor-2.0.0
+      name: harbor-core
     spec:
       ports:
         - name: http-web
@@ -1065,7 +1065,7 @@
       selector:
         app.kubernetes.io/component: core
         app.kubernetes.io/instance: harbor
-        app.kubernetes.io/name: harbor-next
+        app.kubernetes.io/name: harbor
       type: ClusterIP
   3: |
     apiVersion: v1
@@ -1075,10 +1075,10 @@
         app.kubernetes.io/component: exporter
         app.kubernetes.io/instance: harbor
         app.kubernetes.io/managed-by: Helm
-        app.kubernetes.io/name: harbor-next
+        app.kubernetes.io/name: harbor
         app.kubernetes.io/version: v2.15.0
-        helm.sh/chart: harbor-next-2.0.0
-      name: harbor-harbor-next-exporter
+        helm.sh/chart: harbor-2.0.0
+      name: harbor-exporter
     spec:
       ports:
         - name: http-metrics
@@ -1088,7 +1088,7 @@
       selector:
         app.kubernetes.io/component: exporter
         app.kubernetes.io/instance: harbor
-        app.kubernetes.io/name: harbor-next
+        app.kubernetes.io/name: harbor
       type: ClusterIP
   4: |
     apiVersion: networking.k8s.io/v1
@@ -1097,10 +1097,10 @@
       labels:
         app.kubernetes.io/instance: harbor
         app.kubernetes.io/managed-by: Helm
-        app.kubernetes.io/name: harbor-next
+        app.kubernetes.io/name: harbor
         app.kubernetes.io/version: v2.15.0
-        helm.sh/chart: harbor-next-2.0.0
-      name: harbor-harbor-next
+        helm.sh/chart: harbor-2.0.0
+      name: harbor
     spec:
       rules:
         - host: harbor.example.com
@@ -1108,42 +1108,42 @@
             paths:
               - backend:
                   service:
-                    name: harbor-harbor-next-core
+                    name: harbor-core
                     port:
                       number: 80
                 path: /api/
                 pathType: Prefix
               - backend:
                   service:
-                    name: harbor-harbor-next-core
+                    name: harbor-core
                     port:
                       number: 80
                 path: /service/
                 pathType: Prefix
               - backend:
                   service:
-                    name: harbor-harbor-next-core
+                    name: harbor-core
                     port:
                       number: 80
                 path: /v2/
                 pathType: Prefix
               - backend:
                   service:
-                    name: harbor-harbor-next-core
+                    name: harbor-core
                     port:
                       number: 80
                 path: /chartrepo/
                 pathType: Prefix
               - backend:
                   service:
-                    name: harbor-harbor-next-core
+                    name: harbor-core
                     port:
                       number: 80
                 path: /c/
                 pathType: Prefix
               - backend:
                   service:
-                    name: harbor-harbor-next-portal
+                    name: harbor-portal
                     port:
                       number: 80
                 path: /
@@ -1152,25 +1152,25 @@
     apiVersion: v1
     data:
       CACHE_ENABLED: "false"
-      CORE_URL: http://harbor-harbor-next-core
+      CORE_URL: http://harbor-core
       HTTP_PROXY: ""
       HTTPS_PROXY: ""
       LOG_LEVEL: info
-      NO_PROXY: harbor-harbor-next-core,harbor-harbor-next-jobservice,harbor-harbor-next-database,harbor-harbor-next-registry,harbor-harbor-next-portal,harbor-harbor-next-trivy,harbor-harbor-next-exporter,127.0.0.1,localhost,.local,.internal
-      REGISTRY_CONTROLLER_URL: http://harbor-harbor-next-registry:8080
+      NO_PROXY: harbor-core,harbor-jobservice,harbor-database,harbor-registry,harbor-portal,harbor-trivy,harbor-exporter,127.0.0.1,localhost,.local,.internal
+      REGISTRY_CONTROLLER_URL: http://harbor-registry:8080
       REGISTRY_CREDENTIAL_USERNAME: harbor_registry_user
-      REGISTRY_URL: http://harbor-harbor-next-registry:5000
-      TOKEN_SERVICE_URL: http://harbor-harbor-next-core/service/token
+      REGISTRY_URL: http://harbor-registry:5000
+      TOKEN_SERVICE_URL: http://harbor-core/service/token
     kind: ConfigMap
     metadata:
       labels:
         app.kubernetes.io/component: jobservice
         app.kubernetes.io/instance: harbor
         app.kubernetes.io/managed-by: Helm
-        app.kubernetes.io/name: harbor-next
+        app.kubernetes.io/name: harbor
         app.kubernetes.io/version: v2.15.0
-        helm.sh/chart: harbor-next-2.0.0
-      name: harbor-harbor-next-jobservice-env
+        helm.sh/chart: harbor-2.0.0
+      name: harbor-jobservice-env
   6: |
     apiVersion: v1
     data:
@@ -1204,10 +1204,10 @@
       labels:
         app.kubernetes.io/instance: harbor
         app.kubernetes.io/managed-by: Helm
-        app.kubernetes.io/name: harbor-next
+        app.kubernetes.io/name: harbor
         app.kubernetes.io/version: v2.15.0
-        helm.sh/chart: harbor-next-2.0.0
-      name: harbor-harbor-next-jobservice
+        helm.sh/chart: harbor-2.0.0
+      name: harbor-jobservice
   7: |
     apiVersion: v1
     kind: Service
@@ -1216,10 +1216,10 @@
         app.kubernetes.io/component: jobservice
         app.kubernetes.io/instance: harbor
         app.kubernetes.io/managed-by: Helm
-        app.kubernetes.io/name: harbor-next
+        app.kubernetes.io/name: harbor
         app.kubernetes.io/version: v2.15.0
-        helm.sh/chart: harbor-next-2.0.0
-      name: harbor-harbor-next-jobservice
+        helm.sh/chart: harbor-2.0.0
+      name: harbor-jobservice
     spec:
       ports:
         - name: http-jobservice
@@ -1233,7 +1233,7 @@
       selector:
         app.kubernetes.io/component: jobservice
         app.kubernetes.io/instance: harbor
-        app.kubernetes.io/name: harbor-next
+        app.kubernetes.io/name: harbor
       type: ClusterIP
   8: |
     apiVersion: v1
@@ -1277,10 +1277,10 @@
       labels:
         app.kubernetes.io/instance: harbor
         app.kubernetes.io/managed-by: Helm
-        app.kubernetes.io/name: harbor-next
+        app.kubernetes.io/name: harbor
         app.kubernetes.io/version: v2.15.0
-        helm.sh/chart: harbor-next-2.0.0
-      name: harbor-harbor-next-portal
+        helm.sh/chart: harbor-2.0.0
+      name: harbor-portal
   9: |
     apiVersion: v1
     kind: Service
@@ -1289,10 +1289,10 @@
         app.kubernetes.io/component: portal
         app.kubernetes.io/instance: harbor
         app.kubernetes.io/managed-by: Helm
-        app.kubernetes.io/name: harbor-next
+        app.kubernetes.io/name: harbor
         app.kubernetes.io/version: v2.15.0
-        helm.sh/chart: harbor-next-2.0.0
-      name: harbor-harbor-next-portal
+        helm.sh/chart: harbor-2.0.0
+      name: harbor-portal
     spec:
       ports:
         - name: http
@@ -1302,7 +1302,7 @@
       selector:
         app.kubernetes.io/component: portal
         app.kubernetes.io/instance: harbor
-        app.kubernetes.io/name: harbor-next
+        app.kubernetes.io/name: harbor
       type: ClusterIP
   10: |
     apiVersion: v1
@@ -1365,10 +1365,10 @@
       labels:
         app.kubernetes.io/instance: harbor
         app.kubernetes.io/managed-by: Helm
-        app.kubernetes.io/name: harbor-next
+        app.kubernetes.io/name: harbor
         app.kubernetes.io/version: v2.15.0
-        helm.sh/chart: harbor-next-2.0.0
-      name: harbor-harbor-next-registry
+        helm.sh/chart: harbor-2.0.0
+      name: harbor-registry
   11: |
     apiVersion: v1
     kind: Service
@@ -1377,10 +1377,10 @@
         app.kubernetes.io/component: registry
         app.kubernetes.io/instance: harbor
         app.kubernetes.io/managed-by: Helm
-        app.kubernetes.io/name: harbor-next
+        app.kubernetes.io/name: harbor
         app.kubernetes.io/version: v2.15.0
-        helm.sh/chart: harbor-next-2.0.0
-      name: harbor-harbor-next-registry
+        helm.sh/chart: harbor-2.0.0
+      name: harbor-registry
     spec:
       ports:
         - name: http-registry
@@ -1398,7 +1398,7 @@
       selector:
         app.kubernetes.io/component: registry
         app.kubernetes.io/instance: harbor
-        app.kubernetes.io/name: harbor-next
+        app.kubernetes.io/name: harbor
       type: ClusterIP
   12: |
     apiVersion: v1
@@ -1409,10 +1409,10 @@
       labels:
         app.kubernetes.io/instance: harbor
         app.kubernetes.io/managed-by: Helm
-        app.kubernetes.io/name: harbor-next
+        app.kubernetes.io/name: harbor
         app.kubernetes.io/version: v2.15.0
-        helm.sh/chart: harbor-next-2.0.0
-      name: harbor-harbor-next-registryctl
+        helm.sh/chart: harbor-2.0.0
+      name: harbor-registryctl
   13: |
     apiVersion: v1
     automountServiceAccountToken: false
@@ -1422,10 +1422,10 @@
         app.kubernetes.io/component: core
         app.kubernetes.io/instance: harbor
         app.kubernetes.io/managed-by: Helm
-        app.kubernetes.io/name: harbor-next
+        app.kubernetes.io/name: harbor
         app.kubernetes.io/version: v2.15.0
-        helm.sh/chart: harbor-next-2.0.0
-      name: harbor-harbor-next-core
+        helm.sh/chart: harbor-2.0.0
+      name: harbor-core
   14: |
     apiVersion: v1
     automountServiceAccountToken: false
@@ -1435,10 +1435,10 @@
         app.kubernetes.io/component: exporter
         app.kubernetes.io/instance: harbor
         app.kubernetes.io/managed-by: Helm
-        app.kubernetes.io/name: harbor-next
+        app.kubernetes.io/name: harbor
         app.kubernetes.io/version: v2.15.0
-        helm.sh/chart: harbor-next-2.0.0
-      name: harbor-harbor-next-exporter
+        helm.sh/chart: harbor-2.0.0
+      name: harbor-exporter
   15: |
     apiVersion: v1
     automountServiceAccountToken: false
@@ -1448,10 +1448,10 @@
         app.kubernetes.io/component: jobservice
         app.kubernetes.io/instance: harbor
         app.kubernetes.io/managed-by: Helm
-        app.kubernetes.io/name: harbor-next
+        app.kubernetes.io/name: harbor
         app.kubernetes.io/version: v2.15.0
-        helm.sh/chart: harbor-next-2.0.0
-      name: harbor-harbor-next-jobservice
+        helm.sh/chart: harbor-2.0.0
+      name: harbor-jobservice
   16: |
     apiVersion: v1
     automountServiceAccountToken: false
@@ -1461,10 +1461,10 @@
         app.kubernetes.io/component: portal
         app.kubernetes.io/instance: harbor
         app.kubernetes.io/managed-by: Helm
-        app.kubernetes.io/name: harbor-next
+        app.kubernetes.io/name: harbor
         app.kubernetes.io/version: v2.15.0
-        helm.sh/chart: harbor-next-2.0.0
-      name: harbor-harbor-next-portal
+        helm.sh/chart: harbor-2.0.0
+      name: harbor-portal
   17: |
     apiVersion: v1
     automountServiceAccountToken: false
@@ -1474,10 +1474,10 @@
         app.kubernetes.io/component: registry
         app.kubernetes.io/instance: harbor
         app.kubernetes.io/managed-by: Helm
-        app.kubernetes.io/name: harbor-next
+        app.kubernetes.io/name: harbor
         app.kubernetes.io/version: v2.15.0
-        helm.sh/chart: harbor-next-2.0.0
-      name: harbor-harbor-next-registry
+        helm.sh/chart: harbor-2.0.0
+      name: harbor-registry
 4. BYO secrets matrix — every existingSecret path:
   1: |
     apiVersion: v1
@@ -1486,19 +1486,19 @@
       CHART_CACHE_DRIVER: redis
       CONFIG_PATH: /etc/core/app.conf
       CORE_LOCAL_URL: http://127.0.0.1:8080
-      CORE_URL: http://harbor-harbor-next-core
+      CORE_URL: http://harbor-core
       DATABASE_TYPE: postgresql
       EXT_ENDPOINT: https://harbor.example.com
       GDPR_AUDIT_LOGS: "false"
       GDPR_DELETE_USER: "false"
       HTTP_PROXY: ""
       HTTPS_PROXY: ""
-      JOBSERVICE_URL: http://harbor-harbor-next-jobservice
+      JOBSERVICE_URL: http://harbor-jobservice
       LOG_LEVEL: info
-      NO_PROXY: harbor-harbor-next-core,harbor-harbor-next-jobservice,harbor-harbor-next-database,harbor-harbor-next-registry,harbor-harbor-next-portal,harbor-harbor-next-trivy,harbor-harbor-next-exporter,127.0.0.1,localhost,.local,.internal
+      NO_PROXY: harbor-core,harbor-jobservice,harbor-database,harbor-registry,harbor-portal,harbor-trivy,harbor-exporter,127.0.0.1,localhost,.local,.internal
       PERMITTED_REGISTRY_TYPES_FOR_PROXY_CACHE: docker-hub,harbor,azure-acr,ali-acr,aws-ecr,google-gcr,docker-registry,github-ghcr,jfrog-artifactory
       PORT: "8080"
-      PORTAL_URL: http://harbor-harbor-next-portal
+      PORTAL_URL: http://harbor-portal
       POSTGRESQL_CONN_MAX_IDLE_TIME: 300s
       POSTGRESQL_CONN_MAX_LIFETIME: 30m
       POSTGRESQL_DATABASE: registry
@@ -1509,13 +1509,13 @@
       POSTGRESQL_SSLMODE: disable
       POSTGRESQL_USERNAME: postgres
       QUOTA_UPDATE_PROVIDER: db
-      REGISTRY_CONTROLLER_URL: http://harbor-harbor-next-registry:8080
+      REGISTRY_CONTROLLER_URL: http://harbor-registry:8080
       REGISTRY_CREDENTIAL_USERNAME: harbor_registry_user
       REGISTRY_STORAGE_PROVIDER_NAME: filesystem
-      REGISTRY_URL: http://harbor-harbor-next-registry:5000
+      REGISTRY_URL: http://harbor-registry:5000
       REPLICATION_ADAPTER_WHITELIST: ali-acr,aws-ecr,azure-acr,docker-hub,docker-registry,github-ghcr,google-gcr,harbor,huawei-SWR,jfrog-artifactory,tencent-tcr,volcengine-cr,sftp,harbor-satellite
-      TOKEN_SERVICE_URL: http://harbor-harbor-next-core/service/token
-      TRIVY_ADAPTER_URL: http://harbor-harbor-next-trivy:8080
+      TOKEN_SERVICE_URL: http://harbor-core/service/token
+      TRIVY_ADAPTER_URL: http://harbor-trivy:8080
       WITH_TRIVY: "false"
       app.conf: |
         appname = Harbor
@@ -1530,10 +1530,10 @@
         app.kubernetes.io/component: core
         app.kubernetes.io/instance: harbor
         app.kubernetes.io/managed-by: Helm
-        app.kubernetes.io/name: harbor-next
+        app.kubernetes.io/name: harbor
         app.kubernetes.io/version: v2.15.0
-        helm.sh/chart: harbor-next-2.0.0
-      name: harbor-harbor-next-core
+        helm.sh/chart: harbor-2.0.0
+      name: harbor-core
   2: |
     apiVersion: v1
     kind: Service
@@ -1542,10 +1542,10 @@
         app.kubernetes.io/component: core
         app.kubernetes.io/instance: harbor
         app.kubernetes.io/managed-by: Helm
-        app.kubernetes.io/name: harbor-next
+        app.kubernetes.io/name: harbor
         app.kubernetes.io/version: v2.15.0
-        helm.sh/chart: harbor-next-2.0.0
-      name: harbor-harbor-next-core
+        helm.sh/chart: harbor-2.0.0
+      name: harbor-core
     spec:
       ports:
         - name: http-web
@@ -1559,7 +1559,7 @@
       selector:
         app.kubernetes.io/component: core
         app.kubernetes.io/instance: harbor
-        app.kubernetes.io/name: harbor-next
+        app.kubernetes.io/name: harbor
       type: ClusterIP
   3: |
     apiVersion: v1
@@ -1569,10 +1569,10 @@
         app.kubernetes.io/component: exporter
         app.kubernetes.io/instance: harbor
         app.kubernetes.io/managed-by: Helm
-        app.kubernetes.io/name: harbor-next
+        app.kubernetes.io/name: harbor
         app.kubernetes.io/version: v2.15.0
-        helm.sh/chart: harbor-next-2.0.0
-      name: harbor-harbor-next-exporter
+        helm.sh/chart: harbor-2.0.0
+      name: harbor-exporter
     spec:
       ports:
         - name: http-metrics
@@ -1582,7 +1582,7 @@
       selector:
         app.kubernetes.io/component: exporter
         app.kubernetes.io/instance: harbor
-        app.kubernetes.io/name: harbor-next
+        app.kubernetes.io/name: harbor
       type: ClusterIP
   4: |
     apiVersion: networking.k8s.io/v1
@@ -1591,10 +1591,10 @@
       labels:
         app.kubernetes.io/instance: harbor
         app.kubernetes.io/managed-by: Helm
-        app.kubernetes.io/name: harbor-next
+        app.kubernetes.io/name: harbor
         app.kubernetes.io/version: v2.15.0
-        helm.sh/chart: harbor-next-2.0.0
-      name: harbor-harbor-next
+        helm.sh/chart: harbor-2.0.0
+      name: harbor
     spec:
       rules:
         - host: harbor.example.com
@@ -1602,42 +1602,42 @@
             paths:
               - backend:
                   service:
-                    name: harbor-harbor-next-core
+                    name: harbor-core
                     port:
                       number: 80
                 path: /api/
                 pathType: Prefix
               - backend:
                   service:
-                    name: harbor-harbor-next-core
+                    name: harbor-core
                     port:
                       number: 80
                 path: /service/
                 pathType: Prefix
               - backend:
                   service:
-                    name: harbor-harbor-next-core
+                    name: harbor-core
                     port:
                       number: 80
                 path: /v2/
                 pathType: Prefix
               - backend:
                   service:
-                    name: harbor-harbor-next-core
+                    name: harbor-core
                     port:
                       number: 80
                 path: /chartrepo/
                 pathType: Prefix
               - backend:
                   service:
-                    name: harbor-harbor-next-core
+                    name: harbor-core
                     port:
                       number: 80
                 path: /c/
                 pathType: Prefix
               - backend:
                   service:
-                    name: harbor-harbor-next-portal
+                    name: harbor-portal
                     port:
                       number: 80
                 path: /
@@ -1646,25 +1646,25 @@
     apiVersion: v1
     data:
       CACHE_ENABLED: "false"
-      CORE_URL: http://harbor-harbor-next-core
+      CORE_URL: http://harbor-core
       HTTP_PROXY: ""
       HTTPS_PROXY: ""
       LOG_LEVEL: info
-      NO_PROXY: harbor-harbor-next-core,harbor-harbor-next-jobservice,harbor-harbor-next-database,harbor-harbor-next-registry,harbor-harbor-next-portal,harbor-harbor-next-trivy,harbor-harbor-next-exporter,127.0.0.1,localhost,.local,.internal
-      REGISTRY_CONTROLLER_URL: http://harbor-harbor-next-registry:8080
+      NO_PROXY: harbor-core,harbor-jobservice,harbor-database,harbor-registry,harbor-portal,harbor-trivy,harbor-exporter,127.0.0.1,localhost,.local,.internal
+      REGISTRY_CONTROLLER_URL: http://harbor-registry:8080
       REGISTRY_CREDENTIAL_USERNAME: harbor_registry_user
-      REGISTRY_URL: http://harbor-harbor-next-registry:5000
-      TOKEN_SERVICE_URL: http://harbor-harbor-next-core/service/token
+      REGISTRY_URL: http://harbor-registry:5000
+      TOKEN_SERVICE_URL: http://harbor-core/service/token
     kind: ConfigMap
     metadata:
       labels:
         app.kubernetes.io/component: jobservice
         app.kubernetes.io/instance: harbor
         app.kubernetes.io/managed-by: Helm
-        app.kubernetes.io/name: harbor-next
+        app.kubernetes.io/name: harbor
         app.kubernetes.io/version: v2.15.0
-        helm.sh/chart: harbor-next-2.0.0
-      name: harbor-harbor-next-jobservice-env
+        helm.sh/chart: harbor-2.0.0
+      name: harbor-jobservice-env
   6: |
     apiVersion: v1
     data:
@@ -1698,10 +1698,10 @@
       labels:
         app.kubernetes.io/instance: harbor
         app.kubernetes.io/managed-by: Helm
-        app.kubernetes.io/name: harbor-next
+        app.kubernetes.io/name: harbor
         app.kubernetes.io/version: v2.15.0
-        helm.sh/chart: harbor-next-2.0.0
-      name: harbor-harbor-next-jobservice
+        helm.sh/chart: harbor-2.0.0
+      name: harbor-jobservice
   7: |
     apiVersion: v1
     kind: Service
@@ -1710,10 +1710,10 @@
         app.kubernetes.io/component: jobservice
         app.kubernetes.io/instance: harbor
         app.kubernetes.io/managed-by: Helm
-        app.kubernetes.io/name: harbor-next
+        app.kubernetes.io/name: harbor
         app.kubernetes.io/version: v2.15.0
-        helm.sh/chart: harbor-next-2.0.0
-      name: harbor-harbor-next-jobservice
+        helm.sh/chart: harbor-2.0.0
+      name: harbor-jobservice
     spec:
       ports:
         - name: http-jobservice
@@ -1727,7 +1727,7 @@
       selector:
         app.kubernetes.io/component: jobservice
         app.kubernetes.io/instance: harbor
-        app.kubernetes.io/name: harbor-next
+        app.kubernetes.io/name: harbor
       type: ClusterIP
   8: |
     apiVersion: v1
@@ -1771,10 +1771,10 @@
       labels:
         app.kubernetes.io/instance: harbor
         app.kubernetes.io/managed-by: Helm
-        app.kubernetes.io/name: harbor-next
+        app.kubernetes.io/name: harbor
         app.kubernetes.io/version: v2.15.0
-        helm.sh/chart: harbor-next-2.0.0
-      name: harbor-harbor-next-portal
+        helm.sh/chart: harbor-2.0.0
+      name: harbor-portal
   9: |
     apiVersion: v1
     kind: Service
@@ -1783,10 +1783,10 @@
         app.kubernetes.io/component: portal
         app.kubernetes.io/instance: harbor
         app.kubernetes.io/managed-by: Helm
-        app.kubernetes.io/name: harbor-next
+        app.kubernetes.io/name: harbor
         app.kubernetes.io/version: v2.15.0
-        helm.sh/chart: harbor-next-2.0.0
-      name: harbor-harbor-next-portal
+        helm.sh/chart: harbor-2.0.0
+      name: harbor-portal
     spec:
       ports:
         - name: http
@@ -1796,7 +1796,7 @@
       selector:
         app.kubernetes.io/component: portal
         app.kubernetes.io/instance: harbor
-        app.kubernetes.io/name: harbor-next
+        app.kubernetes.io/name: harbor
       type: ClusterIP
   10: |
     apiVersion: v1
@@ -1858,10 +1858,10 @@
       labels:
         app.kubernetes.io/instance: harbor
         app.kubernetes.io/managed-by: Helm
-        app.kubernetes.io/name: harbor-next
+        app.kubernetes.io/name: harbor
         app.kubernetes.io/version: v2.15.0
-        helm.sh/chart: harbor-next-2.0.0
-      name: harbor-harbor-next-registry
+        helm.sh/chart: harbor-2.0.0
+      name: harbor-registry
   11: |
     apiVersion: v1
     kind: Service
@@ -1870,10 +1870,10 @@
         app.kubernetes.io/component: registry
         app.kubernetes.io/instance: harbor
         app.kubernetes.io/managed-by: Helm
-        app.kubernetes.io/name: harbor-next
+        app.kubernetes.io/name: harbor
         app.kubernetes.io/version: v2.15.0
-        helm.sh/chart: harbor-next-2.0.0
-      name: harbor-harbor-next-registry
+        helm.sh/chart: harbor-2.0.0
+      name: harbor-registry
     spec:
       ports:
         - name: http-registry
@@ -1891,7 +1891,7 @@
       selector:
         app.kubernetes.io/component: registry
         app.kubernetes.io/instance: harbor
-        app.kubernetes.io/name: harbor-next
+        app.kubernetes.io/name: harbor
       type: ClusterIP
   12: |
     apiVersion: v1
@@ -1902,10 +1902,10 @@
       labels:
         app.kubernetes.io/instance: harbor
         app.kubernetes.io/managed-by: Helm
-        app.kubernetes.io/name: harbor-next
+        app.kubernetes.io/name: harbor
         app.kubernetes.io/version: v2.15.0
-        helm.sh/chart: harbor-next-2.0.0
-      name: harbor-harbor-next-registryctl
+        helm.sh/chart: harbor-2.0.0
+      name: harbor-registryctl
   13: |
     apiVersion: v1
     automountServiceAccountToken: false
@@ -1915,10 +1915,10 @@
         app.kubernetes.io/component: core
         app.kubernetes.io/instance: harbor
         app.kubernetes.io/managed-by: Helm
-        app.kubernetes.io/name: harbor-next
+        app.kubernetes.io/name: harbor
         app.kubernetes.io/version: v2.15.0
-        helm.sh/chart: harbor-next-2.0.0
-      name: harbor-harbor-next-core
+        helm.sh/chart: harbor-2.0.0
+      name: harbor-core
   14: |
     apiVersion: v1
     automountServiceAccountToken: false
@@ -1928,10 +1928,10 @@
         app.kubernetes.io/component: exporter
         app.kubernetes.io/instance: harbor
         app.kubernetes.io/managed-by: Helm
-        app.kubernetes.io/name: harbor-next
+        app.kubernetes.io/name: harbor
         app.kubernetes.io/version: v2.15.0
-        helm.sh/chart: harbor-next-2.0.0
-      name: harbor-harbor-next-exporter
+        helm.sh/chart: harbor-2.0.0
+      name: harbor-exporter
   15: |
     apiVersion: v1
     automountServiceAccountToken: false
@@ -1941,10 +1941,10 @@
         app.kubernetes.io/component: jobservice
         app.kubernetes.io/instance: harbor
         app.kubernetes.io/managed-by: Helm
-        app.kubernetes.io/name: harbor-next
+        app.kubernetes.io/name: harbor
         app.kubernetes.io/version: v2.15.0
-        helm.sh/chart: harbor-next-2.0.0
-      name: harbor-harbor-next-jobservice
+        helm.sh/chart: harbor-2.0.0
+      name: harbor-jobservice
   16: |
     apiVersion: v1
     automountServiceAccountToken: false
@@ -1954,10 +1954,10 @@
         app.kubernetes.io/component: portal
         app.kubernetes.io/instance: harbor
         app.kubernetes.io/managed-by: Helm
-        app.kubernetes.io/name: harbor-next
+        app.kubernetes.io/name: harbor
         app.kubernetes.io/version: v2.15.0
-        helm.sh/chart: harbor-next-2.0.0
-      name: harbor-harbor-next-portal
+        helm.sh/chart: harbor-2.0.0
+      name: harbor-portal
   17: |
     apiVersion: v1
     automountServiceAccountToken: false
@@ -1967,10 +1967,10 @@
         app.kubernetes.io/component: registry
         app.kubernetes.io/instance: harbor
         app.kubernetes.io/managed-by: Helm
-        app.kubernetes.io/name: harbor-next
+        app.kubernetes.io/name: harbor
         app.kubernetes.io/version: v2.15.0
-        helm.sh/chart: harbor-next-2.0.0
-      name: harbor-harbor-next-registry
+        helm.sh/chart: harbor-2.0.0
+      name: harbor-registry
 5. trace (jaeger) + metrics + ServiceMonitor:
   1: |
     apiVersion: v1
@@ -1979,24 +1979,24 @@
       CHART_CACHE_DRIVER: redis
       CONFIG_PATH: /etc/core/app.conf
       CORE_LOCAL_URL: http://127.0.0.1:8080
-      CORE_URL: http://harbor-harbor-next-core
+      CORE_URL: http://harbor-core
       DATABASE_TYPE: postgresql
       EXT_ENDPOINT: https://harbor.example.com
       GDPR_AUDIT_LOGS: "false"
       GDPR_DELETE_USER: "false"
       HTTP_PROXY: ""
       HTTPS_PROXY: ""
-      JOBSERVICE_URL: http://harbor-harbor-next-jobservice
+      JOBSERVICE_URL: http://harbor-jobservice
       LOG_LEVEL: info
       METRIC_ENABLE: "true"
       METRIC_NAMESPACE: harbor
       METRIC_PATH: /metrics
       METRIC_PORT: "8001"
       METRIC_SUBSYSTEM: core
-      NO_PROXY: harbor-harbor-next-core,harbor-harbor-next-jobservice,harbor-harbor-next-database,harbor-harbor-next-registry,harbor-harbor-next-portal,harbor-harbor-next-trivy,harbor-harbor-next-exporter,127.0.0.1,localhost,.local,.internal
+      NO_PROXY: harbor-core,harbor-jobservice,harbor-database,harbor-registry,harbor-portal,harbor-trivy,harbor-exporter,127.0.0.1,localhost,.local,.internal
       PERMITTED_REGISTRY_TYPES_FOR_PROXY_CACHE: docker-hub,harbor,azure-acr,ali-acr,aws-ecr,google-gcr,docker-registry,github-ghcr,jfrog-artifactory
       PORT: "8080"
-      PORTAL_URL: http://harbor-harbor-next-portal
+      PORTAL_URL: http://harbor-portal
       POSTGRESQL_CONN_MAX_IDLE_TIME: 300s
       POSTGRESQL_CONN_MAX_LIFETIME: 30m
       POSTGRESQL_DATABASE: registry
@@ -2007,13 +2007,13 @@
       POSTGRESQL_SSLMODE: disable
       POSTGRESQL_USERNAME: postgres
       QUOTA_UPDATE_PROVIDER: db
-      REGISTRY_CONTROLLER_URL: http://harbor-harbor-next-registry:8080
+      REGISTRY_CONTROLLER_URL: http://harbor-registry:8080
       REGISTRY_CREDENTIAL_USERNAME: harbor_registry_user
       REGISTRY_STORAGE_PROVIDER_NAME: filesystem
-      REGISTRY_URL: http://harbor-harbor-next-registry:5000
+      REGISTRY_URL: http://harbor-registry:5000
       REPLICATION_ADAPTER_WHITELIST: ali-acr,aws-ecr,azure-acr,docker-hub,docker-registry,github-ghcr,google-gcr,harbor,huawei-SWR,jfrog-artifactory,tencent-tcr,volcengine-cr,sftp,harbor-satellite
-      TOKEN_SERVICE_URL: http://harbor-harbor-next-core/service/token
-      TRIVY_ADAPTER_URL: http://harbor-harbor-next-trivy:8080
+      TOKEN_SERVICE_URL: http://harbor-core/service/token
+      TRIVY_ADAPTER_URL: http://harbor-trivy:8080
       WITH_TRIVY: "false"
       app.conf: |
         appname = Harbor
@@ -2028,10 +2028,10 @@
         app.kubernetes.io/component: core
         app.kubernetes.io/instance: harbor
         app.kubernetes.io/managed-by: Helm
-        app.kubernetes.io/name: harbor-next
+        app.kubernetes.io/name: harbor
         app.kubernetes.io/version: v2.15.0
-        helm.sh/chart: harbor-next-2.0.0
-      name: harbor-harbor-next-core
+        helm.sh/chart: harbor-2.0.0
+      name: harbor-core
   2: |
     apiVersion: v1
     kind: Service
@@ -2040,10 +2040,10 @@
         app.kubernetes.io/component: core
         app.kubernetes.io/instance: harbor
         app.kubernetes.io/managed-by: Helm
-        app.kubernetes.io/name: harbor-next
+        app.kubernetes.io/name: harbor
         app.kubernetes.io/version: v2.15.0
-        helm.sh/chart: harbor-next-2.0.0
-      name: harbor-harbor-next-core
+        helm.sh/chart: harbor-2.0.0
+      name: harbor-core
     spec:
       ports:
         - name: http-web
@@ -2057,7 +2057,7 @@
       selector:
         app.kubernetes.io/component: core
         app.kubernetes.io/instance: harbor
-        app.kubernetes.io/name: harbor-next
+        app.kubernetes.io/name: harbor
       type: ClusterIP
   3: |
     apiVersion: v1
@@ -2067,10 +2067,10 @@
         app.kubernetes.io/component: exporter
         app.kubernetes.io/instance: harbor
         app.kubernetes.io/managed-by: Helm
-        app.kubernetes.io/name: harbor-next
+        app.kubernetes.io/name: harbor
         app.kubernetes.io/version: v2.15.0
-        helm.sh/chart: harbor-next-2.0.0
-      name: harbor-harbor-next-exporter
+        helm.sh/chart: harbor-2.0.0
+      name: harbor-exporter
     spec:
       ports:
         - name: http-metrics
@@ -2080,7 +2080,7 @@
       selector:
         app.kubernetes.io/component: exporter
         app.kubernetes.io/instance: harbor
-        app.kubernetes.io/name: harbor-next
+        app.kubernetes.io/name: harbor
       type: ClusterIP
   4: |
     apiVersion: networking.k8s.io/v1
@@ -2089,10 +2089,10 @@
       labels:
         app.kubernetes.io/instance: harbor
         app.kubernetes.io/managed-by: Helm
-        app.kubernetes.io/name: harbor-next
+        app.kubernetes.io/name: harbor
         app.kubernetes.io/version: v2.15.0
-        helm.sh/chart: harbor-next-2.0.0
-      name: harbor-harbor-next
+        helm.sh/chart: harbor-2.0.0
+      name: harbor
     spec:
       rules:
         - host: harbor.example.com
@@ -2100,42 +2100,42 @@
             paths:
               - backend:
                   service:
-                    name: harbor-harbor-next-core
+                    name: harbor-core
                     port:
                       number: 80
                 path: /api/
                 pathType: Prefix
               - backend:
                   service:
-                    name: harbor-harbor-next-core
+                    name: harbor-core
                     port:
                       number: 80
                 path: /service/
                 pathType: Prefix
               - backend:
                   service:
-                    name: harbor-harbor-next-core
+                    name: harbor-core
                     port:
                       number: 80
                 path: /v2/
                 pathType: Prefix
               - backend:
                   service:
-                    name: harbor-harbor-next-core
+                    name: harbor-core
                     port:
                       number: 80
                 path: /chartrepo/
                 pathType: Prefix
               - backend:
                   service:
-                    name: harbor-harbor-next-core
+                    name: harbor-core
                     port:
                       number: 80
                 path: /c/
                 pathType: Prefix
               - backend:
                   service:
-                    name: harbor-harbor-next-portal
+                    name: harbor-portal
                     port:
                       number: 80
                 path: /
@@ -2144,17 +2144,17 @@
     apiVersion: v1
     data:
       CACHE_ENABLED: "false"
-      CORE_URL: http://harbor-harbor-next-core
+      CORE_URL: http://harbor-core
       HTTP_PROXY: ""
       HTTPS_PROXY: ""
       LOG_LEVEL: info
       METRIC_NAMESPACE: harbor
       METRIC_SUBSYSTEM: jobservice
-      NO_PROXY: harbor-harbor-next-core,harbor-harbor-next-jobservice,harbor-harbor-next-database,harbor-harbor-next-registry,harbor-harbor-next-portal,harbor-harbor-next-trivy,harbor-harbor-next-exporter,127.0.0.1,localhost,.local,.internal
-      REGISTRY_CONTROLLER_URL: http://harbor-harbor-next-registry:8080
+      NO_PROXY: harbor-core,harbor-jobservice,harbor-database,harbor-registry,harbor-portal,harbor-trivy,harbor-exporter,127.0.0.1,localhost,.local,.internal
+      REGISTRY_CONTROLLER_URL: http://harbor-registry:8080
       REGISTRY_CREDENTIAL_USERNAME: harbor_registry_user
-      REGISTRY_URL: http://harbor-harbor-next-registry:5000
-      TOKEN_SERVICE_URL: http://harbor-harbor-next-core/service/token
+      REGISTRY_URL: http://harbor-registry:5000
+      TOKEN_SERVICE_URL: http://harbor-core/service/token
       TRACE_ENABLED: "true"
       TRACE_JAEGER_ENDPOINT: http://jaeger-collector.observability:14268/api/traces
       TRACE_NAMESPACE: harbor-traces
@@ -2166,10 +2166,10 @@
         app.kubernetes.io/component: jobservice
         app.kubernetes.io/instance: harbor
         app.kubernetes.io/managed-by: Helm
-        app.kubernetes.io/name: harbor-next
+        app.kubernetes.io/name: harbor
         app.kubernetes.io/version: v2.15.0
-        helm.sh/chart: harbor-next-2.0.0
-      name: harbor-harbor-next-jobservice-env
+        helm.sh/chart: harbor-2.0.0
+      name: harbor-jobservice-env
   6: |
     apiVersion: v1
     data:
@@ -2207,10 +2207,10 @@
       labels:
         app.kubernetes.io/instance: harbor
         app.kubernetes.io/managed-by: Helm
-        app.kubernetes.io/name: harbor-next
+        app.kubernetes.io/name: harbor
         app.kubernetes.io/version: v2.15.0
-        helm.sh/chart: harbor-next-2.0.0
-      name: harbor-harbor-next-jobservice
+        helm.sh/chart: harbor-2.0.0
+      name: harbor-jobservice
   7: |
     apiVersion: v1
     kind: Service
@@ -2219,10 +2219,10 @@
         app.kubernetes.io/component: jobservice
         app.kubernetes.io/instance: harbor
         app.kubernetes.io/managed-by: Helm
-        app.kubernetes.io/name: harbor-next
+        app.kubernetes.io/name: harbor
         app.kubernetes.io/version: v2.15.0
-        helm.sh/chart: harbor-next-2.0.0
-      name: harbor-harbor-next-jobservice
+        helm.sh/chart: harbor-2.0.0
+      name: harbor-jobservice
     spec:
       ports:
         - name: http-jobservice
@@ -2236,7 +2236,7 @@
       selector:
         app.kubernetes.io/component: jobservice
         app.kubernetes.io/instance: harbor
-        app.kubernetes.io/name: harbor-next
+        app.kubernetes.io/name: harbor
       type: ClusterIP
   8: |
     apiVersion: v1
@@ -2280,10 +2280,10 @@
       labels:
         app.kubernetes.io/instance: harbor
         app.kubernetes.io/managed-by: Helm
-        app.kubernetes.io/name: harbor-next
+        app.kubernetes.io/name: harbor
         app.kubernetes.io/version: v2.15.0
-        helm.sh/chart: harbor-next-2.0.0
-      name: harbor-harbor-next-portal
+        helm.sh/chart: harbor-2.0.0
+      name: harbor-portal
   9: |
     apiVersion: v1
     kind: Service
@@ -2292,10 +2292,10 @@
         app.kubernetes.io/component: portal
         app.kubernetes.io/instance: harbor
         app.kubernetes.io/managed-by: Helm
-        app.kubernetes.io/name: harbor-next
+        app.kubernetes.io/name: harbor
         app.kubernetes.io/version: v2.15.0
-        helm.sh/chart: harbor-next-2.0.0
-      name: harbor-harbor-next-portal
+        helm.sh/chart: harbor-2.0.0
+      name: harbor-portal
     spec:
       ports:
         - name: http
@@ -2305,7 +2305,7 @@
       selector:
         app.kubernetes.io/component: portal
         app.kubernetes.io/instance: harbor
-        app.kubernetes.io/name: harbor-next
+        app.kubernetes.io/name: harbor
       type: ClusterIP
   10: |
     apiVersion: v1
@@ -2370,10 +2370,10 @@
       labels:
         app.kubernetes.io/instance: harbor
         app.kubernetes.io/managed-by: Helm
-        app.kubernetes.io/name: harbor-next
+        app.kubernetes.io/name: harbor
         app.kubernetes.io/version: v2.15.0
-        helm.sh/chart: harbor-next-2.0.0
-      name: harbor-harbor-next-registry
+        helm.sh/chart: harbor-2.0.0
+      name: harbor-registry
   11: |
     apiVersion: v1
     kind: Service
@@ -2382,10 +2382,10 @@
         app.kubernetes.io/component: registry
         app.kubernetes.io/instance: harbor
         app.kubernetes.io/managed-by: Helm
-        app.kubernetes.io/name: harbor-next
+        app.kubernetes.io/name: harbor
         app.kubernetes.io/version: v2.15.0
-        helm.sh/chart: harbor-next-2.0.0
-      name: harbor-harbor-next-registry
+        helm.sh/chart: harbor-2.0.0
+      name: harbor-registry
     spec:
       ports:
         - name: http-registry
@@ -2403,7 +2403,7 @@
       selector:
         app.kubernetes.io/component: registry
         app.kubernetes.io/instance: harbor
-        app.kubernetes.io/name: harbor-next
+        app.kubernetes.io/name: harbor
       type: ClusterIP
   12: |
     apiVersion: v1
@@ -2419,10 +2419,10 @@
       labels:
         app.kubernetes.io/instance: harbor
         app.kubernetes.io/managed-by: Helm
-        app.kubernetes.io/name: harbor-next
+        app.kubernetes.io/name: harbor
         app.kubernetes.io/version: v2.15.0
-        helm.sh/chart: harbor-next-2.0.0
-      name: harbor-harbor-next-registryctl
+        helm.sh/chart: harbor-2.0.0
+      name: harbor-registryctl
   13: |
     apiVersion: v1
     automountServiceAccountToken: false
@@ -2432,10 +2432,10 @@
         app.kubernetes.io/component: core
         app.kubernetes.io/instance: harbor
         app.kubernetes.io/managed-by: Helm
-        app.kubernetes.io/name: harbor-next
+        app.kubernetes.io/name: harbor
         app.kubernetes.io/version: v2.15.0
-        helm.sh/chart: harbor-next-2.0.0
-      name: harbor-harbor-next-core
+        helm.sh/chart: harbor-2.0.0
+      name: harbor-core
   14: |
     apiVersion: v1
     automountServiceAccountToken: false
@@ -2445,10 +2445,10 @@
         app.kubernetes.io/component: exporter
         app.kubernetes.io/instance: harbor
         app.kubernetes.io/managed-by: Helm
-        app.kubernetes.io/name: harbor-next
+        app.kubernetes.io/name: harbor
         app.kubernetes.io/version: v2.15.0
-        helm.sh/chart: harbor-next-2.0.0
-      name: harbor-harbor-next-exporter
+        helm.sh/chart: harbor-2.0.0
+      name: harbor-exporter
   15: |
     apiVersion: v1
     automountServiceAccountToken: false
@@ -2458,10 +2458,10 @@
         app.kubernetes.io/component: jobservice
         app.kubernetes.io/instance: harbor
         app.kubernetes.io/managed-by: Helm
-        app.kubernetes.io/name: harbor-next
+        app.kubernetes.io/name: harbor
         app.kubernetes.io/version: v2.15.0
-        helm.sh/chart: harbor-next-2.0.0
-      name: harbor-harbor-next-jobservice
+        helm.sh/chart: harbor-2.0.0
+      name: harbor-jobservice
   16: |
     apiVersion: v1
     automountServiceAccountToken: false
@@ -2471,10 +2471,10 @@
         app.kubernetes.io/component: portal
         app.kubernetes.io/instance: harbor
         app.kubernetes.io/managed-by: Helm
-        app.kubernetes.io/name: harbor-next
+        app.kubernetes.io/name: harbor
         app.kubernetes.io/version: v2.15.0
-        helm.sh/chart: harbor-next-2.0.0
-      name: harbor-harbor-next-portal
+        helm.sh/chart: harbor-2.0.0
+      name: harbor-portal
   17: |
     apiVersion: v1
     automountServiceAccountToken: false
@@ -2484,10 +2484,10 @@
         app.kubernetes.io/component: registry
         app.kubernetes.io/instance: harbor
         app.kubernetes.io/managed-by: Helm
-        app.kubernetes.io/name: harbor-next
+        app.kubernetes.io/name: harbor
         app.kubernetes.io/version: v2.15.0
-        helm.sh/chart: harbor-next-2.0.0
-      name: harbor-harbor-next-registry
+        helm.sh/chart: harbor-2.0.0
+      name: harbor-registry
   18: |
     apiVersion: monitoring.coreos.com/v1
     kind: ServiceMonitor
@@ -2495,11 +2495,11 @@
       labels:
         app.kubernetes.io/instance: harbor
         app.kubernetes.io/managed-by: Helm
-        app.kubernetes.io/name: harbor-next
+        app.kubernetes.io/name: harbor
         app.kubernetes.io/version: v2.15.0
-        helm.sh/chart: harbor-next-2.0.0
+        helm.sh/chart: harbor-2.0.0
         release: prometheus
-      name: harbor-harbor-next
+      name: harbor
     spec:
       endpoints:
         - honorLabels: true
@@ -2521,7 +2521,7 @@
               - registry
         matchLabels:
           app.kubernetes.io/instance: harbor
-          app.kubernetes.io/name: harbor-next
+          app.kubernetes.io/name: harbor
 6. ingress with cert-manager + multiple hosts (including wildcard):
   1: |
     apiVersion: v1
@@ -2530,19 +2530,19 @@
       CHART_CACHE_DRIVER: redis
       CONFIG_PATH: /etc/core/app.conf
       CORE_LOCAL_URL: http://127.0.0.1:8080
-      CORE_URL: http://harbor-harbor-next-core
+      CORE_URL: http://harbor-core
       DATABASE_TYPE: postgresql
       EXT_ENDPOINT: https://harbor.example.com
       GDPR_AUDIT_LOGS: "false"
       GDPR_DELETE_USER: "false"
       HTTP_PROXY: ""
       HTTPS_PROXY: ""
-      JOBSERVICE_URL: http://harbor-harbor-next-jobservice
+      JOBSERVICE_URL: http://harbor-jobservice
       LOG_LEVEL: info
-      NO_PROXY: harbor-harbor-next-core,harbor-harbor-next-jobservice,harbor-harbor-next-database,harbor-harbor-next-registry,harbor-harbor-next-portal,harbor-harbor-next-trivy,harbor-harbor-next-exporter,127.0.0.1,localhost,.local,.internal
+      NO_PROXY: harbor-core,harbor-jobservice,harbor-database,harbor-registry,harbor-portal,harbor-trivy,harbor-exporter,127.0.0.1,localhost,.local,.internal
       PERMITTED_REGISTRY_TYPES_FOR_PROXY_CACHE: docker-hub,harbor,azure-acr,ali-acr,aws-ecr,google-gcr,docker-registry,github-ghcr,jfrog-artifactory
       PORT: "8080"
-      PORTAL_URL: http://harbor-harbor-next-portal
+      PORTAL_URL: http://harbor-portal
       POSTGRESQL_CONN_MAX_IDLE_TIME: 300s
       POSTGRESQL_CONN_MAX_LIFETIME: 30m
       POSTGRESQL_DATABASE: registry
@@ -2553,13 +2553,13 @@
       POSTGRESQL_SSLMODE: disable
       POSTGRESQL_USERNAME: postgres
       QUOTA_UPDATE_PROVIDER: db
-      REGISTRY_CONTROLLER_URL: http://harbor-harbor-next-registry:8080
+      REGISTRY_CONTROLLER_URL: http://harbor-registry:8080
       REGISTRY_CREDENTIAL_USERNAME: harbor_registry_user
       REGISTRY_STORAGE_PROVIDER_NAME: filesystem
-      REGISTRY_URL: http://harbor-harbor-next-registry:5000
+      REGISTRY_URL: http://harbor-registry:5000
       REPLICATION_ADAPTER_WHITELIST: ali-acr,aws-ecr,azure-acr,docker-hub,docker-registry,github-ghcr,google-gcr,harbor,huawei-SWR,jfrog-artifactory,tencent-tcr,volcengine-cr,sftp,harbor-satellite
-      TOKEN_SERVICE_URL: http://harbor-harbor-next-core/service/token
-      TRIVY_ADAPTER_URL: http://harbor-harbor-next-trivy:8080
+      TOKEN_SERVICE_URL: http://harbor-core/service/token
+      TRIVY_ADAPTER_URL: http://harbor-trivy:8080
       WITH_TRIVY: "false"
       app.conf: |
         appname = Harbor
@@ -2574,10 +2574,10 @@
         app.kubernetes.io/component: core
         app.kubernetes.io/instance: harbor
         app.kubernetes.io/managed-by: Helm
-        app.kubernetes.io/name: harbor-next
+        app.kubernetes.io/name: harbor
         app.kubernetes.io/version: v2.15.0
-        helm.sh/chart: harbor-next-2.0.0
-      name: harbor-harbor-next-core
+        helm.sh/chart: harbor-2.0.0
+      name: harbor-core
   2: |
     apiVersion: v1
     kind: Service
@@ -2586,10 +2586,10 @@
         app.kubernetes.io/component: core
         app.kubernetes.io/instance: harbor
         app.kubernetes.io/managed-by: Helm
-        app.kubernetes.io/name: harbor-next
+        app.kubernetes.io/name: harbor
         app.kubernetes.io/version: v2.15.0
-        helm.sh/chart: harbor-next-2.0.0
-      name: harbor-harbor-next-core
+        helm.sh/chart: harbor-2.0.0
+      name: harbor-core
     spec:
       ports:
         - name: http-web
@@ -2603,7 +2603,7 @@
       selector:
         app.kubernetes.io/component: core
         app.kubernetes.io/instance: harbor
-        app.kubernetes.io/name: harbor-next
+        app.kubernetes.io/name: harbor
       type: ClusterIP
   3: |
     apiVersion: v1
@@ -2613,10 +2613,10 @@
         app.kubernetes.io/component: exporter
         app.kubernetes.io/instance: harbor
         app.kubernetes.io/managed-by: Helm
-        app.kubernetes.io/name: harbor-next
+        app.kubernetes.io/name: harbor
         app.kubernetes.io/version: v2.15.0
-        helm.sh/chart: harbor-next-2.0.0
-      name: harbor-harbor-next-exporter
+        helm.sh/chart: harbor-2.0.0
+      name: harbor-exporter
     spec:
       ports:
         - name: http-metrics
@@ -2626,7 +2626,7 @@
       selector:
         app.kubernetes.io/component: exporter
         app.kubernetes.io/instance: harbor
-        app.kubernetes.io/name: harbor-next
+        app.kubernetes.io/name: harbor
       type: ClusterIP
   4: |
     apiVersion: networking.k8s.io/v1
@@ -2635,10 +2635,10 @@
       labels:
         app.kubernetes.io/instance: harbor
         app.kubernetes.io/managed-by: Helm
-        app.kubernetes.io/name: harbor-next
+        app.kubernetes.io/name: harbor
         app.kubernetes.io/version: v2.15.0
-        helm.sh/chart: harbor-next-2.0.0
-      name: harbor-harbor-next
+        helm.sh/chart: harbor-2.0.0
+      name: harbor
     spec:
       rules:
         - host: harbor.example.com
@@ -2646,42 +2646,42 @@
             paths:
               - backend:
                   service:
-                    name: harbor-harbor-next-core
+                    name: harbor-core
                     port:
                       number: 80
                 path: /api/
                 pathType: Prefix
               - backend:
                   service:
-                    name: harbor-harbor-next-core
+                    name: harbor-core
                     port:
                       number: 80
                 path: /service/
                 pathType: Prefix
               - backend:
                   service:
-                    name: harbor-harbor-next-core
+                    name: harbor-core
                     port:
                       number: 80
                 path: /v2/
                 pathType: Prefix
               - backend:
                   service:
-                    name: harbor-harbor-next-core
+                    name: harbor-core
                     port:
                       number: 80
                 path: /chartrepo/
                 pathType: Prefix
               - backend:
                   service:
-                    name: harbor-harbor-next-core
+                    name: harbor-core
                     port:
                       number: 80
                 path: /c/
                 pathType: Prefix
               - backend:
                   service:
-                    name: harbor-harbor-next-portal
+                    name: harbor-portal
                     port:
                       number: 80
                 path: /
@@ -2691,42 +2691,42 @@
             paths:
               - backend:
                   service:
-                    name: harbor-harbor-next-core
+                    name: harbor-core
                     port:
                       number: 80
                 path: /api/
                 pathType: Prefix
               - backend:
                   service:
-                    name: harbor-harbor-next-core
+                    name: harbor-core
                     port:
                       number: 80
                 path: /service/
                 pathType: Prefix
               - backend:
                   service:
-                    name: harbor-harbor-next-core
+                    name: harbor-core
                     port:
                       number: 80
                 path: /v2/
                 pathType: Prefix
               - backend:
                   service:
-                    name: harbor-harbor-next-core
+                    name: harbor-core
                     port:
                       number: 80
                 path: /chartrepo/
                 pathType: Prefix
               - backend:
                   service:
-                    name: harbor-harbor-next-core
+                    name: harbor-core
                     port:
                       number: 80
                 path: /c/
                 pathType: Prefix
               - backend:
                   service:
-                    name: harbor-harbor-next-portal
+                    name: harbor-portal
                     port:
                       number: 80
                 path: /
@@ -2736,42 +2736,42 @@
             paths:
               - backend:
                   service:
-                    name: harbor-harbor-next-core
+                    name: harbor-core
                     port:
                       number: 80
                 path: /api/
                 pathType: Prefix
               - backend:
                   service:
-                    name: harbor-harbor-next-core
+                    name: harbor-core
                     port:
                       number: 80
                 path: /service/
                 pathType: Prefix
               - backend:
                   service:
-                    name: harbor-harbor-next-core
+                    name: harbor-core
                     port:
                       number: 80
                 path: /v2/
                 pathType: Prefix
               - backend:
                   service:
-                    name: harbor-harbor-next-core
+                    name: harbor-core
                     port:
                       number: 80
                 path: /chartrepo/
                 pathType: Prefix
               - backend:
                   service:
-                    name: harbor-harbor-next-core
+                    name: harbor-core
                     port:
                       number: 80
                 path: /c/
                 pathType: Prefix
               - backend:
                   service:
-                    name: harbor-harbor-next-portal
+                    name: harbor-portal
                     port:
                       number: 80
                 path: /
@@ -2780,25 +2780,25 @@
     apiVersion: v1
     data:
       CACHE_ENABLED: "false"
-      CORE_URL: http://harbor-harbor-next-core
+      CORE_URL: http://harbor-core
       HTTP_PROXY: ""
       HTTPS_PROXY: ""
       LOG_LEVEL: info
-      NO_PROXY: harbor-harbor-next-core,harbor-harbor-next-jobservice,harbor-harbor-next-database,harbor-harbor-next-registry,harbor-harbor-next-portal,harbor-harbor-next-trivy,harbor-harbor-next-exporter,127.0.0.1,localhost,.local,.internal
-      REGISTRY_CONTROLLER_URL: http://harbor-harbor-next-registry:8080
+      NO_PROXY: harbor-core,harbor-jobservice,harbor-database,harbor-registry,harbor-portal,harbor-trivy,harbor-exporter,127.0.0.1,localhost,.local,.internal
+      REGISTRY_CONTROLLER_URL: http://harbor-registry:8080
       REGISTRY_CREDENTIAL_USERNAME: harbor_registry_user
-      REGISTRY_URL: http://harbor-harbor-next-registry:5000
-      TOKEN_SERVICE_URL: http://harbor-harbor-next-core/service/token
+      REGISTRY_URL: http://harbor-registry:5000
+      TOKEN_SERVICE_URL: http://harbor-core/service/token
     kind: ConfigMap
     metadata:
       labels:
         app.kubernetes.io/component: jobservice
         app.kubernetes.io/instance: harbor
         app.kubernetes.io/managed-by: Helm
-        app.kubernetes.io/name: harbor-next
+        app.kubernetes.io/name: harbor
         app.kubernetes.io/version: v2.15.0
-        helm.sh/chart: harbor-next-2.0.0
-      name: harbor-harbor-next-jobservice-env
+        helm.sh/chart: harbor-2.0.0
+      name: harbor-jobservice-env
   6: |
     apiVersion: v1
     data:
@@ -2832,10 +2832,10 @@
       labels:
         app.kubernetes.io/instance: harbor
         app.kubernetes.io/managed-by: Helm
-        app.kubernetes.io/name: harbor-next
+        app.kubernetes.io/name: harbor
         app.kubernetes.io/version: v2.15.0
-        helm.sh/chart: harbor-next-2.0.0
-      name: harbor-harbor-next-jobservice
+        helm.sh/chart: harbor-2.0.0
+      name: harbor-jobservice
   7: |
     apiVersion: v1
     kind: Service
@@ -2844,10 +2844,10 @@
         app.kubernetes.io/component: jobservice
         app.kubernetes.io/instance: harbor
         app.kubernetes.io/managed-by: Helm
-        app.kubernetes.io/name: harbor-next
+        app.kubernetes.io/name: harbor
         app.kubernetes.io/version: v2.15.0
-        helm.sh/chart: harbor-next-2.0.0
-      name: harbor-harbor-next-jobservice
+        helm.sh/chart: harbor-2.0.0
+      name: harbor-jobservice
     spec:
       ports:
         - name: http-jobservice
@@ -2861,7 +2861,7 @@
       selector:
         app.kubernetes.io/component: jobservice
         app.kubernetes.io/instance: harbor
-        app.kubernetes.io/name: harbor-next
+        app.kubernetes.io/name: harbor
       type: ClusterIP
   8: |
     apiVersion: v1
@@ -2905,10 +2905,10 @@
       labels:
         app.kubernetes.io/instance: harbor
         app.kubernetes.io/managed-by: Helm
-        app.kubernetes.io/name: harbor-next
+        app.kubernetes.io/name: harbor
         app.kubernetes.io/version: v2.15.0
-        helm.sh/chart: harbor-next-2.0.0
-      name: harbor-harbor-next-portal
+        helm.sh/chart: harbor-2.0.0
+      name: harbor-portal
   9: |
     apiVersion: v1
     kind: Service
@@ -2917,10 +2917,10 @@
         app.kubernetes.io/component: portal
         app.kubernetes.io/instance: harbor
         app.kubernetes.io/managed-by: Helm
-        app.kubernetes.io/name: harbor-next
+        app.kubernetes.io/name: harbor
         app.kubernetes.io/version: v2.15.0
-        helm.sh/chart: harbor-next-2.0.0
-      name: harbor-harbor-next-portal
+        helm.sh/chart: harbor-2.0.0
+      name: harbor-portal
     spec:
       ports:
         - name: http
@@ -2930,7 +2930,7 @@
       selector:
         app.kubernetes.io/component: portal
         app.kubernetes.io/instance: harbor
-        app.kubernetes.io/name: harbor-next
+        app.kubernetes.io/name: harbor
       type: ClusterIP
   10: |
     apiVersion: v1
@@ -2992,10 +2992,10 @@
       labels:
         app.kubernetes.io/instance: harbor
         app.kubernetes.io/managed-by: Helm
-        app.kubernetes.io/name: harbor-next
+        app.kubernetes.io/name: harbor
         app.kubernetes.io/version: v2.15.0
-        helm.sh/chart: harbor-next-2.0.0
-      name: harbor-harbor-next-registry
+        helm.sh/chart: harbor-2.0.0
+      name: harbor-registry
   11: |
     apiVersion: v1
     kind: Service
@@ -3004,10 +3004,10 @@
         app.kubernetes.io/component: registry
         app.kubernetes.io/instance: harbor
         app.kubernetes.io/managed-by: Helm
-        app.kubernetes.io/name: harbor-next
+        app.kubernetes.io/name: harbor
         app.kubernetes.io/version: v2.15.0
-        helm.sh/chart: harbor-next-2.0.0
-      name: harbor-harbor-next-registry
+        helm.sh/chart: harbor-2.0.0
+      name: harbor-registry
     spec:
       ports:
         - name: http-registry
@@ -3025,7 +3025,7 @@
       selector:
         app.kubernetes.io/component: registry
         app.kubernetes.io/instance: harbor
-        app.kubernetes.io/name: harbor-next
+        app.kubernetes.io/name: harbor
       type: ClusterIP
   12: |
     apiVersion: v1
@@ -3036,10 +3036,10 @@
       labels:
         app.kubernetes.io/instance: harbor
         app.kubernetes.io/managed-by: Helm
-        app.kubernetes.io/name: harbor-next
+        app.kubernetes.io/name: harbor
         app.kubernetes.io/version: v2.15.0
-        helm.sh/chart: harbor-next-2.0.0
-      name: harbor-harbor-next-registryctl
+        helm.sh/chart: harbor-2.0.0
+      name: harbor-registryctl
   13: |
     apiVersion: v1
     automountServiceAccountToken: false
@@ -3049,10 +3049,10 @@
         app.kubernetes.io/component: core
         app.kubernetes.io/instance: harbor
         app.kubernetes.io/managed-by: Helm
-        app.kubernetes.io/name: harbor-next
+        app.kubernetes.io/name: harbor
         app.kubernetes.io/version: v2.15.0
-        helm.sh/chart: harbor-next-2.0.0
-      name: harbor-harbor-next-core
+        helm.sh/chart: harbor-2.0.0
+      name: harbor-core
   14: |
     apiVersion: v1
     automountServiceAccountToken: false
@@ -3062,10 +3062,10 @@
         app.kubernetes.io/component: exporter
         app.kubernetes.io/instance: harbor
         app.kubernetes.io/managed-by: Helm
-        app.kubernetes.io/name: harbor-next
+        app.kubernetes.io/name: harbor
         app.kubernetes.io/version: v2.15.0
-        helm.sh/chart: harbor-next-2.0.0
-      name: harbor-harbor-next-exporter
+        helm.sh/chart: harbor-2.0.0
+      name: harbor-exporter
   15: |
     apiVersion: v1
     automountServiceAccountToken: false
@@ -3075,10 +3075,10 @@
         app.kubernetes.io/component: jobservice
         app.kubernetes.io/instance: harbor
         app.kubernetes.io/managed-by: Helm
-        app.kubernetes.io/name: harbor-next
+        app.kubernetes.io/name: harbor
         app.kubernetes.io/version: v2.15.0
-        helm.sh/chart: harbor-next-2.0.0
-      name: harbor-harbor-next-jobservice
+        helm.sh/chart: harbor-2.0.0
+      name: harbor-jobservice
   16: |
     apiVersion: v1
     automountServiceAccountToken: false
@@ -3088,10 +3088,10 @@
         app.kubernetes.io/component: portal
         app.kubernetes.io/instance: harbor
         app.kubernetes.io/managed-by: Helm
-        app.kubernetes.io/name: harbor-next
+        app.kubernetes.io/name: harbor
         app.kubernetes.io/version: v2.15.0
-        helm.sh/chart: harbor-next-2.0.0
-      name: harbor-harbor-next-portal
+        helm.sh/chart: harbor-2.0.0
+      name: harbor-portal
   17: |
     apiVersion: v1
     automountServiceAccountToken: false
@@ -3101,10 +3101,10 @@
         app.kubernetes.io/component: registry
         app.kubernetes.io/instance: harbor
         app.kubernetes.io/managed-by: Helm
-        app.kubernetes.io/name: harbor-next
+        app.kubernetes.io/name: harbor
         app.kubernetes.io/version: v2.15.0
-        helm.sh/chart: harbor-next-2.0.0
-      name: harbor-harbor-next-registry
+        helm.sh/chart: harbor-2.0.0
+      name: harbor-registry
   18: |
     apiVersion: cert-manager.io/v1
     kind: Certificate
@@ -3112,10 +3112,10 @@
       labels:
         app.kubernetes.io/instance: harbor
         app.kubernetes.io/managed-by: Helm
-        app.kubernetes.io/name: harbor-next
+        app.kubernetes.io/name: harbor
         app.kubernetes.io/version: v2.15.0
-        helm.sh/chart: harbor-next-2.0.0
-      name: harbor-harbor-next-harbor-example-com-671b44f3
+        helm.sh/chart: harbor-2.0.0
+      name: harbor-harbor-example-com-b9096314
     spec:
       dnsNames:
         - harbor.example.com
@@ -3124,7 +3124,7 @@
         kind: ClusterIssuer
         name: letsencrypt-prod
       renewBefore: 360h
-      secretName: harbor-harbor-next-harbor-example-com-671b44f3-tls
+      secretName: harbor-harbor-example-com-b9096314-tls
   19: |
     apiVersion: cert-manager.io/v1
     kind: Certificate
@@ -3132,10 +3132,10 @@
       labels:
         app.kubernetes.io/instance: harbor
         app.kubernetes.io/managed-by: Helm
-        app.kubernetes.io/name: harbor-next
+        app.kubernetes.io/name: harbor
         app.kubernetes.io/version: v2.15.0
-        helm.sh/chart: harbor-next-2.0.0
-      name: harbor-harbor-next-notary-example-com-cad059df
+        helm.sh/chart: harbor-2.0.0
+      name: harbor-notary-example-com-a2fd2ccd
     spec:
       dnsNames:
         - notary.example.com
@@ -3144,7 +3144,7 @@
         kind: ClusterIssuer
         name: letsencrypt-prod
       renewBefore: 360h
-      secretName: harbor-harbor-next-notary-example-com-cad059df-tls
+      secretName: harbor-notary-example-com-a2fd2ccd-tls
   20: |
     apiVersion: cert-manager.io/v1
     kind: Certificate
@@ -3152,10 +3152,10 @@
       labels:
         app.kubernetes.io/instance: harbor
         app.kubernetes.io/managed-by: Helm
-        app.kubernetes.io/name: harbor-next
+        app.kubernetes.io/name: harbor
         app.kubernetes.io/version: v2.15.0
-        helm.sh/chart: harbor-next-2.0.0
-      name: harbor-harbor-next-wildcard-harbor-example-com-16eaf6f2
+        helm.sh/chart: harbor-2.0.0
+      name: harbor-wildcard-harbor-example-com-2f089bf5
     spec:
       dnsNames:
         - '*.harbor.example.com'
@@ -3164,4 +3164,4 @@
         kind: ClusterIssuer
         name: letsencrypt-prod
       renewBefore: 360h
-      secretName: harbor-harbor-next-wildcard-harbor-example-com-16eaf6f2-tls
+      secretName: harbor-wildcard-harbor-example-com-2f089bf5-tls

--- a/deploy/chart/tests/core_test.yaml
+++ b/deploy/chart/tests/core_test.yaml
@@ -77,14 +77,14 @@ tests:
             name: SECRET_KEY
             valueFrom:
               secretKeyRef:
-                name: RELEASE-NAME-harbor-next-core
+                name: RELEASE-NAME-harbor-core
                 key: SECRET_KEY
       - contains:
           path: spec.template.spec.volumes
           content:
             name: secret-key
             secret:
-              secretName: RELEASE-NAME-harbor-next-core
+              secretName: RELEASE-NAME-harbor-core
               items:
                 - key: secretKey
                   path: key
@@ -154,7 +154,7 @@ tests:
       existingSecretSecretKey: my-enc
     documentSelector:
       path: metadata.name
-      value: RELEASE-NAME-harbor-next-core
+      value: RELEASE-NAME-harbor-core
     asserts:
       - notExists:
           path: data.SECRET_KEY
@@ -173,7 +173,7 @@ tests:
       secretKey: "sixteenkeychars1"  # schema requires exactly 16 chars
     documentSelector:
       path: metadata.name
-      value: RELEASE-NAME-harbor-next-core
+      value: RELEASE-NAME-harbor-core
     asserts:
       - equal:
           path: data.SECRET_KEY
@@ -199,7 +199,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].envFrom[1].secretRef.name
-          value: RELEASE-NAME-harbor-next-core
+          value: RELEASE-NAME-harbor-core
       - contains:
           path: spec.template.spec.containers[0].env
           content:

--- a/deploy/chart/tests/db_tls_test.yaml
+++ b/deploy/chart/tests/db_tls_test.yaml
@@ -95,7 +95,7 @@ tests:
             name: POSTGRESQL_PASSWORD
             valueFrom:
               secretKeyRef:
-                name: RELEASE-NAME-harbor-next-database
+                name: RELEASE-NAME-harbor-database
                 key: POSTGRESQL_PASSWORD
       - contains:
           path: spec.template.spec.containers[0].env

--- a/deploy/chart/tests/exporter_test.yaml
+++ b/deploy/chart/tests/exporter_test.yaml
@@ -106,7 +106,7 @@ tests:
           path: spec.template.spec.containers[0].envFrom
           content:
             configMapRef:
-              name: RELEASE-NAME-harbor-next-exporter-env
+              name: RELEASE-NAME-harbor-exporter-env
 
   # No empty ConfigMap and no envFrom when config is unset (default).
   - it: should not render exporter env ConfigMap when config is empty
@@ -165,7 +165,7 @@ tests:
             name: REDIS_PASSWORD
             valueFrom:
               secretKeyRef:
-                name: RELEASE-NAME-harbor-next-redis
+                name: RELEASE-NAME-harbor-redis
                 key: REDIS_PASSWORD
 
   # Config-reload: exporter.config / exporter.secret feed env via envFrom by

--- a/deploy/chart/tests/expose_test.yaml
+++ b/deploy/chart/tests/expose_test.yaml
@@ -133,4 +133,4 @@ tests:
           value: Service
       - equal:
           path: spec.to.name
-          value: RELEASE-NAME-harbor-next-core
+          value: RELEASE-NAME-harbor-core

--- a/deploy/chart/tests/hpa_test.yaml
+++ b/deploy/chart/tests/hpa_test.yaml
@@ -61,7 +61,7 @@ tests:
           value: Deployment
       - equal:
           path: spec.scaleTargetRef.name
-          value: RELEASE-NAME-harbor-next-core
+          value: RELEASE-NAME-harbor-core
       - equal:
           path: spec.minReplicas
           value: 2
@@ -153,7 +153,7 @@ tests:
           value: StatefulSet
       - equal:
           path: spec.scaleTargetRef.name
-          value: RELEASE-NAME-harbor-next-trivy
+          value: RELEASE-NAME-harbor-trivy
 
   # Trivy HPA must NOT render when trivy itself is disabled — otherwise
   # the HPA targets a non-existent StatefulSet and K8s warns.

--- a/deploy/chart/tests/ingress_test.yaml
+++ b/deploy/chart/tests/ingress_test.yaml
@@ -196,7 +196,7 @@ tests:
     asserts:
       - equal:
           path: metadata.name
-          value: RELEASE-NAME-harbor-next-ingress-tls
+          value: RELEASE-NAME-harbor-ingress-tls
 
   - it: should not render the autoGen Secret when autoGenCert is false
     template: templates/ingress.secret.yaml

--- a/deploy/chart/tests/jobservice_test.yaml
+++ b/deploy/chart/tests/jobservice_test.yaml
@@ -24,7 +24,7 @@ tests:
           of: Deployment
       - equal:
           path: metadata.name
-          value: RELEASE-NAME-harbor-next-jobservice
+          value: RELEASE-NAME-harbor-jobservice
 
   # Pins image concat: <registry>/<repository>:<tag>
   - it: should concat registry, repository and tag
@@ -67,7 +67,7 @@ tests:
             name: CORE_SECRET
             valueFrom:
               secretKeyRef:
-                name: RELEASE-NAME-harbor-next-core
+                name: RELEASE-NAME-harbor-core
                 key: secret
 
   # Pins service fullname + chart-hardcoded port 80
@@ -82,7 +82,7 @@ tests:
           of: Service
       - equal:
           path: metadata.name
-          value: RELEASE-NAME-harbor-next-jobservice
+          value: RELEASE-NAME-harbor-jobservice
       - equal:
           path: spec.ports[0].port
           value: 80
@@ -308,7 +308,7 @@ tests:
           value: job-logs
       - equal:
           path: spec.template.spec.volumes[1].persistentVolumeClaim.claimName
-          value: RELEASE-NAME-harbor-next-jobservice
+          value: RELEASE-NAME-harbor-jobservice
 
   # Pins volume selection: existingClaim overrides chart-computed claimName
   - it: should mount existingClaim verbatim when set
@@ -348,7 +348,7 @@ tests:
                 key: JOBSERVICE_SECRET
       - equal:
           path: spec.template.spec.containers[0].envFrom[1].secretRef.name
-          value: RELEASE-NAME-harbor-next-jobservice
+          value: RELEASE-NAME-harbor-jobservice
 
   - it: should wire REGISTRY_CREDENTIAL_PASSWORD env from credentials.existingSecret
     template: templates/jobservice.deployment.yaml

--- a/deploy/chart/tests/pdb_test.yaml
+++ b/deploy/chart/tests/pdb_test.yaml
@@ -50,7 +50,7 @@ tests:
   - it: should support maxUnavailable instead of minAvailable
     documentSelector:
       path: metadata.name
-      value: RELEASE-NAME-harbor-next-core
+      value: RELEASE-NAME-harbor-core
     set:
       externalURL: https://harbor.example.com
       database.host: postgres.example.com
@@ -70,7 +70,7 @@ tests:
   - it: should support percentage values for minAvailable
     documentSelector:
       path: metadata.name
-      value: RELEASE-NAME-harbor-next-core
+      value: RELEASE-NAME-harbor-core
     set:
       externalURL: https://harbor.example.com
       database.host: postgres.example.com

--- a/deploy/chart/tests/registry_test.yaml
+++ b/deploy/chart/tests/registry_test.yaml
@@ -333,7 +333,7 @@ tests:
       registry.existingSecret: my-reg
     documentSelector:
       path: metadata.name
-      value: RELEASE-NAME-harbor-next-registry
+      value: RELEASE-NAME-harbor-registry
     asserts:
       - notExists:
           path: data.REGISTRY_HTTP_SECRET

--- a/deploy/chart/tests/serviceaccount_test.yaml
+++ b/deploy/chart/tests/serviceaccount_test.yaml
@@ -89,7 +89,7 @@ tests:
   - it: should wire IRSA annotation onto the core ServiceAccount
     documentSelector:
       path: metadata.name
-      value: RELEASE-NAME-harbor-next-core
+      value: RELEASE-NAME-harbor-core
     set:
       externalURL: https://harbor.example.com
       database.host: postgres.example.com

--- a/deploy/chart/tests/tls_test.yaml
+++ b/deploy/chart/tests/tls_test.yaml
@@ -41,7 +41,7 @@ tests:
     asserts:
       - matchRegex:
           path: metadata.name
-          pattern: "^RELEASE-NAME-harbor-ne-harbor-example-com-[0-9a-f]{8}$"
+          pattern: "^RELEASE-NAME-harbor-harbor-example-com-[0-9a-f]{8}$"
 
   # Pins the chart-computed secretName: same shape as metadata.name
   # plus a `-tls` suffix, so the Ingress/HTTPRoute can reference the
@@ -63,7 +63,7 @@ tests:
     asserts:
       - matchRegex:
           path: spec.secretName
-          pattern: "^RELEASE-NAME-harbor-ne-harbor-example-com-[0-9a-f]{8}-tls$"
+          pattern: "^RELEASE-NAME-harbor-harbor-example-com-[0-9a-f]{8}-tls$"
 
   # Pins the conditional emission of spec.duration and spec.renewBefore
   # — these keys are only rendered when set in values, and cert-manager
@@ -186,10 +186,10 @@ tests:
     asserts:
       - matchRegex:
           path: metadata.name
-          pattern: "^RELEASE-NAME-harbor-ne-wildcard-example-com-[0-9a-f]{8}$"
+          pattern: "^RELEASE-NAME-harbor-wildcard-example-com-[0-9a-f]{8}$"
       - matchRegex:
           path: spec.secretName
-          pattern: "^RELEASE-NAME-harbor-ne-wildcard-example-com-[0-9a-f]{8}-tls$"
+          pattern: "^RELEASE-NAME-harbor-wildcard-example-com-[0-9a-f]{8}-tls$"
       # dnsNames keeps the original wildcard — the cert covers *.example.com
       - equal:
           path: spec.dnsNames[0]

--- a/deploy/chart/tests/trivy_test.yaml
+++ b/deploy/chart/tests/trivy_test.yaml
@@ -280,7 +280,7 @@ tests:
             name: REDIS_PASSWORD
             valueFrom:
               secretKeyRef:
-                name: RELEASE-NAME-harbor-next-redis
+                name: RELEASE-NAME-harbor-redis
                 key: REDIS_PASSWORD
 
   - it: should expose service port named http-trivy
@@ -331,7 +331,7 @@ tests:
           path: spec.template.spec.containers[0].envFrom
           content:
             configMapRef:
-              name: RELEASE-NAME-harbor-next-trivy-env
+              name: RELEASE-NAME-harbor-trivy-env
 
   - it: should not render trivy env ConfigMap when config is empty
     template: templates/trivy.configmap-env.yaml
@@ -361,7 +361,7 @@ tests:
           of: Secret
       - equal:
           path: metadata.name
-          value: RELEASE-NAME-harbor-next-trivy-env
+          value: RELEASE-NAME-harbor-trivy-env
       - equal:
           path: data.MY_SCANNER_TOKEN
           value: "czNjcjN0"

--- a/release-please-config-chart.json
+++ b/release-please-config-chart.json
@@ -2,7 +2,7 @@
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
   "bootstrap-sha": "e11385c8c49528159a8b009590d48fe55455f8eb",
   "pull-request-header": "This PR prepares the next Helm chart release based on conventional commits scoped to deploy/chart.",
-  "pull-request-title-pattern": "chore: release harbor-next chart ${version}",
+  "pull-request-title-pattern": "chore: release harbor chart ${version}",
   "label": "chart-release: pending",
   "release-label": "chart-release: tagged",
   "include-v-in-tag": true,
@@ -21,11 +21,10 @@
   "packages": {
     "deploy/chart": {
       "release-type": "helm",
-      "package-name": "harbor-next",
+      "package-name": "harbor",
       "component": "chart",
       "include-component-in-tag": true,
-      "changelog-path": "CHANGELOG.md",
-      "release-as": "2.0.0"
+      "changelog-path": "CHANGELOG.md"
     }
   }
 }

--- a/taskfile/helm.yml
+++ b/taskfile/helm.yml
@@ -6,7 +6,7 @@ version: '3'
 
 vars:
   CHART_DIR: deploy/chart
-  CHART_NAME: harbor-next
+  CHART_NAME: harbor
 
   # Tool versions come from versions.env (single source of truth,
   # loaded via the root Taskfile dotenv; CI installs the same pins).
@@ -256,7 +256,7 @@ tasks:
             macOS:  brew install norwoodj/tap/helm-docs
             Linux:  go install github.com/norwoodj/helm-docs/cmd/helm-docs@latest
     cmds:
-      # --chart-to-generate isolates the harbor-next chart so helm-docs
+      # --chart-to-generate isolates the harbor chart so helm-docs
       # doesn't also process the extracted valkey subchart in charts/.
       - helm-docs --chart-search-root={{.CHART_DIR}} --chart-to-generate={{.CHART_DIR}} --dry-run > /tmp/helm-docs-expected.md
       - defer: rm -f /tmp/helm-docs-expected.md /tmp/helm-docs-actual.md
@@ -281,7 +281,7 @@ tasks:
     desc: "Generate chart README.md from values.yaml + README.md.gotmpl"
     deps: [_require-helm-docs]
     cmds:
-      # --chart-to-generate isolates the harbor-next chart so helm-docs
+      # --chart-to-generate isolates the harbor chart so helm-docs
       # doesn't also process the extracted valkey subchart in charts/.
       - helm-docs --chart-search-root={{.CHART_DIR}} --chart-to-generate={{.CHART_DIR}}
     sources:


### PR DESCRIPTION
## Summary

Renames the Helm chart artifact from `harbor-next` to `harbor` (chart-identity only — the repo, app, and images keep their names):

- `deploy/chart/Chart.yaml`: `name: harbor`
- `release-please-config-chart.json`: `package-name: harbor`, PR title pattern `chore: release harbor chart ${version}` (the reason #728 says "harbor-next chart"), and **drops the stale `release-as: "2.0.0"` pin** left from the chart-v2.0.0 release — it made release-please propose 2.0.0 again with a nonsense `chart-v2.0.0...chart-v2.0.0` changelog range in #728
- `publish-chart.yml`: package/push/sign/oras paths → `charts/harbor`
- `taskfile/helm.yml` `CHART_NAME`, chart docs, guides, and examples
- Tests: `RELEASE-NAME-harbor-next-*` assertions and cert-name truncation patterns updated, snapshots regenerated (`helm unittest`: 249/249 passing); README regenerated with helm-docs v1.14.2

## Type of Change

- [x] New feature (`feat:`)
- [x] Breaking change (`feat!:`)

## Release Notes

The Helm chart is now named **`harbor`** and publishes to `oci://8gears.container-registry.com/8gcr/charts/harbor`. The old `charts/harbor-next` path receives no further releases. Because default resource names and the immutable `app.kubernetes.io/name` selector label derive from the chart name, existing `harbor-next` chart installs must set `nameOverride: harbor-next` to upgrade in place — see `deploy/chart/docs/MIGRATION.md` for the exact command.

## Notes for reviewers

- With `release-as` removed, the `feat!:` here bumps the chart to **3.0.0** on the next release-please run; release-please rewrites its open release PR (#728) in place — title, version, and changelog regenerate from this config once merged.
- Intentionally untouched `harbor-next` references: repo URLs, `ttl.sh/harbor-next` image namespace, eks-irsa infra names, the Flux `GitRepository` source name (points at the repo, not the chart), and historical CHANGELOG entries.

## Testing

- [x] `helm unittest deploy/chart` — 23 suites, 249 tests, 106 snapshots passing
- [x] helm-docs README sync check green (pinned v1.14.2 release binary)