### PR TITLE
chore: Disable phantom snyk scanner health check on 8gcr-dev

### DIFF
--- a/deploy/flux/8gcr-dev/helmrelease.yaml
+++ b/deploy/flux/8gcr-dev/helmrelease.yaml
@@ -155,6 +155,11 @@ spec:
           value: "true"
         - name: GRYPE_ADAPTER_URL
           value: http://grype-scanner:8080
+        # 0007 patch defaults WITH_SNYK=true but no deployment runs a
+        # snyk-scanner (needs Snyk API creds) — kills the phantom unhealthy
+        # snyk entry in /api/v2.0/health
+        - name: WITH_SNYK
+          value: "false"
         - name: DEFAULT_SCANNER
           value: Trivy
     jobservice:


### PR DESCRIPTION
Ports `8gcr-rolling` ops commit `78ef583ee6` to `main`, which is now the live bundle source after #776 — without this, the main-side bundle publish reverts the fix and 8gcr-dev's `/api/v2.0/health` goes aggregate-unhealthy again (phantom `snyk` checker from the 0007 patch's `WITH_SNYK=true` default; no snyk-scanner service exists).