### PR TITLE
test: Stub legacy project table in authoritative schema DB test

### DIFF
--- a/src/migration/authoritative_db_test.go
+++ b/src/migration/authoritative_db_test.go
@@ -59,8 +59,16 @@ func TestAuthoritativeSchemaAgainstPostgreSQL(t *testing.T) {
 	}
 	t.Cleanup(schemaPool.Close)
 
-	if _, err := schemaPool.DB().ExecContext(ctx, "CREATE TABLE robot (id BIGSERIAL PRIMARY KEY)"); err != nil {
-		t.Fatalf("create robot dependency: %v", err)
+	// Legacy tables created by the numbered migrations that harbor_next.sql
+	// declares foreign keys against.
+	legacyDependencies := []string{
+		"CREATE TABLE robot (id BIGSERIAL PRIMARY KEY)",
+		"CREATE TABLE project (project_id SERIAL PRIMARY KEY)",
+	}
+	for _, statement := range legacyDependencies {
+		if _, err := schemaPool.DB().ExecContext(ctx, statement); err != nil {
+			t.Fatalf("create legacy dependency: %v", err)
+		}
 	}
 
 	path := authoritativeTestSchemaPath()
@@ -87,6 +95,13 @@ func TestAuthoritativeSchemaAgainstPostgreSQL(t *testing.T) {
 		"claim_rules",
 		"idx_claim_rules_lookup",
 		"idx_identity_providers_jwks_cache",
+		"multi_format_package",
+		"multi_format_version",
+		"multi_project_reference",
+		"idx_multi_format_package_proj_fmt",
+		"idx_multi_format_version_pkg",
+		"idx_multi_project_reference_multi",
+		"idx_multi_project_reference_sub",
 	}
 	for _, object := range objects {
 		var exists bool


### PR DESCRIPTION
Fixes the `TestAuthoritativeSchemaAgainstPostgreSQL` failure on main CI ([failing run](https://github.com/container-registry/harbor-next/actions/runs/33425361294/job/99827980160)).

## Root cause

#780 added `multi_project_reference` to `harbor_next.sql` with foreign keys `REFERENCES project(project_id)`. The `project` table is created by the legacy numbered migrations, which this test does not run — it applies `harbor_next.sql` against a bare throwaway schema containing only stubbed legacy dependencies. `robot` was already stubbed (the pre-existing legacy FK target); `project` was not, so every `applyAuthoritativeSchema()` run failed with `ERROR: relation "project" does not exist (SQLSTATE 42P01)`.

The schema itself is correct: in production the authoritative schema is reconciled after the numbered migrations, so `project` always exists there.

## Change

- Stub `project (project_id SERIAL PRIMARY KEY)` alongside the existing `robot` stub in the test setup.
- Extend the object-existence assertions to cover the #780 tables and indexes (`multi_format_package`, `multi_format_version`, `multi_project_reference` and their indexes) so the test verifies the new schema actually applies.

Verified locally: reproduced the exact CI failure against PostgreSQL, then re-ran the full `src/migration` db-tagged suite green after the fix.