### PR TITLE
ci: Dispatch Fork Sync From Maintenance Branches Too

### DIFF
--- a/.github/workflows/notify-fork-sync.yml
+++ b/.github/workflows/notify-fork-sync.yml
@@ -1,8 +1,13 @@
 name: Notify Fork Sync
 
+# Every commit landing on main or a maintenance branch dispatches 8gcr's
+# patch-branch sync for that line — event-driven, no cron on either side.
 on:
   push:
-    branches: [main]
+    branches:
+      - main
+      # glob quantifier `+` keeps this exact: release-X.Y, nothing trailing
+      - "release-[0-9]+.[0-9]+"
 
 permissions: {}
 
@@ -19,12 +24,20 @@ jobs:
           owner: container-registry
           repositories: 8gcr
 
+      # ref_name/sha reach the shell via env + jq, never template expansion
+      # inside the script (zizmor: template-injection)
       - name: Trigger sync
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          SYNC_SHA: ${{ github.sha }}
+          SYNC_LINE: ${{ github.ref_name }}
         run: |
-          curl -f -X POST \
+          jq -cn --arg sha "${SYNC_SHA}" --arg line "${SYNC_LINE}" \
+            '{event_type: "upstream-sync", client_payload: {sha: $sha, line: $line}}' \
+          | curl -f -X POST \
             -H "Accept: application/vnd.github+json" \
             -H "Content-Type: application/json" \
             -H "X-GitHub-Api-Version: 2022-11-28" \
-            -H "Authorization: Bearer ${{ steps.app-token.outputs.token }}" \
+            -H "Authorization: Bearer ${GH_TOKEN}" \
             "https://api.github.com/repos/container-registry/8gcr/dispatches" \
-            -d '{"event_type":"upstream-sync","client_payload":{"sha":"${{ github.sha }}"}}'
+            -d @-


### PR DESCRIPTION
Companion to container-registry/8gcr#387. `notify-fork-sync` now fires on pushes to `main` **and** `release-X.Y` branches, and the `upstream-sync` payload carries `line` (the pushed branch) next to `sha`. 8gcr's `sync-and-verify` uses it to rebase that line's patch branches: `main` keeps the jj megamerge path, maintenance lines run `task patch-ledger:rebase LINE=release-X.Y` (single-commit rebase, stacked branches follow their parent, ledger messages ride along). Replaces the intent behind the closed #795 — the goal was event-driven patch-branch updates for every line, not the upstream cherry-pick job.