### PR TITLE
build: add optional Make bootstrap (GNUmakefile)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,6 +60,7 @@ openapi-generator-cli.jar
 tests/e2e_setup/robotvars.py
 .task/checksum
 .task/
+.cache/
 deploy/chart/charts/
 devenv/token_service_key.pem
 devenv/ports.env

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -1,0 +1,90 @@
+# Using the Makes Makefile framework
+R := https://github.com/makeplus/makes
+M := $(or $(MAKES_REPO_DIR),.cache/makes)
+P := dff1c42f1c4865cf3535b8171fbaa0bbf27df5ce
+$(shell [ -d '$M' ] || (git clone -q $R '$M' && git -C '$M' checkout -q $P))
+ifneq ($(shell git -C $M rev-parse HEAD 2>/dev/null),$P)
+$(error Makes commit mismatch: expected $P)
+endif
+
+.DEFAULT_GOAL := default
+
+include $M/init.mk
+include versions.env
+
+GO-VERSION := $(GO_VERSION)
+BUN-VERSION := $(BUN_VERSION)
+NODE-VERSION := 22.23.2
+
+ifeq (command line,$(origin TASK))
+TASK-NAME := $(TASK)
+override undefine TASK
+endif
+
+include $M/task.mk
+include $M/git.mk
+include $M/go.mk
+# Task probes Go eagerly, before target prerequisites are installed.
+# Let each selected Go executable determine its own installation root.
+unexport GOROOT
+include $M/bun.mk
+include $M/node.mk
+include $M/docker-compose.mk
+include $M/docker-or-podman.mk
+include $M/shell.mk
+
+TASK-TARGETS := setup build test lint images info
+
+GO-TASKS := setup build test lint images
+
+TASK-ARGS = $(if $(strip $(ARGS)),-- $(ARGS))
+TASK-GOAL = $(or $(TASK-NAME),default)
+DEFAULT-DEPS = $(if $(TASK-NAME),\
+  $(TASK),$(DOCKER-COMPOSE) $(TASK) $(GO) $(BUN) $(NODE) $(DOCKER))
+
+.PHONY: default $(TASK-TARGETS) clean
+
+default:: $(DEFAULT-DEPS)
+	$(TASK) $(TASK-GOAL) $(TASK-ARGS)
+
+$(TASK-TARGETS): $(TASK)
+	$(TASK) $@ $(TASK-ARGS)
+
+$(GO-TASKS): $(GO)
+lint: $(DOCKER)
+images: $(DOCKER-OR-PODMAN)
+
+ifneq (,$(wildcard $(TASK)))
+clean::
+	@$(TASK) $@ $(TASK-ARGS) || true
+endif
+
+MAKES-CLEAN := \
+  .task \
+  bin \
+  build-errors.log \
+  devenv/token_service_key.pem \
+  deploy/compose/config/token_service_key.pem \
+  deploy/chart/.rendered-config.yaml \
+  deploy/chart/charts \
+  deploy/chart/*.tgz \
+  golangci-lint.report \
+  govulncheck.sarif \
+  kubescape.sarif \
+  src/coverage.html \
+  src/coverage.out \
+  src/coverage-pure.out \
+  src/coverage-db.out \
+  src/portal/.angular \
+  src/portal/ng-swagger-gen \
+  src/server/v2.0/models \
+  src/server/v2.0/restapi \
+  trivy-chart.sarif \
+  tmp \
+  *.tgz \
+
+MAKES-REALCLEAN := \
+  src/portal/node_modules \
+  src/portal/src/swagger.json \
+
+include $M/clean.mk

--- a/README.md
+++ b/README.md
@@ -84,12 +84,20 @@ Harbor Next uses [Taskfile](https://taskfile.dev) for local development and in p
 |------|---------|---------|
 | [Task](https://taskfile.dev/installation/) | v3.x | Build system (replaces Make) |
 | [Docker](https://docs.docker.com/get-docker/) / [Podman](https://podman.io/) | 20.10.10+ | Dev environment, linting, image builds |
+| [Docker Compose](https://docs.docker.com/compose/install/) | v2.24+ | Container orchestration |
 | [Go](https://go.dev/dl/) | see `versions.env` | Backend compilation and tests |
 | [Bun](https://bun.sh) | see `versions.env` | Frontend dependency management |
 | [Node.js](https://nodejs.org/) | 16+ | Frontend build, tests, and API codegen |
 | Git | any | Required by build metadata and mock checks |
 
 Additional Go tools (`air`, `dlv`, `govulncheck`) are auto-installed on first use via `go install` or by running `task setup`.
+
+> Note: The optional `GNUmakefile` provides a small set of common entry points and installs their managed prerequisites locally under `./.cache/`.
+> In other words, `make test` from a fresh clone will just work.
+> You don't need Task, Go, Bun, or Node installed to get started here.
+> Run another Task target with `make TASK='test:unit:pure'`, or use `make shell` to enter a subshell containing all the managed tools.
+> Its first use requires internet access.
+> Using `make` is completely optional, but avoids installing anything to get started.
 
 ### Quick Start
 


### PR DESCRIPTION
Task remains the authoritative build and development interface, but a fresh checkout otherwise requires contributors to install Task and the language toolchain before running common workflows.

Add an optional GNUmakefile backed by [Makes](https://github.com/makeplus/makes) so common entry points can install pinned tools under `.cache` and then delegate execution to Task.
Keep the public Make surface intentionally small: setup, build, test, lint, images, info, clean, shell, and the default development command.

Give each named target only the prerequisites it needs before invoking Task.
Build, test, setup, lint, and image workflows receive the managed Go toolchain.
Lint checks Docker, image builds select an available Docker or Podman engine, and the default development command also prepares Bun, Node, and Docker Compose.
Prefer an existing Docker Compose plugin and use the managed Compose fallback only when the plugin is unavailable.

Pin Makes to an exact commit and map the default Go and Bun versions from `versions.env`.
Use Node 22.23.2 for the frontend without changing the upstream version file.
Allow these defaults to be overridden for an individual Make command with `GO-VERSION`, `BUN-VERSION`, or `NODE-VERSION`, such as `make GO-VERSION=1.25.0 test` or
`make NODE-VERSION=22.23.2 shell`.

Support `make TASK=test:unit:pure` as an escape hatch for less common Task targets without mirroring the complete Task namespace. Capture that command-line value before `task.mk` assigns `TASK` to the managed executable, and continue forwarding optional `ARGS` after `--`. Provide `make shell` for users who want all managed tools available while running Task directly.

Keep cleanup usable without provisioning the development environment. Run `task clean` on a best-effort basis only when managed Task is already installed, then remove the explicit Makes clean and realclean paths.
Ignore the local `.cache` directory created by the bootstrap process.

Document the optional wrapper, its supported usage, and Docker Compose as a general prerequisite.
Validate named and `make TASK=info` dispatch, Docker engine selection, cleanup dry runs, Make completion, and whitespace checks.

## Summary

<!-- Brief description of what this PR does -->

## Related Issues

<!-- Fixes #123 -->

## Type of Change

- [ ] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` / `fix!:`)
- [ ] Documentation (`docs:`)
- [ ] Refactoring (`refactor:`)
- [x] CI/CD or build changes (`ci:` / `build:`)
- [ ] Upstream Harbor cherry-pick (`upstream:`)
- [ ] Dependencies update (`chore:`)
- [ ] Tests (`test:`)

## Release Notes

<!--
Optional. Fill in for user-facing changes (new features, breaking changes, deprecations).
Leave blank for ci:/chore:/refactor:/docs:/test: PRs.
-->

## Testing

- [ ] Unit tests added/updated
- [x] Manual testing performed

## Checklist

- [ ] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
- [ ] Commits are signed off (`git commit -s`)
- [ ] No new warnings introduced
