### PR TITLE
chore: Add 8gcr-dev Flux deployment bundle

### DIFF
--- a/.github/workflows/rolling-flux.yml
+++ b/.github/workflows/rolling-flux.yml
@@ -1,0 +1,72 @@
+name: Publish Rolling Flux Bundle
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - "deploy/flux/8gcr-dev/**"
+      - ".github/workflows/rolling-flux.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: rolling-flux-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  REGISTRY_ADDRESS: ${{ vars.REGISTRY_ADDRESS || '8gears.container-registry.com' }}
+  OPS_REGISTRY_PROJECT: ops
+  OPS_ARTIFACT_REPOSITORY: hz-hopper/8gcr-rolling
+  OPS_REGISTRY_USERNAME: ${{ vars.OPS_REGISTRY_USERNAME || 'robot_8gears.container-registry.dev' }}
+
+jobs:
+  publish:
+    name: Publish hz-hopper 8gcr-rolling config
+    runs-on: ubuntu-26.04
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Prepare
+        run: echo "ROLLING_TAG=${GITHUB_REF_NAME}-${GITHUB_SHA:0:7}" >> "$GITHUB_ENV"
+
+      - name: Setup ORAS
+        uses: oras-project/setup-oras@5c0b487ce3fe0ce3ab0d034e63669e426e294e4d # v1.2.3
+        with:
+          version: 1.2.0
+
+      - name: Setup Flux CLI
+        uses: fluxcd/flux2/action@8d5f40dca5aa5d3c0fc3414457dda15a0ac92fa4 # v2.4.0
+        with:
+          version: 2.4.0
+
+      - name: Registry login
+        env:
+          OPS_REGISTRY_PASSWORD: ${{ secrets.OPS_REGISTRY_PASSWORD }}
+        run: |
+          test -n "${OPS_REGISTRY_USERNAME}"
+          test -n "${OPS_REGISTRY_PASSWORD}"
+          echo "${OPS_REGISTRY_PASSWORD}" | oras login "${REGISTRY_ADDRESS}" \
+            --username "${OPS_REGISTRY_USERNAME}" --password-stdin
+
+      - name: Publish Flux deploy bundle
+        run: |
+          BUNDLE_PATH="${RUNNER_TEMP}/8gcr-rolling-flux"
+          ARTIFACT="oci://${REGISTRY_ADDRESS}/${OPS_REGISTRY_PROJECT}/${OPS_ARTIFACT_REPOSITORY}"
+
+          rm -rf "${BUNDLE_PATH}"
+          cp -R deploy/flux/8gcr-dev "${BUNDLE_PATH}"
+
+          flux push artifact \
+            "${ARTIFACT}:${ROLLING_TAG}" \
+            --path="${BUNDLE_PATH}" \
+            --source="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}" \
+            --revision="${GITHUB_REF_NAME}@sha1:${GITHUB_SHA}"
+
+          oras tag \
+            "${REGISTRY_ADDRESS}/${OPS_REGISTRY_PROJECT}/${OPS_ARTIFACT_REPOSITORY}:${ROLLING_TAG}" \
+            latest

