### PR TITLE
ci: Block Renovate from bumping gorilla/csrf past v1.7.2

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -135,6 +135,13 @@
       ]
     },
     {
+      "description": "gorilla/csrf is deliberately pinned to v1.7.2 (goharbor/harbor#22010) — block the v1.7.3+ updates Renovate keeps proposing, including via vulnerability alerts",
+      "matchPackageNames": [
+        "github.com/gorilla/csrf"
+      ],
+      "allowedVersions": "<= 1.7.2"
+    },
+    {
       "description": "Bare deps: commit type everywhere — overrides :semanticPrefixFixDepsChoreOthers from config:recommended, which would otherwise emit fix(deps)/chore(deps)",
       "matchPackageNames": [
         "*"


### PR DESCRIPTION
## Summary

`src/go.mod` deliberately pins `github.com/gorilla/csrf` to v1.7.2 (comment references goharbor/harbor#22010), but Renovate doesn't read comments — it proposed v1.7.3 as a security update and it was briefly merged (#767) before being backed out.

## Fix

Encode the pin in `renovate.json`: a `packageRules` entry with `allowedVersions: "<= 1.7.2"` for `github.com/gorilla/csrf`. This blocks scheduled update PRs and vulnerability-alert PRs alike from re-proposing v1.7.3+, so the csrf drop from main can't be silently re-introduced on the next Renovate run.

Config validated with `renovate-config-validator` 44.46.5.

**Do not let me merge this — per standing order, merging is yours.** PR is ready for review; will report merge-readiness once CI is green.