### PR TITLE
feat: Add configurable default project for project-less pushes

### DIFF
--- a/api/v2.0/swagger.yaml
+++ b/api/v2.0/swagger.yaml
@@ -9412,6 +9412,9 @@ definitions:
       disabled_audit_log_event_types:
         $ref: '#/definitions/StringConfigItem'
         description: The audit log event types to skip to log in database
+      default_project_name:
+        $ref: '#/definitions/StringConfigItem'
+        description: The project that catches repositories pushed or pulled without a project segment. Empty disables the fallback.
   Configurations:
     type: object
     properties:
@@ -9708,6 +9711,11 @@ definitions:
       disabled_audit_log_event_types:
         type: string
         description: the list to disable log audit event types.
+        x-omitempty: true
+        x-isnullable: true
+      default_project_name:
+        type: string
+        description: The project that catches repositories pushed or pulled without a project segment. Empty disables the fallback.
         x-omitempty: true
         x-isnullable: true
   StringConfigItem:

--- a/src/common/const.go
+++ b/src/common/const.go
@@ -235,6 +235,10 @@ const (
 	// Customized banner message
 	BannerMessage = "banner_message"
 
+	// DefaultProjectName is the project that receives repositories pushed/pulled
+	// without a project segment; empty disables the fallback
+	DefaultProjectName = "default_project_name"
+
 	// UnauthenticatedLandingPage controls which page unauthenticated users see
 	UnauthenticatedLandingPage = "unauthenticated_landing_page"
 	LandingPageLogin           = "login"

--- a/src/controller/config/controller.go
+++ b/src/controller/config/controller.go
@@ -28,6 +28,7 @@ import (
 	"github.com/goharbor/harbor/src/lib/log"
 	"github.com/goharbor/harbor/src/lib/q"
 	"github.com/goharbor/harbor/src/pkg/audit"
+	"github.com/goharbor/harbor/src/pkg/project"
 	"github.com/goharbor/harbor/src/pkg/user"
 )
 
@@ -143,6 +144,29 @@ func (c *controller) validateCfg(ctx context.Context, cfgs map[string]any) error
 		return err
 	}
 
+	// verify the default project name cfg
+	if err = verifyDefaultProjectNameCfg(cfgs); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// verifyDefaultProjectNameCfg rejects a default_project_name that is not a
+// legal project name; every bare repository path and token scope would
+// otherwise be qualified with an unusable prefix. Empty disables the fallback.
+func verifyDefaultProjectNameCfg(cfgs map[string]any) error {
+	v, exist := cfgs[common.DefaultProjectName]
+	if !exist {
+		return nil
+	}
+	name, ok := v.(string)
+	if !ok {
+		return errors.BadRequestError(nil).WithMessagef("the %s value must be a string", common.DefaultProjectName)
+	}
+	if name != "" && !project.IsValidName(name) {
+		return errors.BadRequestError(nil).WithMessagef("the %s value %q is not a valid project name", common.DefaultProjectName, name)
+	}
 	return nil
 }
 

--- a/src/controller/config/controller_test.go
+++ b/src/controller/config/controller_test.go
@@ -120,3 +120,27 @@ func Test_verifyValueLengthCfg(t *testing.T) {
 		})
 	}
 }
