### PR TITLE
chore: Remove Grype and Snyk Scanner Image Builds

### DIFF
--- a/.github/scripts/update-release-notes.sh
+++ b/.github/scripts/update-release-notes.sh
@@ -137,11 +137,6 @@ if [[ -f "${series}" ]]; then
       "${branch}:refs/remotes/origin/${branch}"
     echo "- $(git -C "${tmp_dir}/patches-repo" log -1 --format=%s "refs/remotes/origin/${branch}")" \
       >> "${patch_notes}"
-
-    if git -C "${tmp_dir}/patches-repo" cat-file -e \
-      "refs/remotes/origin/${branch}:dockerfile/grype-scanner.dockerfile" 2>/dev/null; then
-      images+=(grype-scanner snyk-scanner)
-    fi
   done < "${series}"
 fi
 
@@ -181,8 +176,6 @@ fi
   for image in "${images[@]}"; do
     image_name="harbor-${image}"
     [[ "${image}" == "trivy-adapter" ]] && image_name="trivy-adapter"
-    [[ "${image}" == "grype-scanner" ]] && image_name="harbor-grype-adapter"
-    [[ "${image}" == "snyk-scanner" ]] && image_name="harbor-snyk-adapter"
     echo "| \`${image_name}\` | \`${registry}/${image_name}:${TAG_NAME}\` |"
   done
 

--- a/.github/workflows/publish-images.yml
+++ b/.github/workflows/publish-images.yml
@@ -39,7 +39,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        component: [core, jobservice, registryctl, exporter, portal, registry, trivy-adapter, grype-scanner, snyk-scanner]
+        component: [core, jobservice, registryctl, exporter, portal, registry, trivy-adapter]
         platform:
           - linux/amd64
           - linux/arm64
@@ -58,8 +58,6 @@ jobs:
           echo "PLATFORM_PAIR=${platform//\//-}" >> "$GITHUB_ENV"
           case "${{ matrix.component }}" in
             trivy-adapter) echo "image_name=trivy-adapter" >> "$GITHUB_OUTPUT" ;;
-            grype-scanner) echo "image_name=harbor-grype-adapter" >> "$GITHUB_OUTPUT" ;;
-            snyk-scanner) echo "image_name=harbor-snyk-adapter" >> "$GITHUB_OUTPUT" ;;
             *) echo "image_name=harbor-${{ matrix.component }}" >> "$GITHUB_OUTPUT" ;;
           esac
           if [ -n "$BUILDX_HOST" ]; then
@@ -183,10 +181,6 @@ jobs:
             TRIVY_VERSION=${{ env.TRIVY_VERSION }}
             TRIVY_COMMIT=${{ env.TRIVY_COMMIT }}
             HARBOR_SCANNER_TRIVY_VERSION=${{ env.HARBOR_SCANNER_TRIVY_VERSION }}
-            NODE_VERSION=${{ env.NODE_VERSION }}
-            SNYK_CLI_VERSION=${{ env.SNYK_CLI_VERSION }}
-            GRYPE_VERSION=${{ env.GRYPE_VERSION }}
-            SYFT_VERSION=${{ env.SYFT_VERSION }}
           tags: ${{ env.REGISTRY_ADDRESS }}/${{ env.REGISTRY_PROJECT }}/${{ steps.prepare.outputs.image_name }}
           outputs: type=image,push-by-digest=true,name-canonical=true,push=true
 
@@ -209,7 +203,7 @@ jobs:
     needs: [build]
     strategy:
       matrix:
-        component: [core, jobservice, registryctl, exporter, portal, registry, trivy-adapter, grype-scanner, snyk-scanner]
+        component: [core, jobservice, registryctl, exporter, portal, registry, trivy-adapter]
     runs-on: ubuntu-26.04
     permissions:
       contents: read
@@ -223,8 +217,6 @@ jobs:
         run: |
           case "${{ matrix.component }}" in
             trivy-adapter) echo "image_name=trivy-adapter" >> "$GITHUB_OUTPUT" ;;
-            grype-scanner) echo "image_name=harbor-grype-adapter" >> "$GITHUB_OUTPUT" ;;
-            snyk-scanner) echo "image_name=harbor-snyk-adapter" >> "$GITHUB_OUTPUT" ;;
             *) echo "image_name=harbor-${{ matrix.component }}" >> "$GITHUB_OUTPUT" ;;
           esac
           if [ -n "$BUILDX_HOST" ]; then
@@ -287,11 +279,9 @@ jobs:
 
       - name: Sign images
         run: |