--- a/deploy/flux/8gcr-dev/README.md
+++ b/deploy/flux/8gcr-dev/README.md
@@ -1,0 +1,136 @@
+# 8gcr FluxCD Bundle
+
+Continuous-deploy bundle for `https://8gcr.container-registry.dev` on the **hz-hopper** cluster. The manifests are safe to keep in a public repo: credential material is SOPS-encrypted.
+
+## Source of truth
+
+`main` is both the reviewed source of truth and the live source: every push to `main` touching this directory republishes the OCI bundle (`.github/workflows/rolling-flux.yml`), which Flux reconciles within ~5 min. The former `8gcr-rolling` branch is retired; the published artifact keeps its `ops/hz-hopper/8gcr-rolling` repository name so the cluster bootstrap needs no change. One-shot operational manifests (debug/reset Jobs) now also land here via PR and are removed the same way once done.
+
+A single environment doesn't justify a Kustomize base/overlay split yet; when a second tenant (e.g. a production overlay pinned to release semver instead of `latest`) appears, factor the shared pieces into `deploy/flux/base/` and keep per-tenant overlays like this directory.
+
+## Layout
+
+| File | Purpose |
+|------|---------|
+| `namespace.yaml` | Namespace `8gcr-dev-main` (the cluster runs multiple Harbor instances; namespace is deployment-specific). |
+| `ocirepository.yaml` | Authenticated pull of the chart from `oci://8gears.container-registry.com/8gcr/charts/harbor-next`, tracking released versions via semver `>=2.0.0`, 5-min interval. |
+| `helmrelease.yaml` | Renders the chart with the 8gcr environment values; references the secrets below; provisions a CloudNativePG `Cluster` via the chart's `extraManifests` escape hatch. |
+| `image-tracking.yaml` | Flux image-reflector resources (`ImageRepository` + `ImagePolicy`) that resolve the digest behind each `8gcr/harbor-*:latest` tag in-cluster. No git write-back. |
+| `rollout-sync.yaml` | CronJob (+ ServiceAccount/RBAC) that copies each reflected digest into the workload's pod-template annotation, rolling the pods when a `latest` digest moves. Registry to cluster directly — no fluxcdbot commits, no bundle republish per image update. |
+| `pull-secret-flux-system.sops.yaml` | SOPS-encrypted `Secret` for `flux-system/harbor-system-pull`, used by Flux to pull `ops/hz-hopper/8gcr-rolling` and inspect `8gcr` images. |
+| `pull-secret-8gcr-dev-main.sops.yaml` | SOPS-encrypted `Secret` for `8gcr-dev-main/harbor-system-pull`, used by Flux and Harbor pods to pull the chart and component images from `8gcr`. |
+| `secrets.sops.yaml` | SOPS-encrypted `Secret` resources for the admin password, the Harbor↔Postgres password, and the CNPG bootstrap credentials. It does not contain registry pull credentials. Decrypted on the cluster by Flux using the existing `flux-system/sops-age` key. |
+| `kustomization.yaml` | Plain Kustomize index, lets the Flux Kustomization controller reconcile this directory. |
+| `bootstrap.yaml` | One-time `kubectl apply` target that creates the `OCIRepository` + `Kustomization` in `flux-system` to fetch and apply this bundle using the `harbor-system-pull` secret. Required only the first time per cluster. |
+
+## How it gets to the cluster
+
+1. **Component image publish** (`.github/workflows/main-images.yml`, runs after `Release Ready` succeeds on `main`, via the reusable `publish-images.yml`):
+   - Applies the commercial patches, then builds all Harbor component images for `linux/amd64` and `linux/arm64`.
+   - Moves `latest` for `8gears.container-registry.com/8gcr/harbor-<component>` (`trivy-adapter` keeps its existing `8gcr/trivy-adapter` repository name).
+   - It does not publish Flux deployment configuration.
+2. **Chart publish** (`.github/workflows/publish-chart.yml`, dispatched for a published `chart-v<semver>` release tag):
+   - Packages `deploy/chart/` and pushes to `oci://8gears.container-registry.com/8gcr/charts/harbor-next:<version>`.
+   - This bundle's chart `OCIRepository` follows those releases with a `>=2.0.0` semver range, so a new chart release rolls out without editing this directory.
+   - It does not publish Flux deployment configuration.
+3. **Rolling Flux config publish** (`.github/workflows/rolling-flux.yml`, every push to `main` that touches this directory):
+   - Bundles this directory and pushes it to `oci://8gears.container-registry.com/ops/hz-hopper/8gcr-rolling:<branch>-<sha7>`.
+   - Moves the `latest` tag on that OCI artifact.
+   - Authenticates to the `ops` project with `secrets.OPS_REGISTRY_PASSWORD`.
+4. **Latest image tracking (gitless)** — image-reflector on hz-hopper watches each `8gcr/harbor-*:latest` tag by digest (`image-tracking.yaml`). The `rollout-sync` CronJob compares each `ImagePolicy` digest with the workload's pod-template annotation and patches it on change, restarting the pods (`imagePullPolicy: Always` re-pulls `latest`). Image updates never touch git or republish the bundle.
+5. **Reconcile** — Flux on hz-hopper pulls the published `ops/hz-hopper/8gcr-rolling:latest` bundle every 5 min, decrypts SOPS secrets, and applies everything. Chart releases roll out via the OCIRepository semver range; image updates roll out via `rollout-sync`.
+
+The manifests intentionally do not store plaintext registry credentials. Pull access is provided by SOPS-managed cluster secrets:
+
+| Namespace | Secret | Used by |
+|---|---|---|
+| `flux-system` | `harbor-system-pull` | Root `OCIRepository/harbor-8gcr` pulling `ops/hz-hopper/8gcr-rolling` and Flux image scanning for `8gcr/harbor-*`. |
+| `8gcr-dev-main` | `harbor-system-pull` | Chart `OCIRepository/harbor-next-chart` and Harbor component image pulls. |
+
+## One-time bootstrap
+
+The cluster needs an initial pointer that says "follow this OCI artifact". That pointer can't itself live inside the artifact (chicken-and-egg). Apply it once per cluster:
+
+```sh
+kubectl apply -f \
+  https://raw.githubusercontent.com/container-registry/harbor-next/main/deploy/flux/8gcr-dev/bootstrap.yaml
+```
+
+This creates an `OCIRepository` and a `Kustomization` in `flux-system` that reconcile the published bundle. After this single `kubectl apply`, every subsequent change reaches the cluster via OCI → Flux. The bootstrap file is idempotent — re-applying it is a no-op.
+
+Equivalent with the Flux CLI:
+
+```sh
+flux create source oci harbor-8gcr \
+  --url=oci://8gears.container-registry.com/ops/hz-hopper/8gcr-rolling \
+  --tag=latest --interval=5m \
+  --secret-ref=harbor-system-pull
+
+flux create kustomization harbor-8gcr \
+  --source=OCIRepository/harbor-8gcr \
+  --path=./ --prune --wait --interval=5m --timeout=10m \
+  --decryption-provider=sops --decryption-secret=sops-age \
+  --depends-on=infrastructure-cert-manager \
+  --depends-on=infrastructure-ingress-nginx
+```
+
+## Cluster prerequisites (provisioned outside this bundle)
+
+Everything else this bundle needs is satisfied by hz-hopper's standing infrastructure:
+
+| Requirement | Source |
+|---|---|
+| FluxCD v2 (`source-controller`, `kustomize-controller`, `helm-controller`, `image-reflector-controller`) | Pre-installed on hz-hopper. image-reflector is required for mutable `latest` digest tracking; image-automation-controller is NOT used (no git write-back). |
+| `flux-system/harbor-system-pull` | SOPS-managed dockerconfigjson for pulling `ops/hz-hopper/8gcr-rolling` and scanning `8gcr/harbor-*` images. |
+| `8gcr-dev-main/harbor-system-pull` | SOPS-managed dockerconfigjson for pulling the chart and component images from `8gcr`. |
+| SOPS decryption key | `Secret/sops-age` in `flux-system` (already present; same key used by other Flux Kustomizations). Public key: `age18jfefmcak9zk6jrh7j59ap0rg3zxg577suvmlyrgm3sn0l28zq4slcu94r`. |
+| CloudNativePG operator | Pre-installed in `cnpg-system`. The chart's `extraManifests` renders a `Cluster.postgresql.cnpg.io/v1`; CNPG reconciles it into a Postgres pod + `harbor-db-rw` Service that the chart's `database.host` value points at. |
+| Cert-manager + `letsencrypt-prod` ClusterIssuer | Pre-installed; HelmRelease ingress is annotated to use it. |
+| `nginx` IngressClass | Pre-installed. |
+| DNS `8gcr.container-registry.dev` → `65.109.85.186` | Manual Cloudflare A record (external-dns on hz-hopper only manages `container-registry.com`, not `.dev`). |
+
+## Editing secrets
+
+The encrypted file is created and updated with [SOPS](https://github.com/getsops/sops) against the cluster's age public key:
+
+```sh
+export AGE_PUB=age18jfefmcak9zk6jrh7j59ap0rg3zxg577suvmlyrgm3sn0l28zq4slcu94r
+
+# create or edit in-place
+sops --age "$AGE_PUB" --encrypted-regex '^(data|stringData)$' \
+  deploy/flux/8gcr-dev/secrets.sops.yaml
+
+# rotate by re-encrypting a freshly-built plaintext file
+sops --age "$AGE_PUB" --encrypted-regex '^(data|stringData)$' \
+  -e plaintext-secrets.yaml > deploy/flux/8gcr-dev/secrets.sops.yaml
+```
+
+The two `Secret` resources in the file:
+
+| Name | Type | Keys | Consumers |
+|---|---|---|---|
+| `harbor-admin` | `Opaque` | `HARBOR_ADMIN_PASSWORD` | Harbor Core (`existingSecretAdminPassword`). |
+| `harbor-db-password` | `kubernetes.io/basic-auth` | `username` (`harbor`), `password` | (1) CNPG bootstrap — `Cluster.spec.bootstrap.initdb.secret.name`; (2) Harbor's chart — `database.existingSecret` + `existingSecretKey: password`. Same Secret, both consumers. |
+
+One DB Secret, one source of truth: rotating `harbor-db-password.password` updates both CNPG-initdb (on a fresh Cluster) and Harbor's runtime client in one place. No risk of the runtime password drifting away from what was seeded into Postgres.
+
+## Release vs rolling
+
+| Trigger | Registry project | Tag | Consumer |
+|---------|------------------|-----|----------|
+| push to `main` (component images) | `8gcr` | `latest`, `main-<sha7>` | image-reflector + `rollout-sync` CronJob track the `latest` digest in-cluster |
+| push to `main` (chart) | `8gcr` | `2.0.0`, `<base>-dev`, `<base>-main.<sha7>` | this bundle's chart source |
+| push to `main` (Flux config) | `ops` | `latest`, `<branch>-<sha7>` | hz-hopper root Flux `OCIRepository` |
+| release-please tag | `8gcr` | `<semver>` | future production overlays (pin to semver) |
+
+## Local validation
+
+```sh
+# render the chart with the values in helmrelease.yaml
+yq '.spec.values' deploy/flux/8gcr-dev/helmrelease.yaml > /tmp/values.yaml
+helm dependency update deploy/chart
+helm template harbor deploy/chart -f /tmp/values.yaml --namespace 8gcr-dev-main | less
+
+# decrypt secrets locally (requires SOPS_AGE_KEY_FILE pointing at the cluster's private key)
+sops -d deploy/flux/8gcr-dev/secrets.sops.yaml
+```

--- a/deploy/flux/8gcr-dev/bootstrap.yaml
+++ b/deploy/flux/8gcr-dev/bootstrap.yaml
@@ -1,0 +1,59 @@
+# One-time bootstrap for the 8gcr Harbor deployment on hz-hopper.
+#
+# Apply once per cluster:
+#   kubectl apply -f https://raw.githubusercontent.com/container-registry/harbor-next/main/deploy/flux/8gcr-dev/bootstrap.yaml
+#
+# This creates the OCIRepository + Kustomization in flux-system that fetches
+# the deploy bundle at
+# oci://8gears.container-registry.com/ops/hz-hopper/8gcr-rolling:latest
+# with the existing flux-system registry pull secret and reconciles every
+# resource in it (including SOPS-encrypted secrets).
+#
+# Re-applying is a no-op. After this single step, all subsequent changes flow
+# through rolling-flux.yml → OCI artifact → Flux reconcile.
+#
+# Prerequisites on the cluster:
+#   - FluxCD v2 with source-controller, kustomize-controller, helm-controller
+#   - Secret/harbor-system-pull in flux-system (dockerconfigjson for
+#     8gears.container-registry.com OCI artifact pulls)
+#   - Secret/sops-age in flux-system (holds the age private key matching
+#     age18jfefmcak9zk6jrh7j59ap0rg3zxg577suvmlyrgm3sn0l28zq4slcu94r)
+#   - CloudNativePG operator in cnpg-system (provisions Postgres via extraManifests)
+#   - cert-manager + letsencrypt-prod ClusterIssuer
+#   - nginx IngressClass
+#   - DNS A record 8gcr.container-registry.dev pointing at the cluster ingress
+---
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: harbor-8gcr
+  namespace: flux-system
+spec:
+  interval: 5m
+  url: oci://8gears.container-registry.com/ops/hz-hopper/8gcr-rolling
+  ref:
+    tag: latest
+  secretRef:
+    name: harbor-system-pull
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: harbor-8gcr
+  namespace: flux-system
+spec:
+  interval: 5m
+  timeout: 10m
+  prune: true
+  wait: false
+  sourceRef:
+    kind: OCIRepository
+  name: harbor-8gcr
+  path: ./
+  decryption:
+    provider: sops
+    secretRef:
+      name: sops-age
+  dependsOn:
+    - name: infrastructure-cert-manager
+    - name: infrastructure-ingress-nginx

--- a/deploy/flux/8gcr-dev/helmrelease.yaml
+++ b/deploy/flux/8gcr-dev/helmrelease.yaml
@@ -1,0 +1,352 @@
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: harbor
+  namespace: 8gcr-dev-main
+spec:
+  interval: 10m
+  releaseName: harbor
+  chartRef:
+    kind: OCIRepository
+    name: harbor-next-chart
+  install:
+    remediation:
+      retries: 3
+  upgrade:
+    remediation:
+      retries: 3
+      remediateLastFailure: true
+    cleanupOnFail: true
+  values:
+    externalURL: https://8gcr.container-registry.dev
+    logLevel: info
+    image:
+      pullPolicy: Always
+    imagePullSecrets:
+      - name: harbor-system-pull
+    # Admin password provisioned by secrets.sops.yaml in this bundle.
+    existingSecretAdminPassword: harbor-admin
+    existingSecretAdminPasswordKey: HARBOR_ADMIN_PASSWORD
+    expose:
+      clusterIP: {enabled: false}
+      nodePort: {enabled: false}
+      loadBalancer: {enabled: false}
+      route: {enabled: false}
+    ingress:
+      enabled: true
+      className: nginx
+      autoGenCert: false
+      core: 8gcr.container-registry.dev
+      hosts:
+        - host: 8gcr.container-registry.dev
+      tls:
+        - secretName: harbor-tls
+          hosts:
+            - 8gcr.container-registry.dev
+      annotations:
+        nginx.ingress.kubernetes.io/proxy-body-size: "0"
+        nginx.ingress.kubernetes.io/ssl-redirect: "true"
+        cert-manager.io/cluster-issuer: letsencrypt-prod
+        # Demo-only config lock: every user on this tenant is a system admin
+        # (see the CNPG postInitApplicationSQL trigger below), so the built-in
+        # role check can no longer gate configuration writes. This guard pins
+        # write access to /api/v2.0/configurations to the *username* `admin`.
+        # It asks Harbor who the caller is (works for Basic auth and portal
+        # session cookies alike) and 403s everyone else. Reads are untouched.
+        # kube-dns (10.96.0.10) is the cluster's fixed DNS Service IP; the core
+        # Service is addressed by name so its ClusterIP can change freely.
+        nginx.ingress.kubernetes.io/server-snippet: |
+          location = /api/v2.0/configurations {
+              resolver 10.96.0.10 valid=30s ipv6=off;
+              set $cfg_upstream harbor-harbor-next-core.8gcr-dev-main.svc.cluster.local;
+              access_by_lua_block {
+                  local m = ngx.req.get_method()
+                  if m == "PUT" or m == "POST" or m == "DELETE" or m == "PATCH" then
+                      local http = require "resty.http"
+                      local httpc = http.new()
+                      httpc:set_timeout(3000)
+                      local ok, cerr = httpc:connect("harbor-harbor-next-core.8gcr-dev-main.svc.cluster.local", 80)
+                      if not ok then
+                          ngx.log(ngx.ERR, "cfg-guard connect: ", cerr)
+                          return ngx.exit(403)
+                      end
+                      local res, rerr = httpc:request({
+                          method = "GET",
+                          path = "/api/v2.0/users/current",
+                          headers = {
+                              ["Authorization"] = ngx.var.http_authorization,
+                              ["Cookie"] = ngx.var.http_cookie,
+                              ["Host"] = ngx.var.host,
+                              ["Accept"] = "application/json",
+                          },
+                      })
+                      if not res then
+                          ngx.log(ngx.ERR, "cfg-guard request: ", rerr)
+                          httpc:close()
+                          return ngx.exit(403)
+                      end
+                      local body = res:read_body() or ""
+                      httpc:set_keepalive()
+                      local uname
+                      if res.status == 200 then
+                          uname = string.match(body, '"username"%s*:%s*"([^"]*)"')
+                      end
+                      if uname ~= "admin" then
+                          ngx.status = 403
+                          ngx.header["Content-Type"] = "application/json"
+                          ngx.say('{"errors":[{"code":"FORBIDDEN","message":"configuration changes are restricted to the admin account on this demo"}]}')
+                          return ngx.exit(403)
+                      end
+                  end
+              }
+              proxy_set_header Host $host;
+              proxy_set_header X-Real-IP $remote_addr;
+              proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+              proxy_set_header X-Forwarded-Proto $scheme;
+              proxy_set_header X-Forwarded-Host $host;
+              proxy_http_version 1.1;
+              proxy_pass http://$cfg_upstream:80$request_uri;
+          }
+    # ---- Database ----
+    # Both CNPG bootstrap (extraManifests below) and Harbor's runtime DB client
+    # read the SAME Secret/harbor-db-password. CNPG requires basic-auth type
+    # (keys: username, password); Harbor's chart reads .password via
+    # existingSecretKey. One secret, one source of truth — no drift between
+    # bootstrap and runtime.
+    database:
+      host: harbor-db-rw.8gcr-dev-main.svc.cluster.local
+      port: 5432
+      username: harbor
+      database: registry
+      sslmode: disable
+      existingSecret: harbor-db-password
+      existingSecretKey: password
+    # ---- Valkey (in-chart, default standalone) ----
+    valkey:
+      enabled: true
+      architecture: standalone
+      auth:
+        enabled: false
+    # ---- Component images (continuous deploy via 8gcr/:latest) ----
+    # Rollouts are gitless: image-reflector (image-tracking.yaml) follows each
+    # mutable latest tag by digest, and the rollout-sync CronJob
+    # (rollout-sync.yaml) writes that digest into the workloads' pod-template
+    # annotations in-cluster; imagePullPolicy: Always re-pulls latest. The
+    # chart intentionally does NOT render those annotations — Helm never
+    # manages the key, so upgrades neither reset nor churn it.
+    core:
+      image:
+        repository: 8gears.container-registry.com/8gcr/harbor-core
+        tag: latest
+      replicas: 1
+      # The chart's core ConfigMap hardcodes this to the OCI providers only, so
+      # binding a project to an npm or Maven endpoint is rejected with
+      # "unsupported registry type npm" even though the adapters are registered
+      # and the endpoints report healthy. env overrides envFrom for a duplicate
+      # key, so this wins over the ConfigMap without a chart change.
+      #
+      # The list is the chart's own default plus the package formats the build
+      # supports; dropping any of the originals would break existing proxy
+      # projects.
+      extraEnv:
+        - name: PERMITTED_REGISTRY_TYPES_FOR_PROXY_CACHE
+          value: "docker-hub,harbor,azure-acr,ali-acr,aws-ecr,google-gcr,docker-registry,github-ghcr,jfrog-artifactory,npm,npmjs,pypi,pypi-registry,maven,maven-central,cargo,crates-io,go,go-registry,go-sumdb,homebrew,homebrew-registry"
+        - name: WITH_GRYPE
+          value: "true"
+        - name: GRYPE_ADAPTER_URL
+          value: http://grype-scanner:8080
+        - name: DEFAULT_SCANNER
+          value: Trivy
+    jobservice:
+      image:
+        repository: 8gears.container-registry.com/8gcr/harbor-jobservice
+        tag: latest
+      replicas: 1
+      persistence:
+        enabled: true
+        storageClass: local-path
+        size: 1Gi
+    registry:
+      image:
+        repository: 8gears.container-registry.com/8gcr/harbor-registry
+        tag: latest
+      controller:
+        image:
+          repository: 8gears.container-registry.com/8gcr/harbor-registryctl
+          tag: latest
+      replicas: 1
+      persistence:
+        enabled: true
+        storageClass: local-path
+        size: 10Gi
+    portal:
+      image:
+        repository: 8gears.container-registry.com/8gcr/harbor-portal
+        tag: latest
+      replicas: 1
+    exporter:
+      enabled: true
+      image:
+        repository: 8gears.container-registry.com/8gcr/harbor-exporter
+        tag: latest
+      replicas: 1
+    trivy:
+      enabled: true
+      image:
+        repository: 8gears.container-registry.com/8gcr/trivy-adapter
+        tag: latest
+      replicas: 1
+    # ---- CNPG Postgres provisioned via the chart's extraManifests escape hatch ----
+    # The harbor-db-password Secret it references is provisioned out-of-band
+    # (SOPS-encrypted in k8s/apps); must contain keys: username, password.
+    extraManifests:
+      - apiVersion: postgresql.cnpg.io/v1
+        kind: Cluster
+        metadata:
+          name: harbor-db
+        spec:
+          imageName: ghcr.io/cloudnative-pg/postgresql:17
+          instances: 1
+          storage:
+            size: 5Gi
+          bootstrap:
+            initdb:
+              database: registry
+              owner: harbor
+              secret:
+                name: harbor-db-password
+              # Demo-only: auto-promote every newly registered user to system
+              # admin (mirrors demo.goharbor.io). Harbor owns the schema and
+              # creates `harbor_user` during its own migrations, which run long
+              # after initdb — so we cannot CREATE TRIGGER here directly. Instead
+              # we install a one-shot DDL event trigger (superuser context) that
+              # fires when Harbor first creates `harbor_user`, then installs the
+              # BEFORE INSERT row trigger. `anonymous` (Harbor's internal
+              # unauthenticated principal) is excluded. Config writes are still
+              # fenced to the real `admin` account by the ingress server-snippet
+              # above. Scope is this tenant's CNPG cluster only — NOT baked into
+              # the shared 8gcr/harbor-core image, which other tenants also pull.
+              # Written without dollar quoting: the nested $$/$body$ variant
+              # died at first real initdb with `syntax error at or near "$"`
+              # (2026-08-29 factory reset; the original cluster predated this
+              # SQL, so the initdb path had never run). Single-quoted plpgsql
+              # bodies with doubled inner quotes survive every layer verbatim.
+              postInitApplicationSQL:
+                - |
+                  CREATE OR REPLACE FUNCTION public.demo_promote_new_user_to_admin() RETURNS trigger
+                  LANGUAGE plpgsql AS '
+                  BEGIN
+                    IF NEW.username IS DISTINCT FROM ''anonymous'' THEN
+                      NEW.sysadmin_flag := true;
+                    END IF;
+                    RETURN NEW;
+                  END;
+                  ';
+                - |
+                  CREATE OR REPLACE FUNCTION public.demo_install_promote_admin() RETURNS event_trigger
+                  LANGUAGE plpgsql AS '
+                  BEGIN
+                    IF to_regclass(''public.harbor_user'') IS NOT NULL
+                       AND NOT EXISTS (SELECT 1 FROM pg_trigger WHERE tgname = ''trg_demo_promote_new_user_to_admin'') THEN
+                      CREATE TRIGGER trg_demo_promote_new_user_to_admin BEFORE INSERT ON harbor_user
+                        FOR EACH ROW EXECUTE FUNCTION public.demo_promote_new_user_to_admin();
+                    END IF;
+                  END;
+                  ';
+                - |
+                  CREATE EVENT TRIGGER demo_install_promote_admin_evt
+                    ON ddl_command_end WHEN TAG IN ('CREATE TABLE')
+                    EXECUTE FUNCTION demo_install_promote_admin();
+      - apiVersion: apps/v1
+        kind: Deployment
+        metadata:
+          name: grype-scanner
+          labels:
+            app.kubernetes.io/name: grype-scanner
+            app.kubernetes.io/component: scanner
+            app.kubernetes.io/part-of: harbor
+        spec:
+          replicas: 1
+          selector:
+            matchLabels:
+              app.kubernetes.io/name: grype-scanner
+          template:
+            metadata:
+              labels:
+                app.kubernetes.io/name: grype-scanner
+                app.kubernetes.io/component: scanner
+                app.kubernetes.io/part-of: harbor
+            spec:
+              imagePullSecrets:
+                - name: harbor-system-pull
+              securityContext:
+                fsGroup: 101
+                fsGroupChangePolicy: OnRootMismatch
+                runAsGroup: 101
+                runAsNonRoot: true
+                runAsUser: 100
+                seccompProfile:
+                  type: RuntimeDefault
+              containers:
+                - name: scanner
+                  image: 8gears.container-registry.com/8gcr/harbor-grype-adapter:latest
+                  imagePullPolicy: Always
+                  securityContext:
+                    allowPrivilegeEscalation: false
+                    capabilities:
+                      drop:
+                        - ALL
+                    runAsNonRoot: true
+                  env:
+                    - name: SCANNER_API_SERVER_ADDR
+                      value: ":8080"
+                    - name: SCANNER_GRYPE_CACHE_DIR
+                      value: /home/scanner/cache
+                    - name: SCANNER_GRYPE_DB_CACHE_DIR
+                      value: /home/scanner/cache/grype-db
+                    - name: SCANNER_GRYPE_SCOPE
+                      value: squashed
+                  ports:
+                    - name: http
+                      containerPort: 8080
+                  readinessProbe:
+                    httpGet:
+                      path: /probe/ready
+                      port: http
+                  livenessProbe:
+                    httpGet:
+                      path: /probe/healthy
+                      port: http
+                  resources:
+                    requests:
+                      cpu: 100m
+                      memory: 256Mi
+                    limits:
+                      memory: 2Gi
+                  volumeMounts:
+                    - name: cache
+                      mountPath: /home/scanner/cache
+                    - name: tmp
+                      mountPath: /tmp
+              volumes:
+                - name: cache
+                  emptyDir:
+                    sizeLimit: 4Gi
+                - name: tmp
+                  emptyDir:
+                    sizeLimit: 2Gi
+      - apiVersion: v1
+        kind: Service
+        metadata:
+          name: grype-scanner
+          labels:
+            app.kubernetes.io/name: grype-scanner
+            app.kubernetes.io/component: scanner
+            app.kubernetes.io/part-of: harbor
+        spec:
+          selector:
+            app.kubernetes.io/name: grype-scanner
+          ports:
+            - name: http
+              port: 8080
+              targetPort: http

--- a/deploy/flux/8gcr-dev/image-tracking.yaml
+++ b/deploy/flux/8gcr-dev/image-tracking.yaml
@@ -1,0 +1,223 @@
+apiVersion: image.toolkit.fluxcd.io/v1
+kind: ImageRepository
+metadata:
+  name: harbor-core
+  namespace: flux-system
+spec:
+  image: 8gears.container-registry.com/8gcr/harbor-core
+  interval: 1m
+  provider: generic
+  secretRef:
+    name: harbor-system-pull
+---
+apiVersion: image.toolkit.fluxcd.io/v1
+kind: ImageRepository
+metadata:
+  name: harbor-jobservice
+  namespace: flux-system
+spec:
+  image: 8gears.container-registry.com/8gcr/harbor-jobservice
+  interval: 1m
+  provider: generic
+  secretRef:
+    name: harbor-system-pull
+---
+apiVersion: image.toolkit.fluxcd.io/v1
+kind: ImageRepository
+metadata:
+  name: harbor-registry
+  namespace: flux-system
+spec:
+  image: 8gears.container-registry.com/8gcr/harbor-registry
+  interval: 1m
+  provider: generic
+  secretRef:
+    name: harbor-system-pull
+---
+apiVersion: image.toolkit.fluxcd.io/v1
+kind: ImageRepository
+metadata:
+  name: harbor-registryctl
+  namespace: flux-system
+spec:
+  image: 8gears.container-registry.com/8gcr/harbor-registryctl
+  interval: 1m
+  provider: generic
+  secretRef:
+    name: harbor-system-pull
+---
+apiVersion: image.toolkit.fluxcd.io/v1
+kind: ImageRepository
+metadata:
+  name: harbor-portal
+  namespace: flux-system
+spec:
+  image: 8gears.container-registry.com/8gcr/harbor-portal
+  interval: 1m
+  provider: generic
+  secretRef:
+    name: harbor-system-pull
+---
+apiVersion: image.toolkit.fluxcd.io/v1
+kind: ImageRepository
+metadata:
+  name: harbor-exporter
+  namespace: flux-system
+spec:
+  image: 8gears.container-registry.com/8gcr/harbor-exporter
+  interval: 1m
+  provider: generic
+  secretRef:
+    name: harbor-system-pull
+---
+apiVersion: image.toolkit.fluxcd.io/v1
+kind: ImageRepository
+metadata:
+  name: trivy-adapter
+  namespace: flux-system
+spec:
+  image: 8gears.container-registry.com/8gcr/trivy-adapter
+  interval: 1m
+  provider: generic
+  secretRef:
+    name: harbor-system-pull
+---
+apiVersion: image.toolkit.fluxcd.io/v1
+kind: ImageRepository
+metadata:
+  name: harbor-grype-adapter
+  namespace: flux-system
+spec:
+  image: 8gears.container-registry.com/8gcr/harbor-grype-adapter
+  interval: 1m
+  provider: generic
+  secretRef:
+    name: harbor-system-pull
+---
+apiVersion: image.toolkit.fluxcd.io/v1
+kind: ImagePolicy
+metadata:
+  name: harbor-core
+  namespace: flux-system
+spec:
+  imageRepositoryRef:
+    name: harbor-core
+  filterTags:
+    pattern: ^latest$
+  policy:
+    alphabetical:
+      order: asc
+  digestReflectionPolicy: Always
+  interval: 1m
+---
+apiVersion: image.toolkit.fluxcd.io/v1
+kind: ImagePolicy
+metadata:
+  name: harbor-jobservice
+  namespace: flux-system
+spec:
+  imageRepositoryRef:
+    name: harbor-jobservice
+  filterTags:
+    pattern: ^latest$
+  policy:
+    alphabetical:
+      order: asc
+  digestReflectionPolicy: Always
+  interval: 1m
+---
+apiVersion: image.toolkit.fluxcd.io/v1
+kind: ImagePolicy
+metadata:
+  name: harbor-registry
+  namespace: flux-system
+spec:
+  imageRepositoryRef:
+    name: harbor-registry
+  filterTags:
+    pattern: ^latest$
+  policy:
+    alphabetical:
+      order: asc
+  digestReflectionPolicy: Always
+  interval: 1m
+---
+apiVersion: image.toolkit.fluxcd.io/v1
+kind: ImagePolicy
+metadata:
+  name: harbor-registryctl
+  namespace: flux-system
+spec:
+  imageRepositoryRef:
+    name: harbor-registryctl
+  filterTags:
+    pattern: ^latest$
+  policy:
+    alphabetical:
+      order: asc
+  digestReflectionPolicy: Always
+  interval: 1m
+---
+apiVersion: image.toolkit.fluxcd.io/v1
+kind: ImagePolicy
+metadata:
+  name: harbor-portal
+  namespace: flux-system
+spec:
+  imageRepositoryRef:
+    name: harbor-portal
+  filterTags:
+    pattern: ^latest$
+  policy:
+    alphabetical:
+      order: asc
+  digestReflectionPolicy: Always
+  interval: 1m
+---
+apiVersion: image.toolkit.fluxcd.io/v1
+kind: ImagePolicy
+metadata:
+  name: harbor-exporter
+  namespace: flux-system
+spec:
+  imageRepositoryRef:
+    name: harbor-exporter
+  filterTags:
+    pattern: ^latest$
+  policy:
+    alphabetical:
+      order: asc
+  digestReflectionPolicy: Always
+  interval: 1m
+---
+apiVersion: image.toolkit.fluxcd.io/v1
+kind: ImagePolicy
+metadata:
+  name: trivy-adapter
+  namespace: flux-system
+spec:
+  imageRepositoryRef:
+    name: trivy-adapter
+  filterTags:
+    pattern: ^latest$
+  policy:
+    alphabetical:
+      order: asc
+  digestReflectionPolicy: Always
+  interval: 1m
+---
+apiVersion: image.toolkit.fluxcd.io/v1
+kind: ImagePolicy
+metadata:
+  name: harbor-grype-adapter
+  namespace: flux-system
+spec:
+  imageRepositoryRef:
+    name: harbor-grype-adapter
+  filterTags:
+    pattern: ^latest$
+  policy:
+    alphabetical:
+      order: asc
+  digestReflectionPolicy: Always
+  interval: 1m

--- a/deploy/flux/8gcr-dev/ingress-packages.yaml
+++ b/deploy/flux/8gcr-dev/ingress-packages.yaml
@@ -1,0 +1,96 @@
+# Routes the non-OCI package APIs to Harbor core.
+#
+# The chart's own Ingress sends only /api/, /service/, /v2/, /chartrepo/ and /c/
+# to core, and everything else to the portal. Core serves the package registries
+# on their own prefixes, so without these rules an `npm install` or a `mvn` build
+# lands on the Angular app and gets 200 text/html back, which npm reports as a
+# JSON parse error and Maven as an unparsable POM.
+#
+# A separate Ingress rather than a chart change, so it ships with this bundle.
+# ingress-nginx merges rules per host and prefers the longer path, so the chart's
+# catch-all "/" to the portal still serves everything else.
+#
+# No cert-manager annotation on purpose: the chart's Ingress owns harbor-tls, and
+# a second issuer reference for the same secret would race it.
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: harbor-packages
+  namespace: 8gcr-dev-main
+  annotations:
+    nginx.ingress.kubernetes.io/ssl-redirect: "true"
+    # Package uploads are not small, and the chart already disables the limit for
+    # /v2/ for the same reason.
+    nginx.ingress.kubernetes.io/proxy-body-size: "0"
+    # A proxy-cache miss fetches from the upstream registry while the client
+    # waits, so the 60s defaults are too short. Same values the Compose
+    # deployment sets for these prefixes.
+    nginx.ingress.kubernetes.io/proxy-send-timeout: "900"
+    nginx.ingress.kubernetes.io/proxy-read-timeout: "900"
+spec:
+  ingressClassName: nginx
+  tls:
+    - secretName: harbor-tls
+      hosts:
+        - 8gcr.container-registry.dev
+  rules:
+    - host: 8gcr.container-registry.dev
+      http:
+        paths:
+          # Keep in sync with the route registration in src/server/server.go.
+          #
+          # The backend name is harbor-harbor-next-core, not harbor-core. The
+          # chart is named harbor-next and the release is named harbor, and the
+          # fullname helper only collapses the two when the chart name is a
+          # substring of the release name. It is not here, so both are kept.
+          # Confirmed with `helm template` against the chart version this
+          # deployment pins; do not shorten it by inspection.
+          - path: /npm/
+            pathType: Prefix
+            backend:
+              service:
+                name: harbor-harbor-next-core
+                port:
+                  number: 80
+          - path: /maven/
+            pathType: Prefix
+            backend:
+              service:
+                name: harbor-harbor-next-core
+                port:
+                  number: 80
+          - path: /pypi/
+            pathType: Prefix
+            backend:
+              service:
+                name: harbor-harbor-next-core
+                port:
+                  number: 80
+          - path: /cargo/
+            pathType: Prefix
+            backend:
+              service:
+                name: harbor-harbor-next-core
+                port:
+                  number: 80
+          - path: /go/
+            pathType: Prefix
+            backend:
+              service:
+                name: harbor-harbor-next-core
+                port:
+                  number: 80
+          - path: /go-sumdb/
+            pathType: Prefix
+            backend:
+              service:
+                name: harbor-harbor-next-core
+                port:
+                  number: 80
+          - path: /homebrew/
+            pathType: Prefix
+            backend:
+              service:
+                name: harbor-harbor-next-core
+                port:
+                  number: 80

--- a/deploy/flux/8gcr-dev/kustomization.yaml
+++ b/deploy/flux/8gcr-dev/kustomization.yaml
@@ -1,0 +1,15 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+# bootstrap.yaml is intentionally NOT listed here — it's the one-time
+# kubectl-apply entry point that creates the Flux Kustomization which
+# reconciles this directory. Reconciling it from inside would be circular.
+resources:
+  - namespace.yaml
+  - secrets.sops.yaml
+  - pull-secret-flux-system.sops.yaml
+  - pull-secret-8gcr-dev-main.sops.yaml
+  - ocirepository.yaml
+  - image-tracking.yaml
+  - rollout-sync.yaml
+  - helmrelease.yaml
+  - ingress-packages.yaml

--- a/deploy/flux/8gcr-dev/namespace.yaml
+++ b/deploy/flux/8gcr-dev/namespace.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: 8gcr-dev-main
+  labels:
+    app.kubernetes.io/name: harbor
+    app.kubernetes.io/instance: 8gcr-dev-main
+    app.kubernetes.io/managed-by: flux

--- a/deploy/flux/8gcr-dev/ocirepository.yaml
+++ b/deploy/flux/8gcr-dev/ocirepository.yaml
@@ -1,0 +1,12 @@
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: harbor-next-chart
+  namespace: 8gcr-dev-main
+spec:
+  interval: 5m
+  url: oci://8gears.container-registry.com/8gcr/charts/harbor-next
+  ref:
+    semver: ">=2.0.0"
+  secretRef:
+    name: harbor-system-pull

--- a/deploy/flux/8gcr-dev/pull-secret-8gcr-dev-main.sops.yaml
+++ b/deploy/flux/8gcr-dev/pull-secret-8gcr-dev-main.sops.yaml
@@ -1,0 +1,23 @@
+apiVersion: v1
+data:
+    .dockerconfigjson: ENC[AES256_GCM,data:0uG5fJWC4KFllwKzljOnBcz/hAqQJ2FbaOJKr+6sgAkpPNU8n49RVM7LVa60ZJQx9AuJaCEzroTEzv2PiEo3tDoZ8qi8RaXaVpxeh9U8NI2vcIAfVMeGRg8JekWgnURFvlS3JOtcH22z6K5yiiJHMKAtBqEuyF2iKqHpeXr48We+OZ+HyxRo9J27nbH1fh4u1KB8ZMcVQPIiPRD++sE4VxDVP18/QW36JvdlD+4xgj/CA43S5eJz3eNqkx/CGjdb1CkTXzwuDqAVctM3kp8+3MwLZ7qhQ0+jepWXBO4cGb5x13er/y61upTMCSdi/Whv5Te7zGEfojHQw9a+KQTwr9jtPc5d7o32lXYe9kPhgC6UVzXZyFu1X8TzlsIRlnyJzElmf9TVIsmkeSAB5Y/CzCsjQ16TiNSpM1uU1frSQmdhSYwn,iv:7XRKJbR9EisI/6Gb2MG++UI5XndhCOcOcHo7UzlboeE=,tag:f/vZzuJ6jSyWZXXfBUDp3A==,type:str]
+kind: Secret
+metadata:
+    name: harbor-system-pull
+    namespace: 8gcr-dev-main
+type: kubernetes.io/dockerconfigjson
+sops:
+    age:
+        - enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSA0cWhXeVJYN0tWS0xkTkJU
+            Ym53T1paL0RMYTRiRUkxenpaNkZxeWJxblNZCktDRU9WeTljaDJldG5XbzdXQStk
+            UmxsUmZDcXlHZnQyRGhRbHgxV013WDAKLS0tIFNnSzVkTmZnT24zenV2b3ppdkJR
+            eXhGcUFCVVU5Ym56cUdnQnF0aGxMdHMKbcRMpV3sU6KGutlGw9z02jhYc76m+k4t
+            cuaeHVc262AIsaw/NlN+El5sVY4Dsrwvh602c/NwlcU0IN83pgnPlg==
+            -----END AGE ENCRYPTED FILE-----
+          recipient: age18jfefmcak9zk6jrh7j59ap0rg3zxg577suvmlyrgm3sn0l28zq4slcu94r
+    encrypted_regex: ^(data|stringData)$
+    lastmodified: "2026-07-09T19:57:05Z"
+    mac: ENC[AES256_GCM,data:1XNGxz2ROPK6HwFpk1UamgaFXNvXNZhWAZG3jlsp3SOwKskcVCJdbBsIntppzega20NOk6KV6y9Zf11i8rNqM1TNwRzb2B5uZGXXfvLiytvLy68b0IOuD1HXXwzfuGnn7y3sip0eEDWSQg5Mq35tekp4fwfI6EJFBKE3Pjq9BHA=,iv:iP162+7xn0I0EtnzQcmsCxv+aB4zqOYgMII6VapVbmc=,tag:hl1IJP8ZBimwYTophqDEWA==,type:str]
+    version: 3.13.1

--- a/deploy/flux/8gcr-dev/pull-secret-flux-system.sops.yaml
+++ b/deploy/flux/8gcr-dev/pull-secret-flux-system.sops.yaml
@@ -1,0 +1,23 @@
+apiVersion: v1
+data:
+    .dockerconfigjson: ENC[AES256_GCM,data:a8XvQnX74jord1RDZByx2eArkCpFtE8IkxXVJNHaqgx4ow3OfYMNm6Q06FHPWFEtdIIt9iiWCK3O8EKr8cWfTV1iIhspYi70fLBDmmifa4rbmGhZmu+D+8XhECD4mmnRuz61ELJQZaMLZK/ZzoXO+RGKUa1dPWwVzkhM3rcq/tvExJQXO7fn8O7vmAj4tCVSxJ44z16JE95pgPt9Kio0qdajoCfe2Fe6MVGWCRWyvVfI4oQSFcmjm/DbrPxbOFqBHftr5M0H/DIsmT1UA4zZYkBt+69hcyUFiyg8aZogbLZNbSTKm3v07PLSBYENvn0v18cej5k7S0StLXNfl3hsoWtFKpowy/shxBBdgnnvlJECgQ3kSrdH5P4UJfCnd5tASXekrx+hiaWWFFyGPcTpdf5PfTywWbkXbCKtc2rT6pgZKyXm,iv:nMOZohUFllZpTLFBXmN4cdR8rZ4ZDN+dNVGqOgJiPxw=,tag:M5Yj72sSiaR+jKoUMqLpBQ==,type:str]
+kind: Secret
+metadata:
+    name: harbor-system-pull
+    namespace: flux-system
+type: kubernetes.io/dockerconfigjson
+sops:
+    age:
+        - enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSAybWtiRXhYN0QzMDhOYjRr
+            TlhDRUZmMVlSWHN2MjhBWncvb1dHYVpwZFFrCkRBZFNHbnFqNkFKQllMMmFxSnlO
+            cWlNdWd3cGt1MmJmazJTa3JodE9YTGsKLS0tIFJoQWhCZ2RoNHV0VGZBOTZpKzA1
+            STlJaUZ3emZyTXhCZmxZTFZOMVRjb0EKLW0126uMWBNuf1wnj3MFYikh7dgkkp1E
+            B6O76Y+7EMtAr2TAYnXHw2LQF19QBSL9+DoQChQwIHLdocBhd+wd1A==
+            -----END AGE ENCRYPTED FILE-----
+          recipient: age18jfefmcak9zk6jrh7j59ap0rg3zxg577suvmlyrgm3sn0l28zq4slcu94r
+    encrypted_regex: ^(data|stringData)$
+    lastmodified: "2026-07-09T19:57:05Z"
+    mac: ENC[AES256_GCM,data:gqnLh8AEEqE0Bsxt5in2/SZdIP9WtSbBy2dn7cZR+dAQtbPczqV5yidloh2dWcqB6rwDG4O7cuR4Ijqq9wknYKPq4Q3xNBjkoS33ZwljLMvH08RfPZ3rzh716U+kP6DvVHEGOwHi5bl6CL3gRPgV5sWi39UfvteKVqMcgkhB/Bc=,iv:Gb0SVNkliJ+dOwkcacb9yhNx4+qteKDrwoQKjIxohBo=,tag:3L2IM8h7bF/iNl86sKfIjw==,type:str]
+    version: 3.13.1

--- a/deploy/flux/8gcr-dev/rollout-sync.yaml
+++ b/deploy/flux/8gcr-dev/rollout-sync.yaml
@@ -1,0 +1,149 @@
+# Gitless last mile of the image pipeline: image-reflector (image-tracking.yaml)
+# resolves the digest behind each 8gcr/harbor-*:latest tag; this CronJob copies
+# that digest into the workload's pod-template annotation, which is what makes
+# Kubernetes roll the pods (imagePullPolicy: Always re-pulls latest). No git
+# write-back, no bundle republish — registry to cluster directly.
+#
+# The annotation is intentionally NOT rendered by the Helm chart: Helm's
+# three-way merge leaves keys it never managed alone, so upgrades neither reset
+# nor churn it. Patching is idempotent — the merge patch is a no-op while the
+# annotation already carries the current digest.
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: rollout-sync
+  namespace: 8gcr-dev-main
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: rollout-sync-imagepolicies
+  namespace: flux-system
+rules:
+  - apiGroups: [image.toolkit.fluxcd.io]
+    resources: [imagepolicies]
+    verbs: [get, list]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: rollout-sync-imagepolicies
+  namespace: flux-system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: rollout-sync-imagepolicies
+subjects:
+  - kind: ServiceAccount
+    name: rollout-sync
+    namespace: 8gcr-dev-main
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: rollout-sync-workloads
+  namespace: 8gcr-dev-main
+rules:
+  - apiGroups: [apps]
+    resources: [deployments, statefulsets]
+    verbs: [get, list, patch]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: rollout-sync-workloads
+  namespace: 8gcr-dev-main
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: rollout-sync-workloads
+subjects:
+  - kind: ServiceAccount
+    name: rollout-sync
+    namespace: 8gcr-dev-main
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: rollout-sync
+  namespace: 8gcr-dev-main
+  labels:
+    app.kubernetes.io/name: rollout-sync
+    app.kubernetes.io/part-of: harbor
+spec:
+  schedule: "*/2 * * * *"
+  concurrencyPolicy: Forbid
+  startingDeadlineSeconds: 120
+  successfulJobsHistoryLimit: 1
+  failedJobsHistoryLimit: 3
+  jobTemplate:
+    spec:
+      backoffLimit: 0
+      activeDeadlineSeconds: 120
+      template:
+        metadata:
+          labels:
+            app.kubernetes.io/name: rollout-sync
+            app.kubernetes.io/part-of: harbor
+        spec:
+          serviceAccountName: rollout-sync
+          restartPolicy: Never
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 65534
+            runAsGroup: 65534
+            seccompProfile:
+              type: RuntimeDefault
+          containers:
+            - name: sync
+              image: docker.io/alpine/kubectl:1.33.4
+              securityContext:
+                allowPrivilegeEscalation: false
+                capabilities:
+                  drop:
+                    - ALL
+                readOnlyRootFilesystem: true
+              resources:
+                requests:
+                  cpu: 10m
+                  memory: 32Mi
+                limits:
+                  memory: 64Mi
+              command:
+                - /bin/sh
+                - -eu
+                - -c
+                - |
+                  ns_app=8gcr-dev-main
+                  ns_flux=flux-system
+                  fail=0
+                  sync() {
+                    kind=$1 workload=$2 policy=$3 anno=$4
+                    want=$(kubectl get imagepolicies.image.toolkit.fluxcd.io "$policy" -n "$ns_flux" \
+                      -o jsonpath='{.status.latestRef.digest}') || {
+                      echo "ERROR: cannot read ImagePolicy $policy" >&2; fail=1; return 0; }
+                    if [ -z "$want" ]; then
+                      echo "$policy: no digest reflected yet, skipping"; return 0
+                    fi
+                    esc=$(printf '%s' "$anno" | sed 's/\./\\./g')
+                    have=$(kubectl get "$kind" "$workload" -n "$ns_app" \
+                      -o jsonpath="{.spec.template.metadata.annotations['$esc']}") || {
+                      echo "ERROR: cannot read $kind/$workload" >&2; fail=1; return 0; }
+                    if [ "$have" = "$want" ]; then
+                      echo "$kind/$workload ($anno) up to date at $want"; return 0
+                    fi
+                    echo "$kind/$workload ($anno): $have -> $want"
+                    kubectl patch "$kind" "$workload" -n "$ns_app" --type merge \
+                      -p "{\"spec\":{\"template\":{\"metadata\":{\"annotations\":{\"$anno\":\"$want\"}}}}}" || {
+                      echo "ERROR: cannot patch $kind/$workload" >&2; fail=1; return 0; }
+                  }
+                  rev=deploy.8gears.io/image-revision
+                  sync deployment  harbor-harbor-next-core       harbor-core          "$rev"
+                  sync deployment  harbor-harbor-next-jobservice harbor-jobservice    "$rev"
+                  sync deployment  harbor-harbor-next-registry   harbor-registry      "$rev"
+                  sync deployment  harbor-harbor-next-registry   harbor-registryctl   deploy.8gears.io/registryctl-image-revision
+                  sync deployment  harbor-harbor-next-portal     harbor-portal        "$rev"
+                  sync deployment  harbor-harbor-next-exporter   harbor-exporter      "$rev"
+                  sync statefulset harbor-harbor-next-trivy      trivy-adapter        "$rev"
+                  sync deployment  grype-scanner                 harbor-grype-adapter "$rev"
+                  exit "$fail"

--- a/deploy/flux/8gcr-dev/secrets.sops.yaml
+++ b/deploy/flux/8gcr-dev/secrets.sops.yaml
@@ -1,0 +1,54 @@
+# harbor-admin: consumed by Harbor Core (existingSecretAdminPassword).
+apiVersion: v1
+kind: Secret
+metadata:
+    name: harbor-admin
+    namespace: 8gcr-dev-main
+stringData:
+    HARBOR_ADMIN_PASSWORD: ENC[AES256_GCM,data:kCbWZqjH8U5iZXgkTshf/iCvTVxTt6A5,iv:AqdQGk1DE6LGRRgD/bmN2qIu2QS+2vNrCxE+MxZQ8tc=,tag:KVvHMOMVqV1LPUlvqJ9DLg==,type:str]
+sops:
+    age:
+        - recipient: age18jfefmcak9zk6jrh7j59ap0rg3zxg577suvmlyrgm3sn0l28zq4slcu94r
+          enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBiUUNyT1VEWFpUdGZlZjFq
+            Z2V6cnFCcmsyYWpMWFl5TDZ2V2lSdHh1ZzNBCmJOQUwwSEVwU1c3TTl5dGNQOEFk
+            YlFieGdFYzRwbEdzekFNbXFFdlIzNVUKLS0tIEI1Y2FSNnpra0dZYXd1L1JwWno5
+            R09mZUQ0bG1qZkJDVzB3b1NscTBjNVUKKbSxdu5BxBlENMeyFRT7nWoyYFqbVQ8G
+            1tJfm02ZjEXUvH3hxC2jlS/qQbq0Z0kRElUKqm8iouz3+42/SB/jrA==
+            -----END AGE ENCRYPTED FILE-----
+    lastmodified: "2026-05-12T13:16:56Z"
+    mac: ENC[AES256_GCM,data:qlh6sGxPGjwk/uaVe45uqVtYaCZMOtEjcgEmB5SzPKl+/QojZhi+v+8wKTLMARDnmGGoysqmSm5wLqauDdIjejfyIUvwxg/nAILfTsL/kmXHixjwmWvEaAacGghltho/dlGd/qydoYkVOOA+aO3B+ldJ+OcH2dPpbILWGyWuo3k=,iv:DxcRN6Wt89MLTbhkR+Z/Q57CRkJC29djs4hiTJoSDBY=,tag:u7EJp41yJqDkmLKhKvSesw==,type:str]
+    encrypted_regex: ^(data|stringData)$
+    version: 3.10.2
+---
+# harbor-db-password: dual-purpose.
+#   - CNPG initdb.secret (Cluster CR in helmrelease extraManifests) — seeds the
+#     Postgres role 'harbor' with this password at bootstrap.
+#   - Harbor's chart database.existingSecret + database.existingSecretKey=password
+#     — Core and Exporter read this key for runtime DB connections.
+# Single source of truth: rotating here updates both consumers in one go.
+apiVersion: v1
+kind: Secret
+type: kubernetes.io/basic-auth
+metadata:
+    name: harbor-db-password
+    namespace: 8gcr-dev-main
+stringData:
+    username: ENC[AES256_GCM,data:chmpb9TJ,iv:05j3pS0lBeI6TF2115sJv649fehsjKSMPUeYaRN5okM=,tag:0B9nJfbyURKDJOTo9bw7hw==,type:str]
+    password: ENC[AES256_GCM,data:i/ZgVuz5VZ0xCAFFcELf372nRSyBpPriz1+5Z4g=,iv:uwh0CWJBIRxs2Evd07Bnw9bgzo/QEi8u9tJvgFVxVY4=,tag:WJApUqB453JO7re8je5P4A==,type:str]
+sops:
+    age:
+        - recipient: age18jfefmcak9zk6jrh7j59ap0rg3zxg577suvmlyrgm3sn0l28zq4slcu94r
+          enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBiUUNyT1VEWFpUdGZlZjFq
+            Z2V6cnFCcmsyYWpMWFl5TDZ2V2lSdHh1ZzNBCmJOQUwwSEVwU1c3TTl5dGNQOEFk
+            YlFieGdFYzRwbEdzekFNbXFFdlIzNVUKLS0tIEI1Y2FSNnpra0dZYXd1L1JwWno5
+            R09mZUQ0bG1qZkJDVzB3b1NscTBjNVUKKbSxdu5BxBlENMeyFRT7nWoyYFqbVQ8G
+            1tJfm02ZjEXUvH3hxC2jlS/qQbq0Z0kRElUKqm8iouz3+42/SB/jrA==
+            -----END AGE ENCRYPTED FILE-----
+    lastmodified: "2026-05-12T13:16:56Z"
+    mac: ENC[AES256_GCM,data:qlh6sGxPGjwk/uaVe45uqVtYaCZMOtEjcgEmB5SzPKl+/QojZhi+v+8wKTLMARDnmGGoysqmSm5wLqauDdIjejfyIUvwxg/nAILfTsL/kmXHixjwmWvEaAacGghltho/dlGd/qydoYkVOOA+aO3B+ldJ+OcH2dPpbILWGyWuo3k=,iv:DxcRN6Wt89MLTbhkR+Z/Q57CRkJC29djs4hiTJoSDBY=,tag:u7EJp41yJqDkmLKhKvSesw==,type:str]
+    encrypted_regex: ^(data|stringData)$
+    version: 3.10.2


### PR DESCRIPTION
Lands the FluxCD continuous-deploy bundle for `https://8gcr.container-registry.dev` (cluster **hz-hopper**, namespace `8gcr-dev-main`) on `main` as the **single source**: `rolling-flux.yml` now triggers on pushes to `main` touching `deploy/flux/8gcr-dev/`, republishing the OCI bundle Flux follows. This retires the `8gcr-rolling` branch. The published artifact keeps its `ops/hz-hopper/8gcr-rolling` repository name, so the cluster bootstrap needs no change. All secret material is SOPS-encrypted against the cluster age key.

Flow after merge: PR merges to main → bundle republished (config changes) + Main Images moves `latest` (image changes) → image-reflector + rollout-sync roll pods gitlessly. One-shot ops manifests (debug/reset Jobs) land and are removed via main PRs from now on.

## Verified end to end (NP-16, 2026-08-31)

1. `main` @ `8872665f` → Release Ready → Main Images published new `latest` digests for all 9 components at **07:04:30–53Z** (e.g. `harbor-core` `56b4c399…` → `ea473fed…`).
2. In-cluster (temporary read-only observer, since removed): all 8 `ImagePolicy` objects reflected the new digests, `rollout-sync` patched every workload annotation, all 7 tracked workloads restarted at **07:06:01–03Z** — ~90 s from registry push to rollout.
3. By 07:10Z: policies == annotations == registry digests; CNPG + valkey untouched; ping 200 and all components healthy after.

Note: `latest` tracks the newest `main` commit that *passes Release Ready* (`cancel-in-progress` skips intermediates) — intended.

## Layout decision

Flat `deploy/flux/8gcr-dev/` kept; base/overlay split deferred until a second tenant (e.g. production overlay pinned to release semver) — rationale in README. `rolling-flux.yml` aligned with main conventions (checkout v7 pin, `persist-credentials: false`, `ubuntu-26.04`, no inline `${{ }}` in run steps).

## Post-merge

- First main push touching the bundle dir publishes from main; verify the run, then delete the `8gcr-rolling` branch.
