### PR TITLE
ci: Render Commercial Feature Deltas From Patch Ledgers

### DIFF
--- a/.github/scripts/update-release-notes.sh
+++ b/.github/scripts/update-release-notes.sh
@@ -126,6 +126,12 @@ patch_notes="${tmp_dir}/commercial-patches.md"
 
 # The Harbor branch owns the ordered manifest. 8gcr only stores the branch
 # commits, so release notes and image builds always use the same exact list.
+# Each patch commit's message carries an append-only changelog ledger (see
+# 8gcr's COMMERCIAL-PATCH-FLOW.md): entries after the last release marker
+# are this release's delta; when re-rendering an old tag, the window before
+# that tag's marker is used instead.
+commercial_count=0
+unchanged_features=()
 if [[ -f "${series}" ]]; then
   while IFS= read -r branch; do
     branch="${branch%%#*}"
@@ -140,8 +146,48 @@ if [[ -f "${series}" ]]; then
 
     git -C "${tmp_dir}/patches-repo" fetch --depth=1 "${patches_remote}" \
       "${branch}:refs/remotes/origin/${branch}"
-    echo "- $(git -C "${tmp_dir}/patches-repo" log -1 --format=%s "refs/remotes/origin/${branch}")" \
-      >> "${patch_notes}"
+    commercial_count=$((commercial_count + 1))
+    feature_title=$(git -C "${tmp_dir}/patches-repo" log -1 --format=%s "refs/remotes/origin/${branch}")
+    # No early exit inside the awk: the whole ledger is always consumed, so
+    # a long message can never SIGPIPE `git log` under pipefail.
+    feature_entries=$(git -C "${tmp_dir}/patches-repo" log -1 --format=%B "refs/remotes/origin/${branch}" \
+      | awk -v tag="${TAG_NAME}" '
+          function newer(a, b,   x, y, i) {
+            sub(/^v/, "", a); sub(/^v/, "", b)
+            split(a, x, "."); split(b, y, ".")
+            for (i = 1; i <= 3; i++) {
+              if (x[i] + 0 > y[i] + 0) return 1
+              if (x[i] + 0 < y[i] + 0) return 0
+            }
+            return 0
+          }
+          /^Changelog:$/ { inledger = 1; buf = ""; next }
+          !inledger { next }
+          /^--- release / {
+            if ($3 == tag) { found = 1; out = buf }
+            if (newer($3, tag)) sawnewer = 1
+            buf = ""; next
+          }
+          /^- / || /^  / { buf = buf $0 "\n" }
+          END {
+            if (found) { printf "%s", out }
+            # No marker for the tag: the trailing entries are the unreleased
+            # delta — correct for the current release (notes render before
+            # the marker is stamped), but a marker NEWER than the tag means
+            # this is a historical re-render of a pre-ledger tag: no entries.
+            else if (!sawnewer) { printf "%s", buf }
+          }
+        ')
+    if [[ -n "${feature_entries}" ]]; then
+      {
+        echo "### ${feature_title}"
+        echo
+        printf '%s' "${feature_entries}"
+        echo
+      } >> "${patch_notes}"
+    else
+      unchanged_features+=("${feature_title}")
+    fi
   done < "${series}"
 fi
 
@@ -151,13 +197,19 @@ fi
     echo
   fi
 
-  if [[ -s "${patch_notes}" ]]; then
+  if [[ "${commercial_count}" -gt 0 ]]; then
     echo "## Commercial Features"
     echo
-    echo "This release includes the following commercial enhancements:"
-    echo
-    cat "${patch_notes}"
-    echo
+    if [[ -s "${patch_notes}" ]]; then
+      echo "Changes to commercial features in this release:"
+      echo
+      cat "${patch_notes}"
+    fi
+    if [[ "${#unchanged_features[@]}" -gt 0 ]]; then
+      printf -v unchanged_list '%s, ' "${unchanged_features[@]}"
+      echo "_No changes this release: ${unchanged_list%, }._"
+      echo
+    fi
   fi
 
   cat "${tmp_dir}/formatted-notes.md"

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -236,6 +236,45 @@ jobs:
     secrets:
       SYNC_APP_PRIVATE_KEY: ${{ secrets.SYNC_APP_PRIVATE_KEY }}
 
+  mark-commercial-release:
+    # Stamp release markers into the 8gcr patch-branch changelog ledgers.
+    # Runs strictly AFTER the notes job: notes render the entries after the
+    # last marker, then this marks them as shipped in this tag. Manual
+    # re-renders of old tags never dispatch (this job only runs on a fresh
+    # release), so old markers are never disturbed.
+    name: Mark Commercial Release
+    needs: [release-please, update-release-notes]
+    if: ${{ needs.release-please.outputs.release_created == 'true' }}
+    runs-on: ubuntu-26.04
+    permissions:
+      # checkout of this repo (the app token below is scoped to 8gcr only)
+      contents: read
+    steps:
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          app-id: ${{ vars.SYNC_APP_ID }}
+          private-key: ${{ secrets.SYNC_APP_PRIVATE_KEY }}
+          owner: container-registry
+          repositories: 8gcr
+          # repository_dispatch needs contents write; request nothing else
+          permission-contents: write
+
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - uses: $/.github/actions/setup-task
+
+      - name: Dispatch release-cut
+        env:
+          DISPATCH_TOKEN: ${{ steps.app-token.outputs.token }}
+          TAG_NAME: ${{ needs.release-please.outputs.tag_name }}
+          TARGET_SHA: ${{ github.sha }}
+          LINE: ${{ github.ref_name }}
+        run: task release-notes:dispatch-release-cut
+
   chart:
     name: Publish Helm Chart
     # Driven by the chart's own release-please line (release-please-chart),

--- a/taskfile/release-notes.yml
+++ b/taskfile/release-notes.yml
@@ -11,6 +11,33 @@ tasks:
     cmds:
       - .github/scripts/update-release-notes.sh
 
+  dispatch-release-cut:
+    desc: "Tell 8gcr a release shipped so it stamps ledger markers (TAG_NAME, TARGET_SHA, LINE, DISPATCH_TOKEN)"
+    preconditions:
+      - sh: test -n "${TAG_NAME:-}"
+        msg: "TAG_NAME is required (for example, v2.16.0)"
+      - sh: test -n "${TARGET_SHA:-}"
+        msg: "TARGET_SHA is required (the released harbor-next commit)"
+      - sh: test -n "${LINE:-}"
+        msg: "LINE is required (main or release-X.Y)"
+      - sh: test -n "${DISPATCH_TOKEN:-}"
+        msg: "DISPATCH_TOKEN is required (token with write access to container-registry/8gcr)"
+      - sh: command -v jq >/dev/null 2>&1
+        msg: "jq is required"
+    cmds:
+      - |
+        # jq serializes the payload so odd characters in a locally supplied
+        # value can never break the JSON
+        payload=$(jq -n --arg tag "${TAG_NAME}" --arg sha "${TARGET_SHA}" --arg line "${LINE}" \
+          '{event_type: "release-cut", client_payload: {tag: $tag, target_sha: $sha, line: $line}}')
+        curl -f -X POST \
+          -H "Accept: application/vnd.github+json" \
+          -H "Content-Type: application/json" \
+          -H "X-GitHub-Api-Version: 2022-11-28" \
+          -H "Authorization: Bearer ${DISPATCH_TOKEN}" \
+          "https://api.github.com/repos/container-registry/8gcr/dispatches" \
+          -d "${payload}"
+
   preview:
     desc: "Render release notes locally without updating the GitHub Release (TAG_NAME=vX.Y.Z)"
     preconditions:


### PR DESCRIPTION
## Summary

Companion to container-registry/8gcr#387 (changelog-ledger patch flow). Two changes:

1. **`update-release-notes.sh` commercial block**: instead of listing each patch branch's tip subject (a static feature list, identical every release), parse the patch commit's changelog ledger and render the entries after the last release marker — what actually changed in each commercial feature this release. Re-rendering an old tag uses the window before that tag's marker, so historical notes stay correct. Features without entries collapse into one `No changes this release: …` line.

2. **`mark-commercial-release` job** in `release-please.yml`: after the notes job succeeds on a fresh release, run `task release-notes:dispatch-release-cut` (new task, also usable locally) to send a `release-cut` repository_dispatch to 8gcr with `tag` / `target_sha` / `line`. 8gcr's Release Marker workflow then stamps the shipped entries. Render first, mark second; manual re-renders of old tags never dispatch.

Works unchanged for maintenance lines: `release-2.X` runs carry `line: release-2.X` and their own manifest/branches.

Behavior before the 8gcr branches are ledger-seeded: every feature parses as "no entries" and the section renders the collapsed no-changes line — safe to merge in either order, though seeding first gives richer notes immediately.