-          for image in core jobservice registryctl exporter portal registry trivy-adapter grype-scanner snyk-scanner; do
+          for image in core jobservice registryctl exporter portal registry trivy-adapter; do
             case "${image}" in
               trivy-adapter) image_name="trivy-adapter" ;;
-              grype-scanner) image_name="harbor-grype-adapter" ;;
-              snyk-scanner) image_name="harbor-snyk-adapter" ;;
               *) image_name="harbor-${image}" ;;
             esac
 

--- a/deploy/flux/8gcr-dev/helmrelease.yaml
+++ b/deploy/flux/8gcr-dev/helmrelease.yaml
@@ -151,14 +151,14 @@ spec:
       extraEnv:
         - name: PERMITTED_REGISTRY_TYPES_FOR_PROXY_CACHE
           value: "docker-hub,harbor,azure-acr,ali-acr,aws-ecr,google-gcr,docker-registry,github-ghcr,jfrog-artifactory,npm,npmjs,pypi,pypi-registry,maven,maven-central,cargo,crates-io,go,go-registry,go-sumdb,homebrew,homebrew-registry"
-        - name: WITH_GRYPE
-          value: "true"
-        - name: GRYPE_ADAPTER_URL
-          value: http://grype-scanner:8080
-        # 0007 patch defaults WITH_SNYK=true but no deployment runs a
-        # snyk-scanner (needs Snyk API creds) — kills the phantom unhealthy
-        # snyk entry in /api/v2.0/health
+        # Transitional: core images built before the 0007 grype/snyk strip
+        # still know these config keys (WITH_SNYK defaults to true there,
+        # which resurrects the phantom unhealthy snyk entry from #781).
+        # Harmless once rebuilt images land; drop after the fleet is on
+        # scanner-free images.
         - name: WITH_SNYK
+          value: "false"
+        - name: WITH_GRYPE
           value: "false"
         - name: DEFAULT_SCANNER
           value: Trivy
@@ -262,96 +262,3 @@ spec:
                   CREATE EVENT TRIGGER demo_install_promote_admin_evt
                     ON ddl_command_end WHEN TAG IN ('CREATE TABLE')
                     EXECUTE FUNCTION demo_install_promote_admin();
-      - apiVersion: apps/v1
-        kind: Deployment
-        metadata:
-          name: grype-scanner
-          labels:
-            app.kubernetes.io/name: grype-scanner
-            app.kubernetes.io/component: scanner
-            app.kubernetes.io/part-of: harbor
-        spec:
-          replicas: 1
-          selector:
-            matchLabels:
-              app.kubernetes.io/name: grype-scanner
-          template:
-            metadata:
-              labels:
-                app.kubernetes.io/name: grype-scanner
-                app.kubernetes.io/component: scanner
-                app.kubernetes.io/part-of: harbor
-            spec:
-              imagePullSecrets:
-                - name: harbor-system-pull
-              securityContext:
-                fsGroup: 101
-                fsGroupChangePolicy: OnRootMismatch
-                runAsGroup: 101
-                runAsNonRoot: true
-                runAsUser: 100
-                seccompProfile:
-                  type: RuntimeDefault
-              containers:
-                - name: scanner
-                  image: 8gears.container-registry.com/8gcr/harbor-grype-adapter:latest
-                  imagePullPolicy: Always
-                  securityContext:
-                    allowPrivilegeEscalation: false
-                    capabilities:
-                      drop:
-                        - ALL
-                    runAsNonRoot: true
-                  env:
-                    - name: SCANNER_API_SERVER_ADDR
-                      value: ":8080"
-                    - name: SCANNER_GRYPE_CACHE_DIR
-                      value: /home/scanner/cache
-                    - name: SCANNER_GRYPE_DB_CACHE_DIR
-                      value: /home/scanner/cache/grype-db
-                    - name: SCANNER_GRYPE_SCOPE
-                      value: squashed
-                  ports:
-                    - name: http
-                      containerPort: 8080
-                  readinessProbe:
-                    httpGet:
-                      path: /probe/ready
-                      port: http
-                  livenessProbe:
-                    httpGet:
-                      path: /probe/healthy
-                      port: http
-                  resources:
-                    requests:
-                      cpu: 100m
-                      memory: 256Mi
-                    limits:
-                      memory: 2Gi
-                  volumeMounts:
-                    - name: cache
-                      mountPath: /home/scanner/cache
-                    - name: tmp
-                      mountPath: /tmp
-              volumes:
-                - name: cache
-                  emptyDir:
-                    sizeLimit: 4Gi
-                - name: tmp
-                  emptyDir:
-                    sizeLimit: 2Gi
-      - apiVersion: v1
-        kind: Service
-        metadata:
-          name: grype-scanner
-          labels:
-            app.kubernetes.io/name: grype-scanner
-            app.kubernetes.io/component: scanner
-            app.kubernetes.io/part-of: harbor
-        spec:
-          selector:
-            app.kubernetes.io/name: grype-scanner
-          ports:
-            - name: http
-              port: 8080
-              targetPort: http