+
+func TestVerifyDefaultProjectNameCfg(t *testing.T) {
+	tests := []struct {
+		name    string
+		cfgs    map[string]any
+		wantErr bool
+	}{
+		{name: "absent", cfgs: map[string]any{}, wantErr: false},
+		{name: "empty disables fallback", cfgs: map[string]any{common.DefaultProjectName: ""}, wantErr: false},
+		{name: "valid name", cfgs: map[string]any{common.DefaultProjectName: "library"}, wantErr: false},
+		{name: "uppercase", cfgs: map[string]any{common.DefaultProjectName: "Library"}, wantErr: true},
+		{name: "contains slash", cfgs: map[string]any{common.DefaultProjectName: "a/b"}, wantErr: true},
+		{name: "contains space", cfgs: map[string]any{common.DefaultProjectName: "a b"}, wantErr: true},
+		{name: "leading separator", cfgs: map[string]any{common.DefaultProjectName: "_lib"}, wantErr: true},
+		{name: "not a string", cfgs: map[string]any{common.DefaultProjectName: 42}, wantErr: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := verifyDefaultProjectNameCfg(tt.cfgs); (err != nil) != tt.wantErr {
+				t.Errorf("verifyDefaultProjectNameCfg() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}

--- a/src/core/service/token/creator.go
+++ b/src/core/service/token/creator.go
@@ -28,6 +28,7 @@ import (
 	rbac_project "github.com/goharbor/harbor/src/common/rbac/project"
 	"github.com/goharbor/harbor/src/common/security"
 	"github.com/goharbor/harbor/src/controller/project"
+	"github.com/goharbor/harbor/src/lib/config"
 	"github.com/goharbor/harbor/src/lib/errors"
 	"github.com/goharbor/harbor/src/lib/log"
 )
@@ -214,11 +215,30 @@ func (g generalCreator) Create(r *http.Request) (*models.Token, error) {
 		}
 	}
 	access := GetResourceActions(scopes)
+	rewriteBareRepositoryScopes(r.Context(), access)
 	err = filterAccess(r.Context(), access, project.Ctl, g.filterMap)
 	if err != nil {
 		return nil, err
 	}
 	return MakeToken(r.Context(), ctx.GetUsername(), g.service, access)
+}
+
+// rewriteBareRepositoryScopes qualifies repository scopes that lack a project
+// segment with the configured default project, so a client-computed scope like
+// "repository:alpine:push,pull" grants access on "<default>/alpine". Clients
+// build the scope from the repository reference they were given, hence a bare
+// push produces a bare scope even though the URL rewrite in the artifactinfo
+// middleware already qualified the request path.
+func rewriteBareRepositoryScopes(ctx context.Context, access []*token.ResourceActions) {
+	dp := config.DefaultProjectName(ctx)
+	if dp == "" {
+		return
+	}
+	for _, a := range access {
+		if a.Type == "repository" && a.Name != "" && !strings.Contains(a.Name, "/") {
+			a.Name = dp + "/" + a.Name
+		}
+	}
 }
 
 func parseScopes(u *url.URL) []string {

--- a/src/core/service/token/creator_test.go
+++ b/src/core/service/token/creator_test.go
@@ -1,0 +1,56 @@
+// Copyright Project Harbor Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	  http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package token
+
+import (
+	"context"
+	"testing"
+
+	"github.com/docker/distribution/registry/auth/token"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/goharbor/harbor/src/common"
+	"github.com/goharbor/harbor/src/lib/config"
+	_ "github.com/goharbor/harbor/src/pkg/config/inmemory"
+)
+
+func TestRewriteBareRepositoryScopes(t *testing.T) {
+	ctx := context.Background()
+	prev := config.DefaultCfgManager
+	config.InitWithSettings(map[string]any{common.DefaultProjectName: "library"})
+	defer func() {
+		// the inmemory manager is a shared singleton — restore its value too
+		_ = config.DefaultMgr().UpdateConfig(ctx, map[string]any{common.DefaultProjectName: "library"})
+		config.DefaultCfgManager = prev
+	}()
+	access := []*token.ResourceActions{
+		{Type: "repository", Name: "alpine", Actions: []string{"pull", "push"}},
+		{Type: "repository", Name: "myproj/alpine", Actions: []string{"pull"}},
+		{Type: "registry", Name: "catalog", Actions: []string{"*"}},
+		{Type: "repository", Name: "", Actions: []string{}},
+	}
+	rewriteBareRepositoryScopes(ctx, access)
+	assert.Equal(t, "library/alpine", access[0].Name)
+	assert.Equal(t, "myproj/alpine", access[1].Name)
+	assert.Equal(t, "catalog", access[2].Name)
+	assert.Equal(t, "", access[3].Name)
+
+	assert.NoError(t, config.DefaultMgr().UpdateConfig(ctx, map[string]any{common.DefaultProjectName: ""}))
+	access = []*token.ResourceActions{
+		{Type: "repository", Name: "alpine", Actions: []string{"pull", "push"}},
+	}
+	rewriteBareRepositoryScopes(ctx, access)
+	assert.Equal(t, "alpine", access[0].Name)
+}

--- a/src/lib/config/metadata/metadatalist.go
+++ b/src/lib/config/metadata/metadatalist.go
@@ -207,6 +207,7 @@ var (
 		{Name: common.ExecutionStatusRefreshIntervalSeconds, Scope: SystemScope, Group: BasicGroup, EnvKey: "EXECUTION_STATUS_REFRESH_INTERVAL_SECONDS", DefaultValue: "30", ItemType: &Int64Type{}, Editable: false, Description: `The interval seconds to refresh the execution status`},
 
 		{Name: common.BannerMessage, Scope: UserScope, Group: BasicGroup, EnvKey: "BANNER_MESSAGE", DefaultValue: "", ItemType: &StringType{}, Editable: true, Description: `The customized banner message for the UI`},
+		{Name: common.DefaultProjectName, Scope: UserScope, Group: BasicGroup, DefaultValue: "library", ItemType: &StringType{}, Editable: true, Description: `The project that catches repositories pushed or pulled without a project segment, e.g. "registry.example.com/alpine" lands in this project. Set empty to disable the fallback and reject such requests. The project must exist and its name must be a valid project name.`},
 		{Name: common.QuotaUpdateProvider, Scope: SystemScope, Group: BasicGroup, EnvKey: "QUOTA_UPDATE_PROVIDER", DefaultValue: "db", ItemType: &StringType{}, Editable: false, Description: `The provider for updating quota, 'db' or 'redis' is supported`},
 
 		{Name: common.BeegoMaxMemoryBytes, Scope: SystemScope, Group: BasicGroup, EnvKey: "BEEGO_MAX_MEMORY_BYTES", DefaultValue: fmt.Sprintf("%d", common.DefaultBeegoMaxMemoryBytes), ItemType: &Int64Type{}, Editable: false, Description: `The bytes for limiting the beego max memory, default is 128GB`},

--- a/src/lib/config/userconfig.go
+++ b/src/lib/config/userconfig.go
@@ -264,6 +264,15 @@ func BannerMessage(ctx context.Context) string {
 	return DefaultMgr().Get(ctx, common.BannerMessage).GetString()
 }
 
+// DefaultProjectName returns the project that catches repositories pushed or
+// pulled without a project segment; empty disables the fallback
+func DefaultProjectName(ctx context.Context) string {
+	if DefaultMgr() == nil {
+		return ""
+	}
+	return DefaultMgr().Get(ctx, common.DefaultProjectName).GetString()
+}
+
 // AuditLogEventEnabled returns the audit log enabled setting for a specific event_type, such as delete_user, create_user
 func AuditLogEventEnabled(ctx context.Context, eventType string) bool {
 	if DefaultMgr() == nil || DefaultMgr().Get(ctx, common.AuditLogEventsDisabled) == nil {

--- a/src/pkg/project/manager.go
+++ b/src/pkg/project/manager.go
@@ -64,6 +64,11 @@ var (
 	validProjectName = regexp.MustCompile(`^` + restrictedNameChars + `$`)
 )
 
+// IsValidName returns whether name is a legal project name (length and charset).
+func IsValidName(name string) bool {
+	return !utils.IsIllegalLength(name, projectNameMinLen, projectNameMaxLen) && validProjectName.MatchString(name)
+}
+
 type manager struct {
 	dao dao.DAO
 }
@@ -79,8 +84,7 @@ func (m *manager) Create(ctx context.Context, project *models.Project) (int64, e
 		return 0, errors.BadRequestError(nil).WithMessagef(format, project.Name, projectNameMaxLen, projectNameMinLen)
 	}
 
-	legal := validProjectName.MatchString(project.Name)
-	if !legal {
+	if !validProjectName.MatchString(project.Name) {
 		return 0, errors.BadRequestError(nil).WithMessage("project name is not in lower case or contains illegal characters")
 	}
 

--- a/src/server/middleware/artifactinfo/artifact_info.go
+++ b/src/server/middleware/artifactinfo/artifact_info.go
@@ -25,6 +25,7 @@ import (
 	"github.com/opencontainers/go-digest"
 
 	"github.com/goharbor/harbor/src/lib"
+	"github.com/goharbor/harbor/src/lib/config"
 	"github.com/goharbor/harbor/src/lib/errors"
 	lib_http "github.com/goharbor/harbor/src/lib/http"
 	"github.com/goharbor/harbor/src/lib/log"
@@ -63,6 +64,10 @@ func Middleware() func(http.Handler) http.Handler {
 				return
 			}
 			repo := m[lib.RepositorySubexp]
+			if r, ok := rewriteBareRepository(req, repo); ok {
+				repo = r
+				m[lib.RepositorySubexp] = repo
+			}
 			pn, err := projectNameFromRepo(repo)
 			if err != nil {
 				lib_http.SendError(rw, errors.BadRequestError(err))
@@ -82,6 +87,10 @@ func Middleware() func(http.Handler) http.Handler {
 				art.Tag = t
 			}
 			if bmr, ok := m[blobMountRepo]; ok {
+				if r, ok := rewriteBareBlobMount(req, bmr); ok {
+					bmr = r
+					m[blobMountRepo] = bmr
+				}
 				// Fail early for now, though in docker registry an invalid may return 202
 				// it's not clear in OCI spec how to handle invalid from param
 				bmp, err := projectNameFromRepo(bmr)
@@ -97,6 +106,47 @@ func Middleware() func(http.Handler) http.Handler {
 			next.ServeHTTP(rw, req.WithContext(ctx))
 		})
 	}
+}
+
+// rewriteBareRepository prepends the configured default project to a repository
+// that lacks a project segment (e.g. "alpine" -> "library/alpine") and updates
+// the request URL in place so routing, authorization and the registry proxy all
+// see the qualified repository. It returns the rewritten repository and whether
+// a rewrite happened.
+func rewriteBareRepository(req *http.Request, repo string) (string, bool) {
+	if strings.Contains(repo, "/") {
+		return repo, false
+	}
+	dp := config.DefaultProjectName(req.Context())
+	if dp == "" {
+		return repo, false
+	}
+	// All matched v2 URLs continue with "/" right after the repository name
+	rest, ok := strings.CutPrefix(req.URL.Path, "/v2/"+repo+"/")
+	if !ok {
+		return repo, false
+	}
+	rewritten := dp + "/" + repo
+	req.URL.Path = "/v2/" + rewritten + "/" + rest
+	log.Debugf("rewrote bare repository %q to %q", repo, rewritten)
+	return rewritten, true
+}
+
+// rewriteBareBlobMount qualifies a project-less blob mount "from" query
+// parameter with the configured default project, mirroring rewriteBareRepository.
+func rewriteBareBlobMount(req *http.Request, bmr string) (string, bool) {
+	if strings.Contains(bmr, "/") {
+		return bmr, false
+	}
+	dp := config.DefaultProjectName(req.Context())
+	if dp == "" {
+		return bmr, false
+	}
+	rewritten := dp + "/" + bmr
+	q := req.URL.Query()
+	q.Set(blobFromQuery, rewritten)
+	req.URL.RawQuery = q.Encode()
+	return rewritten, true
 }
 
 func projectNameFromRepo(repo string) (string, error) {

--- a/src/server/middleware/artifactinfo/artifact_info_test.go
+++ b/src/server/middleware/artifactinfo/artifact_info_test.go
@@ -23,8 +23,11 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
+	"github.com/goharbor/harbor/src/common"
 	"github.com/goharbor/harbor/src/lib"
+	"github.com/goharbor/harbor/src/lib/config"
 	"github.com/goharbor/harbor/src/lib/errors"
+	_ "github.com/goharbor/harbor/src/pkg/config/inmemory"
 )
 
 func TestParseURL(t *testing.T) {
@@ -199,4 +202,62 @@ func TestPopulateArtifactInfo(t *testing.T) {
 			assert.Equal(t, tt.art, a)
 		}
 	}
+}
+
+func TestDefaultProjectRewrite(t *testing.T) {
+	prev := config.DefaultCfgManager
+	config.InitWithSettings(map[string]any{common.DefaultProjectName: "library"})
+	defer func() {
+		// the inmemory manager is a shared singleton — restore its value too
+		_ = config.DefaultMgr().UpdateConfig(context.Background(), map[string]any{common.DefaultProjectName: "library"})
+		config.DefaultCfgManager = prev
+	}()
+
+	next := &handler{}
+	mw := Middleware()(next)
+
+	// bare manifest reference lands in the default project
+	req := httptest.NewRequest(http.MethodPut, "/v2/hello-world/manifests/latest", nil)
+	rec := httptest.NewRecorder()
+	mw.ServeHTTP(rec, req)
+	assert.Equal(t, http.StatusOK, rec.Code)
+	assert.Equal(t, "/v2/library/hello-world/manifests/latest", req.URL.Path)
+	art := lib.GetArtifactInfo(next.ctx)
+	assert.Equal(t, "library/hello-world", art.Repository)
+	assert.Equal(t, "library", art.ProjectName)
+	assert.Equal(t, "latest", art.Tag)
+
+	// bare blob upload
+	req = httptest.NewRequest(http.MethodPost, "/v2/busybox/blobs/uploads/", nil)
+	rec = httptest.NewRecorder()
+	mw.ServeHTTP(rec, req)
+	assert.Equal(t, http.StatusOK, rec.Code)
+	assert.Equal(t, "/v2/library/busybox/blobs/uploads/", req.URL.Path)
+	assert.Equal(t, "library/busybox", lib.GetArtifactInfo(next.ctx).Repository)
+
+	// bare blob mount source is qualified as well
+	req = httptest.NewRequest(http.MethodPost, "/v2/library/ubuntu/blobs/uploads/?mount=sha256:08e4a417ff4e3913d8723a05cc34055db01c2fd165b588e049c5bad16ce6094f&from=no-project", nil)
+	rec = httptest.NewRecorder()
+	mw.ServeHTTP(rec, req)
+	assert.Equal(t, http.StatusOK, rec.Code)
+	art = lib.GetArtifactInfo(next.ctx)
+	assert.Equal(t, "library/no-project", art.BlobMountRepository)
+	assert.Equal(t, "library", art.BlobMountProjectName)
+	assert.Equal(t, "library/no-project", req.URL.Query().Get("from"))
+
+	// qualified repository is untouched
+	req = httptest.NewRequest(http.MethodDelete, "/v2/dev/img/manifests/latest", nil)
+	rec = httptest.NewRecorder()
+	mw.ServeHTTP(rec, req)
+	assert.Equal(t, http.StatusOK, rec.Code)
+	assert.Equal(t, "/v2/dev/img/manifests/latest", req.URL.Path)
+	assert.Equal(t, "dev/img", lib.GetArtifactInfo(next.ctx).Repository)
+
+	// empty setting disables the rewrite and restores the legacy rejection
+	assert.NoError(t, config.DefaultMgr().UpdateConfig(context.Background(), map[string]any{common.DefaultProjectName: ""}))
+	req = httptest.NewRequest(http.MethodPut, "/v2/hello-world/manifests/latest", nil)
+	rec = httptest.NewRecorder()
+	mw.ServeHTTP(rec, req)
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+	assert.Equal(t, "/v2/hello-world/manifests/latest", req.URL.Path)
 }


### PR DESCRIPTION
## Summary

Harbor rejects registry paths without a project segment — `podman push registry.example.com/alpine:latest` fails with `invalid repository name` while the same push works against ghcr.io and Docker Hub. Docker Hub only works because the Docker CLI rewrites bare names to `library/<name>` client-side, and only for docker.io.

This adds the rewrite server-side so every OCI client (podman, oras, crane, containerd, docker) gets a flat namespace:

- **artifactinfo middleware**: bare repository paths (and blob-mount `?from=` sources) are qualified with the configured default project before routing, authorization, and the registry proxy see them — one rewrite point, everything downstream sees an ordinary `library/alpine` repo.
- **token service**: bare `repository:<name>:<actions>` scopes are qualified the same way, because CLI clients compute the token scope from the repository reference, not from the challenge.
- **config**: new `default_project_name` item (default `library`, already seeded by the initial migration, exposed via the configurations API). Empty disables the fallback and restores the previous rejection. If the configured project does not exist, the request fails at authorization like any push to a nonexistent project.

Design doc with flow diagrams and the rejected `_`-as-visible-name alternative lives in the internal task notes (05-default-project-design).

## Test plan

- Unit tests: middleware rewrite (manifest, blob upload, blob mount, qualified-path untouched, disabled mode) and token scope rewrite.
- `golangci-lint`: 0 issues; full `go build ./...` green.
- e2e for bare push/pull follows separately on the dev overlay.

## Release Notes

Pushes and pulls without a project segment (e.g. `podman push registry.example.com/alpine:latest`) now land in a configurable default project instead of being rejected, giving Harbor a Docker Hub / ghcr.io-style flat namespace for every OCI client. The default project is `library`; set `default_project_name` to another project or to empty (which disables the fallback) via the configurations API.