### PR TITLE
ci: Emit bare deps: commit type for Renovate updates

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -12,7 +12,8 @@
   "dependencyDashboard": true,
   "configMigration": true,
   "semanticCommits": "enabled",
-  "semanticCommitType": "chore",
+  "semanticCommitType": "deps",
+  "semanticCommitScope": null,
   "labels": [
     "dependencies"
   ],
@@ -132,6 +133,14 @@
       "addLabels": [
         "docker"
       ]
+    },
+    {
+      "description": "Bare deps: commit type everywhere — overrides :semanticPrefixFixDepsChoreOthers from config:recommended, which would otherwise emit fix(deps)/chore(deps)",
+      "matchPackageNames": [
+        "*"
+      ],
+      "semanticCommitType": "deps",
+      "semanticCommitScope": null
     }
   ],
   "customManagers": [

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -28,6 +28,7 @@ jobs:
             chore
             revert
             upstream
+            deps
           requireScope: false
           subjectPattern: ^.{1,100}$
           subjectPatternError: |

--- a/release-please-config-maintenance.json
+++ b/release-please-config-maintenance.json
@@ -9,6 +9,7 @@
   "changelog-sections": [
     {"type": "feat",     "section": "Features"},
     {"type": "fix",      "section": "Bug Fixes"},
+    {"type": "deps",     "section": "Dependencies", "hidden": true},
     {"type": "perf",     "section": "Performance Improvements"},
     {"type": "upstream", "section": "Upstream"},
     {"type": "revert",   "section": "Reverts"},

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -11,6 +11,7 @@
   "changelog-sections": [
     {"type": "feat",     "section": "Features"},
     {"type": "fix",      "section": "Bug Fixes"},
+    {"type": "deps",     "section": "Dependencies", "hidden": true},
     {"type": "perf",     "section": "Performance Improvements"},
     {"type": "upstream", "section": "Upstream"},
     {"type": "revert",   "section": "Reverts"},


### PR DESCRIPTION
## Summary

Renovate PRs currently land as `fix(deps): …` / `chore(deps): …` (from `:semanticPrefixFixDepsChoreOthers` inside `config:recommended`). This switches all Renovate commits/PR titles to a bare `deps: …`.

## Changes

- **renovate.json**: `semanticCommitType: "deps"`, `semanticCommitScope: null` (bare type, no scope — `semanticCommitType` accepts any string, validated with `renovate-config-validator` 44.46.5), plus a trailing catch-all `packageRules` entry (`matchPackageNames: ["*"]`) so the preset's per-depType `fix`/`chore` overrides can never win.
- **release-please-config.json + release-please-config-maintenance.json**: `deps` registered as a **hidden** changelog section — dependency updates are deliberately kept out of release notes (per Vadim). This also fixes the current leak where `fix(deps)` commits land under *Bug Fixes*.
- **pr-title.yml**: `deps` added to the allowed semantic PR title types (otherwise every Renovate PR would fail the title check).

## ⚠️ Version-bump behavior change — the tradeoff

Today `fix(deps)` is a **releasable** commit: dependency updates alone trigger/refresh the release-please PR. `deps` is **not** a release-please releasable type:

- Dependency-only commit streams will **no longer create or update a release PR**. Dep updates ride along with the next `feat`/`fix`/other releasable commit, invisible in notes.
- Security updates from vulnerabilityAlerts also become `deps:` and inherit this. If security bumps should keep driving releases on their own, add `"semanticCommitType": "fix"` inside the `vulnerabilityAlerts` block as a follow-up.
- `main` is `always-bump-minor`, so nothing changes about *how much* the version bumps — only *whether* deps alone trigger a release.

## Coordination

Main history is concurrently being rewritten (dropcommit retitling the already-merged dep commits); this branch is based on pre-rewrite main `e8829d3b` — rebase before merge if main moves under it. **Do not merge — opened for review per instructions.**