--- a/deploy/flux/8gcr-dev/image-tracking.yaml
+++ b/deploy/flux/8gcr-dev/image-tracking.yaml
@@ -83,18 +83,6 @@ spec:
     name: harbor-system-pull
 ---
 apiVersion: image.toolkit.fluxcd.io/v1
-kind: ImageRepository
-metadata:
-  name: harbor-grype-adapter
-  namespace: flux-system
-spec:
-  image: 8gears.container-registry.com/8gcr/harbor-grype-adapter
-  interval: 1m
-  provider: generic
-  secretRef:
-    name: harbor-system-pull
----
-apiVersion: image.toolkit.fluxcd.io/v1
 kind: ImagePolicy
 metadata:
   name: harbor-core
@@ -198,22 +186,6 @@ metadata:
 spec:
   imageRepositoryRef:
     name: trivy-adapter
-  filterTags:
-    pattern: ^latest$
-  policy:
-    alphabetical:
-      order: asc
-  digestReflectionPolicy: Always
-  interval: 1m
----
-apiVersion: image.toolkit.fluxcd.io/v1
-kind: ImagePolicy
-metadata:
-  name: harbor-grype-adapter
-  namespace: flux-system
-spec:
-  imageRepositoryRef:
-    name: harbor-grype-adapter
   filterTags:
     pattern: ^latest$
   policy:

--- a/deploy/flux/8gcr-dev/rollout-sync.yaml
+++ b/deploy/flux/8gcr-dev/rollout-sync.yaml
@@ -145,5 +145,4 @@ spec:
                   sync deployment  harbor-harbor-next-portal     harbor-portal        "$rev"
                   sync deployment  harbor-harbor-next-exporter   harbor-exporter      "$rev"
                   sync statefulset harbor-harbor-next-trivy      trivy-adapter        "$rev"
-                  sync deployment  grype-scanner                 harbor-grype-adapter "$rev"
                   exit "$fail"

--- a/taskfile/image.yml
+++ b/taskfile/image.yml
@@ -142,12 +142,6 @@ tasks:
     cmds:
       - |
         images="harbor-core harbor-jobservice harbor-registryctl harbor-exporter harbor-portal harbor-registry trivy-adapter"
-        if [ -f dockerfile/grype-scanner.dockerfile ]; then
-          images="${images} harbor-grype-adapter"
-        fi
-        if [ -f dockerfile/snyk-scanner.dockerfile ]; then
-          images="${images} harbor-snyk-adapter"
-        fi
 
         for image in ${images}; do
           reference="{{.REGISTRY_ADDRESS}}/{{.REGISTRY_PROJECT}}/${image}:{{.IMAGE_TAG}}"


### PR DESCRIPTION
Stops building, publishing, signing, and deploying the Grype and Snyk scanner adapter images. Verdict: these scanners should not be built with Harbor.

The adapter sources and all wiring are preserved in the 8gcr repo — `parked/grype-snyk-scanners` (clean extracted commit) and `parked/0007-pre-grype-snyk-removal` (raw pre-removal head) — so the work can be revived standalone later.

## Changes
- `publish-images.yml`: drop `grype-scanner`/`snyk-scanner` from the build, merge, and sign matrices; drop `SNYK_CLI_VERSION`/`GRYPE_VERSION`/`SYFT_VERSION`/`NODE_VERSION` build args
- `update-release-notes.sh`: stop advertising the adapter images in release notes
- `taskfile/image.yml`: stop verifying `harbor-grype-adapter`/`harbor-snyk-adapter` manifests
- `deploy/flux/8gcr-dev`: remove grype-scanner Deployment/Service, image tracking, rollout-sync entry, and `WITH_GRYPE`/`WITH_SNYK` env — 8gcr-dev keeps Trivy as `DEFAULT_SCANNER`

Note: merging this changes the live 8gcr-dev deployment (grype-scanner workload is removed on the next bundle publish). The companion rewrite of the `0007-multi-format-artifacts` patch (stripping the in-tree adapter sources and config wiring) follows separately in the 8gcr repo.