### PR TITLE
ci: Use github-tags datasource for aquasecurity/trivy in versions.env

### DIFF
--- a/versions.env
+++ b/versions.env
@@ -59,7 +59,7 @@ POSTGRES_VERSION=16
 # External dependencies
 # renovate: datasource=github-tags depName=distribution/distribution
 DISTRIBUTION_VERSION=v3.1.1
-# renovate: datasource=github-releases depName=aquasecurity/trivy extractVersion=^v(?<version>.*)$
+# renovate: datasource=github-tags depName=aquasecurity/trivy extractVersion=^v(?<version>.*)$
 TRIVY_VERSION=0.72.0
 # renovate: datasource=docker depName=aquasec/trivy versioning=docker
 TRIVY_BASE_IMAGE_VERSION=0.72.0


### PR DESCRIPTION
## Summary

The Dependency Dashboard (#761) reports `Failed to look up github-releases package aquasecurity/trivy: no-result` for `versions.env`. Root cause: GitHub releases between trivy 0.26 and 0.69 were deleted from the upstream repository after the supply-chain incident (aquasecurity/trivy#10345), which breaks Renovate's `github-releases` datasource for that repo. Git tags remain intact.

## Fix

Switch the `TRIVY_VERSION` pin metadata from `github-releases` to `github-tags`, matching the existing `distribution/distribution` and `container-registry/harbor-scanner-trivy` entries. `extractVersion` is unchanged since tags keep the `v` prefix.