### PR TITLE
ci: Use docker datasource for TRIVY_VERSION in versions.env

### DIFF
--- a/versions.env
+++ b/versions.env
@@ -59,7 +59,7 @@ POSTGRES_VERSION=16
 # External dependencies
 # renovate: datasource=github-tags depName=distribution/distribution
 DISTRIBUTION_VERSION=v3.1.1
-# renovate: datasource=github-tags depName=aquasecurity/trivy extractVersion=^v(?<version>.*)$
+# renovate: datasource=docker depName=aquasec/trivy versioning=docker
 TRIVY_VERSION=0.74.0
 # renovate: datasource=docker depName=aquasec/trivy versioning=docker
 TRIVY_BASE_IMAGE_VERSION=0.74.0


### PR DESCRIPTION
## Summary

Follow-up to #801: the github-tags lookup for `aquasecurity/trivy` still returns `no-result` on the Dependency Dashboard. Local reproduction with a user PAT succeeds for the identical config, and the app token resolves github datasource lookups for other orgs (cli/cli, go-swagger), so the failure is specific to the Renovate app installation token querying the aquasecurity org.

## Fix

`TRIVY_VERSION` is only ever used as an `aquasec/trivy` image tag (`dockerfile/dev.trivy-adapter.dockerfile`, `taskfile/helm.yml`), so point its Renovate metadata at the docker datasource — the semantically correct source, and the same one that already resolves `TRIVY_BASE_IMAGE_VERSION` without issues. Keeps both pins in lockstep through the same datasource.

If a github datasource for aquasecurity repos is ever needed again, the renovate workflow would need a separate `GITHUB_COM_TOKEN` PAT for third-party lookups.