### PR TITLE
ci: publish stack-aware preview images and charts for pull requests

### DIFF
--- a/.github/workflows/pr-chart.yml
+++ b/.github/workflows/pr-chart.yml
@@ -1,0 +1,267 @@
+name: PR Preview Chart
+
+# Packages, pushes and signs a preview of deploy/chart for a pull request,
+# versioned <chart version>-pr.<N>, into the PR registry project, and leaves a
+# sticky comment with the install command. The chart-input allowlist lives in
+# the `changes` job, not in a `paths` trigger filter: GitHub evaluates `paths`
+# against the PR's own diff, which for a stacked PR is only the top slice.
+
+on:
+  pull_request:
+    branches: [main, "release-[0-9]*.[0-9]*"]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: pr-chart-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+env:
+  REGISTRY_ADDRESS: ${{ vars.REGISTRY_ADDRESS || '8gears.container-registry.com' }}
+  PR_REGISTRY_PROJECT: ${{ vars.PR_REGISTRY_PROJECT }}
+  RELEASE_PROJECT: ${{ vars.REGISTRY_PROJECT || '8gcr' }}
+
+jobs:
+  changes:
+    name: Check chart inputs
+    # Forked PRs have no registry credentials and bot PRs need no preview. A
+    # chart release PR only restamps version and changelog. In a native
+    # GitHub stack only the top PR publishes: its head contains every lower PR.
+    if: >-
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      !contains(fromJSON('["8gcr-renovate[bot]", "renovate[bot]", "8gcr-sync[bot]"]'), github.actor) &&
+      !startsWith(github.head_ref, 'release-please--') &&
+      (github.event.pull_request.stack == null ||
+       github.event.pull_request.stack.position == github.event.pull_request.stack.size)
+    runs-on: ubuntu-26.04
+    timeout-minutes: 5
+    outputs:
+      build: ${{ steps.diff.outputs.build }}
+      stack_number: ${{ github.event.pull_request.stack.number || '' }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          # Full history: the diff below spans the whole stack
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Diff against the stack base
+        id: diff
+        env:
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          STACK_BASE_SHA: ${{ github.event.pull_request.stack.base.sha || '' }}
+          # Only inputs that reach the packaged chart.
+          CHART_INPUTS: |
+            ^deploy/chart/
+            ^\.github/workflows/pr-chart\.yml$
+            ^\.github/scripts/chart-annotate-images\.sh$
+        run: |
+          base="${STACK_BASE_SHA:-${PR_BASE_SHA}}"
+          # --no-renames: a rename out of the allowlist would otherwise show
+          # only its new path and hide that a chart input went away
+          changed="$(git diff --name-only --no-renames "${base}...${HEAD_SHA}")"
+          if grep -Ef <(printf '%s' "${CHART_INPUTS}") <<<"${changed}"; then
+            echo "build=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "No chart input changed between ${base} and ${HEAD_SHA}; skipping the preview chart"
+            echo "build=false" >> "$GITHUB_OUTPUT"
+          fi
+
+  preview-chart:
+    name: Publish preview chart
+    needs: [changes]
+    if: needs.changes.outputs.build == 'true'
+    runs-on: ubuntu-26.04
+    timeout-minutes: 20
+    permissions:
+      contents: read
+      # cosign signs with the workflow's OIDC identity
+      id-token: write
+    outputs:
+      version: ${{ steps.version.outputs.version }}
+      app_version: ${{ steps.version.outputs.app_version }}
+      digest: ${{ steps.push.outputs.digest }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          # The PR head, not the merge commit: the same ref the image previews build
+          ref: ${{ github.event.pull_request.head.sha }}
+          persist-credentials: false
+
+      - name: Load versions
+        # Helm homes: self-hosted runner images may ship a root-owned
+        # ~/.cache; keep all helm state in the always-writable temp.
+        run: |
+          grep -E '^[A-Z_]+=' versions.env >> "$GITHUB_ENV"
+          {
+            echo "HELM_CACHE_HOME=${RUNNER_TEMP}/helm/cache"
+            echo "HELM_CONFIG_HOME=${RUNNER_TEMP}/helm/config"
+            echo "HELM_DATA_HOME=${RUNNER_TEMP}/helm/data"
+          } >> "$GITHUB_ENV"
+
+      - name: Install Helm
+        uses: azure/setup-helm@9bc31f4ebc9c6b171d7bfbaa5d006ae7abdb4310 # v5.0.1
+        with:
+          version: ${{ env.HELM_VERSION }}
+
+      - name: Install envsubst
+        run: command -v envsubst || (sudo apt-get update && sudo apt-get install -y gettext-base)
+
+      - name: Install cosign
+        uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
+
+      - name: Resolve the preview version
+        id: version
+        # <chart version>-pr.<N>: a semver prerelease, so helm accepts it as an
+        # exact --version and the OCI tag is the version string itself. It is
+        # overwritten on every push; the comment carries the digest for pinning.
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          set -euo pipefail
+          read_key() {
+            awk -F'[:[:space:]]+' -v key="$1" '$1 == key { gsub(/["'"'"']/, "", $2); print $2; exit }' deploy/chart/Chart.yaml
+          }
+          version="$(read_key version)"
+          app_version="$(read_key appVersion)"
+          if [[ ! "${version}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "::error::Unusable chart version in deploy/chart/Chart.yaml: '${version}'"
+            exit 1
+          fi
+          preview="${version}-pr.${PR_NUMBER}"
+          echo "PREVIEW_VERSION=${preview}" >> "$GITHUB_ENV"
+          {
+            echo "version=${preview}"
+            echo "app_version=${app_version}"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Log in to registry
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
+        with:
+          registry: ${{ env.REGISTRY_ADDRESS }}
+          username: ${{ vars.PR_REGISTRY_USERNAME }}
+          password: ${{ secrets.PR_REGISTRY_PASSWORD }}
+
+      - name: Add per-release Artifact Hub images annotation
+        # The annotation names the images the chart defaults to: the released
+        # appVersion in the release project, not the preview project.
+        run: |
+          .github/scripts/chart-annotate-images.sh \
+            deploy/chart "${REGISTRY_ADDRESS}" "${RELEASE_PROJECT}"
+
+      - name: Build chart dependencies
+        # deploy/chart/charts/ is gitignored; Chart.lock pins the subcharts.
+        run: helm dependency build deploy/chart
+
+      - name: Package chart
+        # appVersion stays as committed, so default image tags resolve to a
+        # published Harbor release.
+        run: helm package deploy/chart --version "${PREVIEW_VERSION}" --destination dist
+
+      - name: Push chart
+        id: push
+        # pipefail: GitHub's default shell is `bash -e` without it, so a
+        # failing helm push would be masked by tee, and its error message can
+        # itself contain a sha256 digest the capture below would match.
+        run: |
+          set -euo pipefail
+          helm push "dist/harbor-next-${PREVIEW_VERSION}.tgz" \
+            "oci://${REGISTRY_ADDRESS}/${PR_REGISTRY_PROJECT}/charts" 2>&1 | tee push.log
+          digest=$(grep -o 'sha256:[a-f0-9]\{64\}' push.log | head -1)
+          if [ -z "$digest" ]; then
+            echo "::error::Failed to capture the chart digest from helm push output"
+            exit 1
+          fi
+          echo "digest=${digest}" >> "$GITHUB_OUTPUT"
+
+      - name: Sign chart
+        env:
+          CHART_DIGEST: ${{ steps.push.outputs.digest }}
+        run: |
+          cosign sign --yes \
+            "${REGISTRY_ADDRESS}/${PR_REGISTRY_PROJECT}/charts/harbor-next@${CHART_DIGEST}"
+
+  pr-comment:
+    name: Comment preview chart ref
+    needs: [changes, preview-chart]
+    if: needs.changes.outputs.build == 'true'
+    runs-on: ubuntu-26.04
+    permissions:
+      pull-requests: write
+    env:
+      PREVIEW_VERSION: ${{ needs.preview-chart.outputs.version }}
+      APP_VERSION: ${{ needs.preview-chart.outputs.app_version }}
+      DIGEST: ${{ needs.preview-chart.outputs.digest }}
+      STACK_NUMBER: ${{ needs.changes.outputs.stack_number }}
+    steps:
+      - name: Create or update PR comment
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        env:
+          MARKER: "<!-- harbor-next-pr-chart-preview -->"
+        with:
+          script: |
+            const marker = process.env.MARKER;
+            const registryAddress = process.env.REGISTRY_ADDRESS;
+            const previewProject = process.env.PR_REGISTRY_PROJECT;
+            const chart = `${registryAddress}/${previewProject}/charts/harbor-next`;
+            const previewVersion = process.env.PREVIEW_VERSION;
+            const appVersion = process.env.APP_VERSION;
+            const digest = process.env.DIGEST;
+            const stackNumber = process.env.STACK_NUMBER;
+            const repository = process.env.GITHUB_REPOSITORY;
+            const issueNumber = context.payload.pull_request.number;
+            const { owner, repo } = context.repo;
+            const stackNote = stackNumber
+              ? `\nThis PR is the top of stack #${stackNumber}; the chart is packaged from its head and contains every PR in the stack.\n`
+              : '';
+
+            const body = `${marker}
+            A preview chart for this PR is available:
+
+            \`\`\`
+            helm install harbor-next \\
+              oci://${chart} \\
+              --version ${previewVersion}
+            \`\`\`
+
+            Digest: \`${digest}\`. The chart defaults to Harbor \`${appVersion}\`; this PR's \`pr-${issueNumber}\` images in \`${previewProject}\`, when published, can be selected through the chart's image values.
+            ${stackNote}
+            Verify the preview chart:
+
+            \`\`\`
+            cosign verify \\
+              --certificate-identity-regexp="https://github.com/${repository}/.github/workflows/pr-chart.yml@.*" \\
+              --certificate-oidc-issuer="https://token.actions.githubusercontent.com" \\
+              ${chart}@${digest}
+            \`\`\``;
+
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              owner,
+              repo,
+              issue_number: issueNumber,
+              per_page: 100,
+            });
+
+            const existingComment = comments.find(comment =>
+              comment.user?.login === 'github-actions[bot]' &&
+              comment.body?.startsWith(marker)
+            );
+
+            if (existingComment) {
+              await github.rest.issues.updateComment({
+                owner,
+                repo,
+                comment_id: existingComment.id,
+                body,
+              });
+              return;
+            }
+
+            await github.rest.issues.createComment({
+              owner,
+              repo,
+              issue_number: issueNumber,
+              body,
+            });

--- a/.github/workflows/pr-chart.yml
+++ b/.github/workflows/pr-chart.yml
@@ -8,6 +8,9 @@ name: PR Preview Chart
 
 on:
   pull_request:
+    # `stacked`: GitHub opens the PRs of a stack before it links them, so
+    # `opened` never carries `pull_request.stack`; the link fires `stacked`.
+    types: [opened, synchronize, reopened, stacked]
     branches: [main, "release-[0-9]*.[0-9]*"]
 
 permissions:
@@ -52,12 +55,15 @@ jobs:
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
           PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
           STACK_BASE_SHA: ${{ github.event.pull_request.stack.base.sha || '' }}
+          STACK_NUMBER: ${{ github.event.pull_request.stack.number || '' }}
+          EVENT_ACTION: ${{ github.event.action }}
           # Only inputs that reach the packaged chart.
           CHART_INPUTS: |
             ^deploy/chart/
             ^\.github/workflows/pr-chart\.yml$
             ^\.github/scripts/chart-annotate-images\.sh$
         run: |
+          echo "event=${EVENT_ACTION} stack=${STACK_NUMBER:-none}"
           base="${STACK_BASE_SHA:-${PR_BASE_SHA}}"
           # --no-renames: a rename out of the allowlist would otherwise show
           # only its new path and hide that a chart input went away

--- a/.github/workflows/pr-chart.yml
+++ b/.github/workflows/pr-chart.yml
@@ -284,10 +284,14 @@ jobs:
               // earlier revision left a reference behind.
               if (!existing) return;
               let reason;
-              if (process.env.CHANGES_RESULT === 'skipped') {
+              if (process.env.CHANGES_RESULT === 'skipped' && stackNumber) {
                 const top = stack?.pull_requests?.[stack.pull_requests.length - 1];
                 reason = `this PR is not the top of stack #${stackNumber}` +
                   (top ? `, so the stack's preview chart is published on #${top.number}` : '');
+              } else if (process.env.CHANGES_RESULT !== 'success') {
+                // A failed or cancelled input check publishes nothing either,
+                // and must not be reported as "no input changed".
+                reason = `the chart input check for \`${short}\` did not complete (${process.env.CHANGES_RESULT})`;
               } else if (process.env.BUILD_RESULT === 'skipped') {
                 reason = `no chart input changed between the base and \`${short}\``;
               } else {
@@ -312,7 +316,7 @@ jobs:
             const stackSection = [];
             if (stackNumber) {
               stackSection.push('', `This PR is the top of stack #${stackNumber}, so the chart comes from a head that contains every PR in it:`, '');
-              stackSection.push(...(stack
+              stackSection.push(...(stack?.pull_requests?.length
                 ? stack.pull_requests.map((pr, index) => `${index + 1}. #${pr.number} ${pr.title}`)
                 : ['(see the stack view on this PR)']));
               if (matched.length) {
@@ -324,7 +328,9 @@ jobs:
             const sibling = comments.find(comment =>
               comment.user?.login === 'github-actions[bot]' && comment.body?.startsWith(siblingMarker));
             const siblingSection = sibling
-              ? ['', `Preview images for this PR are published too: ${sibling.html_url}`]
+              ? ['', sibling.body.includes(staleStart)
+                  ? `Preview images for this PR have a comment, but it is currently marked outdated: ${sibling.html_url}`
+                  : `Preview images for this PR are published too: ${sibling.html_url}`]
               : [];
 
             const body = [

--- a/.github/workflows/pr-chart.yml
+++ b/.github/workflows/pr-chart.yml
@@ -120,9 +120,6 @@ jobs:
         with:
           version: ${{ env.HELM_VERSION }}
 
-      - name: Install envsubst
-        run: command -v envsubst || (sudo apt-get update && sudo apt-get install -y gettext-base)
-
       - name: Install cosign
         uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
 
@@ -151,19 +148,21 @@ jobs:
             echo "app_version=${app_version}"
           } >> "$GITHUB_OUTPUT"
 
+      - name: Add per-release Artifact Hub images annotation
+        # Before the login on purpose: the script comes from the pull request,
+        # and PR-controlled code must not run on a runner that already holds
+        # registry credentials. The annotation names the images the chart
+        # defaults to, the released appVersion in the release project.
+        run: |
+          .github/scripts/chart-annotate-images.sh \
+            deploy/chart "${REGISTRY_ADDRESS}" "${RELEASE_PROJECT}"
+
       - name: Log in to registry
         uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
         with:
           registry: ${{ env.REGISTRY_ADDRESS }}
           username: ${{ vars.PR_REGISTRY_USERNAME }}
           password: ${{ secrets.PR_REGISTRY_PASSWORD }}
-
-      - name: Add per-release Artifact Hub images annotation
-        # The annotation names the images the chart defaults to: the released
-        # appVersion in the release project, not the preview project.
-        run: |
-          .github/scripts/chart-annotate-images.sh \
-            deploy/chart "${REGISTRY_ADDRESS}" "${RELEASE_PROJECT}"
 
       - name: Build chart dependencies
         # deploy/chart/charts/ is gitignored; Chart.lock pins the subcharts.
@@ -219,6 +218,7 @@ jobs:
       STACK_NUMBER: ${{ github.event.pull_request.stack.number || '' }}
       MATCHED: ${{ needs.changes.outputs.matched }}
       CHANGES_RESULT: ${{ needs.changes.result }}
+      CHANGES_BUILD: ${{ needs.changes.outputs.build }}
       BUILD_RESULT: ${{ needs.preview-chart.result }}
     steps:
       - name: Create or update PR comment
@@ -274,7 +274,9 @@ jobs:
               for (const line of body.split('\n')) {
                 if (line === staleStart) { inNotice = true; continue; }
                 if (line === staleEnd) { inNotice = false; continue; }
-                if (!inNotice && line !== marker) kept.push(line);
+                // `:stale` also matches the inline marker the first
+                // implementation used, so an old notice is not kept forever.
+                if (!inNotice && line !== marker && !/^<!--[^>]*:stale/.test(line)) kept.push(line);
               }
               return kept.join('\n').trim();
             };
@@ -292,10 +294,13 @@ jobs:
                 // A failed or cancelled input check publishes nothing either,
                 // and must not be reported as "no input changed".
                 reason = `the chart input check for \`${short}\` did not complete (${process.env.CHANGES_RESULT})`;
-              } else if (process.env.BUILD_RESULT === 'skipped') {
+              } else if (process.env.CHANGES_BUILD !== 'true') {
                 reason = `no chart input changed between the base and \`${short}\``;
               } else {
-                reason = `the preview chart build for \`${short}\` did not succeed (${process.env.BUILD_RESULT})`;
+                // The publish step repoints the mutable reference before it
+                // signs, so a build that got that far has already replaced it.
+                reason = `the preview chart build for \`${short}\` did not succeed (${process.env.BUILD_RESULT}). ` +
+                  'That build may already have repointed the preview reference, so trust the digest below rather than the tag';
               }
               await post([
                 marker,
@@ -343,7 +348,7 @@ jobs:
               `  --version ${previewVersion}`,
               '```',
               '',
-              `Digest: \`${digest}\`. The chart defaults to Harbor \`${appVersion}\`; this PR's \`pr-${issueNumber}\` images in \`${previewProject}\`, when published, are selected through the chart's image values.`,
+              `Digest: \`${digest}\`. The chart installs Harbor \`${appVersion}\` as committed. This PR's \`pr-${issueNumber}\` images, when published, live in \`${previewProject}\` and are not selected by this command: point the chart at them with per-component \`image.registry\` and \`image.repository\` values.`,
               ...stackSection,
               ...siblingSection,
               '',

--- a/.github/workflows/pr-chart.yml
+++ b/.github/workflows/pr-chart.yml
@@ -41,6 +41,7 @@ jobs:
     timeout-minutes: 5
     outputs:
       build: ${{ steps.diff.outputs.build }}
+      matched: ${{ steps.diff.outputs.matched }}
       stack_number: ${{ github.event.pull_request.stack.number || '' }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -68,8 +69,15 @@ jobs:
           # --no-renames: a rename out of the allowlist would otherwise show
           # only its new path and hide that a chart input went away
           changed="$(git diff --name-only --no-renames "${base}...${HEAD_SHA}")"
-          if grep -Ef <(printf '%s' "${CHART_INPUTS}") <<<"${changed}"; then
+          if matched="$(grep -Ef <(printf '%s' "${CHART_INPUTS}") <<<"${changed}")"; then
             echo "build=true" >> "$GITHUB_OUTPUT"
+            # Named in the PR comment, so a PR that changes no chart input
+            # itself can see why its stack still produces one.
+            {
+              echo "matched<<MATCHED_EOF"
+              printf '%s\n' "${matched}"
+              echo "MATCHED_EOF"
+            } >> "$GITHUB_OUTPUT"
           else
             echo "No chart input changed between ${base} and ${HEAD_SHA}; skipping the preview chart"
             echo "build=false" >> "$GITHUB_OUTPUT"
@@ -192,82 +200,155 @@ jobs:
   pr-comment:
     name: Comment preview chart ref
     needs: [changes, preview-chart]
-    if: needs.changes.outputs.build == 'true'
+    # Also runs when nothing was published: a build that is skipped, fails, or
+    # belongs to a PR that is not the top of its stack leaves an earlier
+    # reference standing, and the comment has to say that it is stale.
+    if: >-
+      always() &&
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      !contains(fromJSON('["8gcr-renovate[bot]", "renovate[bot]", "8gcr-sync[bot]"]'), github.actor)
     runs-on: ubuntu-26.04
+    timeout-minutes: 5
     permissions:
       pull-requests: write
     env:
       PREVIEW_VERSION: ${{ needs.preview-chart.outputs.version }}
       APP_VERSION: ${{ needs.preview-chart.outputs.app_version }}
       DIGEST: ${{ needs.preview-chart.outputs.digest }}
-      STACK_NUMBER: ${{ needs.changes.outputs.stack_number }}
+      HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+      STACK_NUMBER: ${{ github.event.pull_request.stack.number || '' }}
+      MATCHED: ${{ needs.changes.outputs.matched }}
+      CHANGES_RESULT: ${{ needs.changes.result }}
+      BUILD_RESULT: ${{ needs.preview-chart.result }}
     steps:
       - name: Create or update PR comment
-        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3  # v9.0.0
         env:
           MARKER: "<!-- harbor-next-pr-chart-preview -->"
+          SIBLING_MARKER: "<!-- harbor-next-pr-preview -->"
         with:
           script: |
             const marker = process.env.MARKER;
-            const registryAddress = process.env.REGISTRY_ADDRESS;
-            const previewProject = process.env.PR_REGISTRY_PROJECT;
-            const chart = `${registryAddress}/${previewProject}/charts/harbor-next`;
-            const previewVersion = process.env.PREVIEW_VERSION;
-            const appVersion = process.env.APP_VERSION;
-            const digest = process.env.DIGEST;
+            const siblingMarker = process.env.SIBLING_MARKER;
+            const staleStart = '<!-- preview:stale-start -->';
+            const staleEnd = '<!-- preview:stale-end -->';
             const stackNumber = process.env.STACK_NUMBER;
+            const short = process.env.HEAD_SHA.slice(0, 7);
             const repository = process.env.GITHUB_REPOSITORY;
             const issueNumber = context.payload.pull_request.number;
             const { owner, repo } = context.repo;
-            const stackNote = stackNumber
-              ? `\nThis PR is the top of stack #${stackNumber}; the chart is packaged from its head and contains every PR in the stack.\n`
-              : '';
+            const previewProject = process.env.PR_REGISTRY_PROJECT;
+            const chart = `${process.env.REGISTRY_ADDRESS}/${previewProject}/charts/harbor-next`;
+            const previewVersion = process.env.PREVIEW_VERSION;
+            const appVersion = process.env.APP_VERSION;
+            const digest = process.env.DIGEST;
 
-            const body = `${marker}
-            A preview chart for this PR is available:
-
-            \`\`\`
-            helm install harbor-next \\
-              oci://${chart} \\
-              --version ${previewVersion}
-            \`\`\`
-
-            Digest: \`${digest}\`. The chart defaults to Harbor \`${appVersion}\`; this PR's \`pr-${issueNumber}\` images in \`${previewProject}\`, when published, can be selected through the chart's image values.
-            ${stackNote}
-            Verify the preview chart:
-
-            \`\`\`
-            cosign verify \\
-              --certificate-identity-regexp="https://github.com/${repository}/.github/workflows/pr-chart.yml@.*" \\
-              --certificate-oidc-issuer="https://token.actions.githubusercontent.com" \\
-              ${chart}@${digest}
-            \`\`\``;
+            const stack = stackNumber
+              ? await github.request('GET /repos/{owner}/{repo}/stacks/{stack_number}', {
+                  owner, repo, stack_number: Number(stackNumber),
+                }).then(response => response.data).catch(error => {
+                  core.warning(`Could not list stack #${stackNumber}: ${error.message}`);
+                  return null;
+                })
+              : null;
 
             const comments = await github.paginate(github.rest.issues.listComments, {
-              owner,
-              repo,
-              issue_number: issueNumber,
-              per_page: 100,
+              owner, repo, issue_number: issueNumber, per_page: 100,
             });
+            const existing = comments.find(comment =>
+              comment.user?.login === 'github-actions[bot]' && comment.body?.startsWith(marker));
 
-            const existingComment = comments.find(comment =>
-              comment.user?.login === 'github-actions[bot]' &&
-              comment.body?.startsWith(marker)
-            );
+            const post = async body => {
+              if (existing) {
+                await github.rest.issues.updateComment({ owner, repo, comment_id: existing.id, body });
+                return;
+              }
+              await github.rest.issues.createComment({ owner, repo, issue_number: issueNumber, body });
+            };
 
-            if (existingComment) {
-              await github.rest.issues.updateComment({
-                owner,
-                repo,
-                comment_id: existingComment.id,
-                body,
-              });
+            // The notice is delimited rather than pattern-matched, so a second
+            // one replaces the first instead of stacking under it.
+            const withoutNotice = body => {
+              const kept = [];
+              let inNotice = false;
+              for (const line of body.split('\n')) {
+                if (line === staleStart) { inNotice = true; continue; }
+                if (line === staleEnd) { inNotice = false; continue; }
+                if (!inNotice && line !== marker) kept.push(line);
+              }
+              return kept.join('\n').trim();
+            };
+
+            if (process.env.BUILD_RESULT !== 'success') {
+              // Nothing was published, so there is nothing to correct unless an
+              // earlier revision left a reference behind.
+              if (!existing) return;
+              let reason;
+              if (process.env.CHANGES_RESULT === 'skipped') {
+                const top = stack?.pull_requests?.[stack.pull_requests.length - 1];
+                reason = `this PR is not the top of stack #${stackNumber}` +
+                  (top ? `, so the stack's preview chart is published on #${top.number}` : '');
+              } else if (process.env.BUILD_RESULT === 'skipped') {
+                reason = `no chart input changed between the base and \`${short}\``;
+              } else {
+                reason = `the preview chart build for \`${short}\` did not succeed (${process.env.BUILD_RESULT})`;
+              }
+              await post([
+                marker,
+                staleStart,
+                '> [!WARNING]',
+                `> **Outdated:** ${reason}. What follows is from an earlier revision of this PR.`,
+                staleEnd,
+                '',
+                withoutNotice(existing.body),
+              ].join('\n'));
               return;
             }
 
-            await github.rest.issues.createComment({
-              owner,
-              repo,
-              issue_number: issueNumber,
-              body,
-            });
+            const matched = (process.env.MATCHED || '').split('\n').map(line => line.trim()).filter(Boolean);
+            const shown = matched.slice(0, 5).map(path => `\`${path}\``).join(', ');
+            const more = matched.length > 5 ? ` and ${matched.length - 5} more` : '';
+
+            const stackSection = [];
+            if (stackNumber) {
+              stackSection.push('', `This PR is the top of stack #${stackNumber}, so the chart comes from a head that contains every PR in it:`, '');
+              stackSection.push(...(stack
+                ? stack.pull_requests.map((pr, index) => `${index + 1}. #${pr.number} ${pr.title}`)
+                : ['(see the stack view on this PR)']));
+              if (matched.length) {
+                stackSection.push('', `Built because ${shown}${more} changed somewhere in the stack.`);
+              }
+              stackSection.push('', 'Lower PRs publish nothing of their own; push a fix there, then `gh stack rebase && gh stack push` to rebuild this one.');
+            }
+
+            const sibling = comments.find(comment =>
+              comment.user?.login === 'github-actions[bot]' && comment.body?.startsWith(siblingMarker));
+            const siblingSection = sibling
+              ? ['', `Preview images for this PR are published too: ${sibling.html_url}`]
+              : [];
+
+            const body = [
+              marker,
+              `A preview chart for this PR is available, packaged from \`${short}\`:`,
+              '',
+              '```',
+              'helm install harbor-next \\',
+              `  oci://${chart} \\`,
+              `  --version ${previewVersion}`,
+              '```',
+              '',
+              `Digest: \`${digest}\`. The chart defaults to Harbor \`${appVersion}\`; this PR's \`pr-${issueNumber}\` images in \`${previewProject}\`, when published, are selected through the chart's image values.`,
+              ...stackSection,
+              ...siblingSection,
+              '',
+              'Verify the preview chart:',
+              '',
+              '```',
+              'cosign verify \\',
+              `  --certificate-identity-regexp="https://github.com/${repository}/.github/workflows/pr-chart.yml@.*" \\`,
+              '  --certificate-oidc-issuer="https://token.actions.githubusercontent.com" \\',
+              `  ${chart}@${digest}`,
+              '```',
+            ].join('\n');
+
+            await post(body);

--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -3,28 +3,9 @@ name: PR Preview Images
 on:
   pull_request:
     branches: [main, "release-[0-9]*.[0-9]*"]
-    # Allowlist: only build preview images when an input that actually reaches
-    # one of the images changes. Each entry below is consumed by a dockerfile
-    # COPY/build-arg or by the task build steps (gen-apis / build:binary).
-    # Anything not listed (docs, tests, lint config, dev taskfiles, other
-    # workflows) cannot change an image, so it is skipped. Commercial code
-    # from 8gcr isn't applied for PR previews at all — see publish-images.yml.
-    paths:
-      - "src/**"                             # Go components + portal sources
-      - "api/v2.0/swagger.yaml"              # gen-apis (core) + portal API client
-      - "tools/swagger/templates/**"         # gen-apis output templates
-      - "make/migrations/**"                 # baked into harbor-core
-      - "icons/**"                           # baked into harbor-core
-      - "config/portal/**"                   # portal nginx.conf
-      - "LICENSE"                            # baked into harbor-portal
-      - "VERSION"                            # ReleaseVersion ldflag baked into the Go binaries
-      - "dockerfile/**"                      # every image
-      - "versions.env"                       # build-args + registry/trivy/distribution pins
-      - "Taskfile.yml"                       # build orchestration root
-      - "taskfile/build.yml"                 # gen-apis + build:binary recipes
-      - ".github/workflows/pr-ci.yml"        # this workflow
-      - ".github/actions/setup-go-cached/**" # Go build env used by the build jobs
-      - ".github/actions/setup-task/**"      # Task install action used by the build jobs
+    # No `paths` filter: GitHub evaluates it against the PR's own diff, which
+    # for a stacked PR is only the top slice. The image-input allowlist lives
+    # in the `changes` job below, which diffs against the stack base instead.
 
 permissions:
   contents: read
@@ -37,11 +18,73 @@ env:
   REGISTRY_ADDRESS: ${{ vars.REGISTRY_ADDRESS || '8gears.container-registry.com' }}
   PR_REGISTRY_PROJECT: ${{ vars.PR_REGISTRY_PROJECT }}
   PREVIEW_TAG: pr-${{ github.event.pull_request.number }}
+  # stack-<n> follows the top of a native GitHub stack; empty for a plain PR
+  STACK_TAG: ${{ github.event.pull_request.stack && format('stack-{0}', github.event.pull_request.stack.number) || '' }}
 
 jobs:
+  changes:
+    name: Check image inputs
+    # Forked PRs have no registry credentials and bot PRs need no preview. In
+    # a native GitHub stack only the top PR builds: its head already contains
+    # every lower PR, so each lower image would be a prefix of it.
+    if: >-
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      !contains(fromJSON('["8gcr-renovate[bot]", "renovate[bot]", "8gcr-sync[bot]"]'), github.actor) &&
+      (github.event.pull_request.stack == null ||
+       github.event.pull_request.stack.position == github.event.pull_request.stack.size)
+    runs-on: ubuntu-26.04
+    timeout-minutes: 5
+    outputs:
+      build: ${{ steps.diff.outputs.build }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          # Full history: the diff below spans the whole stack
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Diff against the stack base
+        id: diff
+        env:
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          STACK_BASE_SHA: ${{ github.event.pull_request.stack.base.sha || '' }}
+          # Allowlist: only build preview images when an input that actually
+          # reaches one of the images changes. Each entry is consumed by a
+          # dockerfile COPY/build-arg or by the task build steps (gen-apis /
+          # build:binary). Anything not listed (docs, tests, lint config, dev
+          # taskfiles, other workflows) cannot change an image. Commercial code
+          # from 8gcr isn't applied for PR previews at all, see publish-images.yml.
+          IMAGE_INPUTS: |
+            ^src/
+            ^api/v2\.0/swagger\.yaml$
+            ^tools/swagger/templates/
+            ^make/migrations/
+            ^icons/
+            ^config/portal/
+            ^LICENSE$
+            ^VERSION$
+            ^dockerfile/
+            ^versions\.env$
+            ^Taskfile\.yml$
+            ^taskfile/build\.yml$
+            ^\.github/workflows/pr-ci\.yml$
+            ^\.github/actions/setup-go-cached/
+            ^\.github/actions/setup-task/
+        run: |
+          base="${STACK_BASE_SHA:-${PR_BASE_SHA}}"
+          changed="$(git diff --name-only "${base}...${HEAD_SHA}")"
+          if grep -Ef <(printf '%s' "${IMAGE_INPUTS}") <<<"${changed}"; then
+            echo "build=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "No image input changed between ${base} and ${HEAD_SHA}; skipping the preview images"
+            echo "build=false" >> "$GITHUB_OUTPUT"
+          fi
+
   build:
     name: "${{ matrix.component }} (${{ matrix.platform }})"
-    if: ${{ github.event.pull_request.head.repo.full_name == github.repository && !contains(fromJSON('["8gcr-renovate[bot]", "renovate[bot]", "8gcr-sync[bot]"]'), github.actor) }}
+    needs: [changes]
+    if: needs.changes.outputs.build == 'true'
     strategy:
       fail-fast: false
       matrix:
@@ -157,8 +200,8 @@ jobs:
 
   merge:
     name: "Merge ${{ matrix.component }}"
-    if: ${{ github.event.pull_request.head.repo.full_name == github.repository && !contains(fromJSON('["8gcr-renovate[bot]", "renovate[bot]", "8gcr-sync[bot]"]'), github.actor) }}
-    needs: [build]
+    needs: [changes, build]
+    if: needs.changes.outputs.build == 'true'
     strategy:
       fail-fast: false
       matrix:
@@ -203,15 +246,18 @@ jobs:
         env:
           IMAGE: ${{ env.REGISTRY_ADDRESS }}/${{ env.PR_REGISTRY_PROJECT }}/${{ steps.prepare.outputs.image_name }}
         run: |
+          tags=(-t "${IMAGE}:${PREVIEW_TAG}")
+          if [ -n "${STACK_TAG}" ]; then
+            tags+=(-t "${IMAGE}:${STACK_TAG}")
+          fi
           # shellcheck disable=SC2046
-          docker buildx imagetools create \
-            -t "${IMAGE}:${PREVIEW_TAG}" \
+          docker buildx imagetools create "${tags[@]}" \
             $(printf "${IMAGE}@sha256:%s " *)
 
   sign:
     name: Sign preview images
-    if: ${{ github.event.pull_request.head.repo.full_name == github.repository && !contains(fromJSON('["8gcr-renovate[bot]", "renovate[bot]", "8gcr-sync[bot]"]'), github.actor) }}
-    needs: [merge]
+    needs: [changes, merge]
+    if: needs.changes.outputs.build == 'true'
     runs-on: ubuntu-26.04
     permissions:
       contents: read
@@ -267,8 +313,8 @@ jobs:
 
   pr-comment:
     name: Comment preview image refs
-    if: ${{ github.event.pull_request.head.repo.full_name == github.repository && !contains(fromJSON('["8gcr-renovate[bot]", "renovate[bot]", "8gcr-sync[bot]"]'), github.actor) }}
-    needs: [sign]
+    needs: [changes, sign]
+    if: needs.changes.outputs.build == 'true'
     runs-on: ubuntu-26.04
     permissions:
       issues: write
@@ -288,19 +334,46 @@ jobs:
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
           MARKER: "<!-- harbor-next-pr-preview -->"
+          STACK_NUMBER: ${{ github.event.pull_request.stack.number || '' }}
         with:
           script: |
             const marker = process.env.MARKER;
             const registryAddress = process.env.REGISTRY_ADDRESS;
             const registryProject = process.env.PR_REGISTRY_PROJECT;
             const previewTag = process.env.PREVIEW_TAG;
+            const stackNumber = process.env.STACK_NUMBER;
+            const stackTag = process.env.STACK_TAG;
             const repository = process.env.GITHUB_REPOSITORY;
             const issueNumber = context.payload.pull_request.number;
             const owner = context.repo.owner;
             const repo = context.repo.repo;
 
+            let stackSection = '';
+            if (stackNumber) {
+              let members = '';
+              try {
+                const { data: stack } = await github.request('GET /repos/{owner}/{repo}/stacks/{stack_number}', {
+                  owner, repo, stack_number: Number(stackNumber),
+                });
+                members = stack.pull_requests
+                  .map((pr, i) => `${i + 1}. #${pr.number} ${pr.title}`)
+                  .join('\n');
+              } catch (error) {
+                core.warning(`Could not list stack #${stackNumber}: ${error.message}`);
+                members = '(see the stack view on this PR)';
+              }
+              stackSection = `
+            This PR is the top of stack #${stackNumber}. The images are built from its head, so they contain every PR in the stack:
+
+            ${members}
+
+            The same images are tagged \`${stackTag}\`, which always points at the latest build of the top of the stack. Lower PRs do not get images of their own; push a fix there and \`gh stack rebase && gh stack push\` to rebuild.
+            `;
+            }
+
             const body = `${marker}
             Preview images for this PR are available in \`${registryAddress}/${registryProject}\` with tag \`${previewTag}\`.
+            ${stackSection}
 
             - \`${registryAddress}/${registryProject}/harbor-core:${previewTag}\`
             - \`${registryAddress}/${registryProject}/harbor-jobservice:${previewTag}\`

--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -11,7 +11,9 @@ permissions:
   contents: read
 
 concurrency:
-  group: pr-preview-${{ github.event.pull_request.number || github.ref }}
+  # Keyed by stack when stacked: a PR pushed on top of an in-flight top would
+  # otherwise let the older build finish last and repoint stack-<n> backwards.
+  group: pr-preview-${{ github.event.pull_request.stack && format('stack-{0}', github.event.pull_request.stack.number) || github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 env:
@@ -73,7 +75,9 @@ jobs:
             ^\.github/actions/setup-task/
         run: |
           base="${STACK_BASE_SHA:-${PR_BASE_SHA}}"
-          changed="$(git diff --name-only "${base}...${HEAD_SHA}")"
+          # --no-renames: a rename out of the allowlist would otherwise show
+          # only its new path and hide that an image input went away
+          changed="$(git diff --name-only --no-renames "${base}...${HEAD_SHA}")"
           if grep -Ef <(printf '%s' "${IMAGE_INPUTS}") <<<"${changed}"; then
             echo "build=true" >> "$GITHUB_OUTPUT"
           else

--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -406,10 +406,14 @@ jobs:
               // earlier revision left a reference behind.
               if (!existing) return;
               let reason;
-              if (process.env.CHANGES_RESULT === 'skipped') {
+              if (process.env.CHANGES_RESULT === 'skipped' && stackNumber) {
                 const top = stack?.pull_requests?.[stack.pull_requests.length - 1];
                 reason = `this PR is not the top of stack #${stackNumber}` +
                   (top ? `, so the stack's preview image is published on #${top.number}` : '');
+              } else if (process.env.CHANGES_RESULT !== 'success') {
+                // A failed or cancelled input check publishes nothing either,
+                // and must not be reported as "no input changed".
+                reason = `the image input check for \`${short}\` did not complete (${process.env.CHANGES_RESULT})`;
               } else if (process.env.BUILD_RESULT === 'skipped') {
                 reason = `no image input changed between the base and \`${short}\``;
               } else {
@@ -434,7 +438,7 @@ jobs:
             const stackSection = [];
             if (stackNumber) {
               stackSection.push('', `This PR is the top of stack #${stackNumber}, so the images come from a head that contains every PR in it:`, '');
-              stackSection.push(...(stack
+              stackSection.push(...(stack?.pull_requests?.length
                 ? stack.pull_requests.map((pr, index) => `${index + 1}. #${pr.number} ${pr.title}`)
                 : ['(see the stack view on this PR)']));
               if (matched.length) {
@@ -446,7 +450,9 @@ jobs:
             const sibling = comments.find(comment =>
               comment.user?.login === 'github-actions[bot]' && comment.body?.startsWith(siblingMarker));
             const siblingSection = sibling
-              ? ['', `A preview chart for this PR is published too, and its comment carries the install command: ${sibling.html_url}`]
+              ? ['', sibling.body.includes(staleStart)
+                  ? `A preview chart for this PR has a comment, but it is currently marked outdated: ${sibling.html_url}`
+                  : `A preview chart for this PR is published too, and its comment carries the install command: ${sibling.html_url}`]
               : [];
 
             const body = [

--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -11,17 +11,13 @@ permissions:
   contents: read
 
 concurrency:
-  # Keyed by stack when stacked: a PR pushed on top of an in-flight top would
-  # otherwise let the older build finish last and repoint stack-<n> backwards.
-  group: pr-preview-${{ github.event.pull_request.stack && format('stack-{0}', github.event.pull_request.stack.number) || github.event.pull_request.number || github.ref }}
+  group: pr-preview-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 env:
   REGISTRY_ADDRESS: ${{ vars.REGISTRY_ADDRESS || '8gears.container-registry.com' }}
   PR_REGISTRY_PROJECT: ${{ vars.PR_REGISTRY_PROJECT }}
   PREVIEW_TAG: pr-${{ github.event.pull_request.number }}
-  # stack-<n> follows the top of a native GitHub stack; empty for a plain PR
-  STACK_TAG: ${{ github.event.pull_request.stack && format('stack-{0}', github.event.pull_request.stack.number) || '' }}
 
 jobs:
   changes:
@@ -250,12 +246,9 @@ jobs:
         env:
           IMAGE: ${{ env.REGISTRY_ADDRESS }}/${{ env.PR_REGISTRY_PROJECT }}/${{ steps.prepare.outputs.image_name }}
         run: |
-          tags=(-t "${IMAGE}:${PREVIEW_TAG}")
-          if [ -n "${STACK_TAG}" ]; then
-            tags+=(-t "${IMAGE}:${STACK_TAG}")
-          fi
           # shellcheck disable=SC2046
-          docker buildx imagetools create "${tags[@]}" \
+          docker buildx imagetools create \
+            -t "${IMAGE}:${PREVIEW_TAG}" \
             $(printf "${IMAGE}@sha256:%s " *)
 
   sign:
@@ -346,7 +339,6 @@ jobs:
             const registryProject = process.env.PR_REGISTRY_PROJECT;
             const previewTag = process.env.PREVIEW_TAG;
             const stackNumber = process.env.STACK_NUMBER;
-            const stackTag = process.env.STACK_TAG;
             const repository = process.env.GITHUB_REPOSITORY;
             const issueNumber = context.payload.pull_request.number;
             const owner = context.repo.owner;
@@ -371,7 +363,7 @@ jobs:
 
             ${members}
 
-            The same images are tagged \`${stackTag}\`, which always points at the latest build of the top of the stack. Lower PRs do not get images of their own; push a fix there and \`gh stack rebase && gh stack push\` to rebuild.
+            Lower PRs do not get images of their own; push a fix there and \`gh stack rebase && gh stack push\` to rebuild these.
             `;
             }
 

--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -2,6 +2,9 @@ name: PR Preview Images
 
 on:
   pull_request:
+    # `stacked`: GitHub opens the PRs of a stack before it links them, so
+    # `opened` never carries `pull_request.stack`; the link fires `stacked`.
+    types: [opened, synchronize, reopened, stacked]
     branches: [main, "release-[0-9]*.[0-9]*"]
     # No `paths` filter: GitHub evaluates it against the PR's own diff, which
     # for a stacked PR is only the top slice. The image-input allowlist lives
@@ -47,6 +50,8 @@ jobs:
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
           PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
           STACK_BASE_SHA: ${{ github.event.pull_request.stack.base.sha || '' }}
+          STACK_NUMBER: ${{ github.event.pull_request.stack.number || '' }}
+          EVENT_ACTION: ${{ github.event.action }}
           # Allowlist: only build preview images when an input that actually
           # reaches one of the images changes. Each entry is consumed by a
           # dockerfile COPY/build-arg or by the task build steps (gen-apis /
@@ -70,6 +75,7 @@ jobs:
             ^\.github/actions/setup-go-cached/
             ^\.github/actions/setup-task/
         run: |
+          echo "event=${EVENT_ACTION} stack=${STACK_NUMBER:-none}"
           base="${STACK_BASE_SHA:-${PR_BASE_SHA}}"
           # --no-renames: a rename out of the allowlist would otherwise show
           # only its new path and hide that an image input went away

--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -37,6 +37,7 @@ jobs:
     timeout-minutes: 5
     outputs:
       build: ${{ steps.diff.outputs.build }}
+      matched: ${{ steps.diff.outputs.matched }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -80,8 +81,15 @@ jobs:
           # --no-renames: a rename out of the allowlist would otherwise show
           # only its new path and hide that an image input went away
           changed="$(git diff --name-only --no-renames "${base}...${HEAD_SHA}")"
-          if grep -Ef <(printf '%s' "${IMAGE_INPUTS}") <<<"${changed}"; then
+          if matched="$(grep -Ef <(printf '%s' "${IMAGE_INPUTS}") <<<"${changed}")"; then
             echo "build=true" >> "$GITHUB_OUTPUT"
+            # Named in the PR comment, so a PR that changes no image input
+            # itself can see why its stack still produces one.
+            {
+              echo "matched<<MATCHED_EOF"
+              printf '%s\n' "${matched}"
+              echo "MATCHED_EOF"
+            } >> "$GITHUB_OUTPUT"
           else
             echo "No image input changed between ${base} and ${HEAD_SHA}; skipping the preview images"
             echo "build=false" >> "$GITHUB_OUTPUT"
@@ -317,118 +325,156 @@ jobs:
   pr-comment:
     name: Comment preview image refs
     needs: [changes, sign]
-    if: needs.changes.outputs.build == 'true'
+    # Also runs when nothing was published: a build that is skipped, fails, or
+    # belongs to a PR that is not the top of its stack leaves an earlier
+    # reference standing, and the comment has to say that it is stale.
+    if: >-
+      always() &&
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      !contains(fromJSON('["8gcr-renovate[bot]", "renovate[bot]", "8gcr-sync[bot]"]'), github.actor)
     runs-on: ubuntu-26.04
+    timeout-minutes: 5
     permissions:
-      issues: write
       pull-requests: write
+    env:
+      PREVIEW_TAG: pr-${{ github.event.pull_request.number }}
+      HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+      STACK_NUMBER: ${{ github.event.pull_request.stack.number || '' }}
+      MATCHED: ${{ needs.changes.outputs.matched }}
+      CHANGES_RESULT: ${{ needs.changes.result }}
+      BUILD_RESULT: ${{ needs.sign.result }}
     steps:
-      - name: Install gh CLI
-        run: |
-          if ! command -v gh &>/dev/null; then
-            curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \
-              | sudo dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg
-            echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" \
-              | sudo tee /etc/apt/sources.list.d/github-cli.list > /dev/null
-            sudo apt-get update && sudo apt-get install -y gh
-          fi
-
       - name: Create or update PR comment
-        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3  # v9.0.0
         env:
           MARKER: "<!-- harbor-next-pr-preview -->"
-          STACK_NUMBER: ${{ github.event.pull_request.stack.number || '' }}
+          SIBLING_MARKER: "<!-- harbor-next-pr-chart-preview -->"
         with:
           script: |
             const marker = process.env.MARKER;
+            const siblingMarker = process.env.SIBLING_MARKER;
+            const staleStart = '<!-- preview:stale-start -->';
+            const staleEnd = '<!-- preview:stale-end -->';
+            const stackNumber = process.env.STACK_NUMBER;
+            const short = process.env.HEAD_SHA.slice(0, 7);
+            const repository = process.env.GITHUB_REPOSITORY;
+            const issueNumber = context.payload.pull_request.number;
+            const { owner, repo } = context.repo;
             const registryAddress = process.env.REGISTRY_ADDRESS;
             const registryProject = process.env.PR_REGISTRY_PROJECT;
             const previewTag = process.env.PREVIEW_TAG;
-            const stackNumber = process.env.STACK_NUMBER;
-            const repository = process.env.GITHUB_REPOSITORY;
-            const issueNumber = context.payload.pull_request.number;
-            const owner = context.repo.owner;
-            const repo = context.repo.repo;
+            const components = ['harbor-core', 'harbor-jobservice', 'harbor-registryctl', 'harbor-exporter', 'harbor-portal', 'harbor-registry', 'trivy-adapter'];
 
-            let stackSection = '';
-            if (stackNumber) {
-              let members = '';
-              try {
-                const { data: stack } = await github.request('GET /repos/{owner}/{repo}/stacks/{stack_number}', {
+            const stack = stackNumber
+              ? await github.request('GET /repos/{owner}/{repo}/stacks/{stack_number}', {
                   owner, repo, stack_number: Number(stackNumber),
-                });
-                members = stack.pull_requests
-                  .map((pr, i) => `${i + 1}. #${pr.number} ${pr.title}`)
-                  .join('\n');
-              } catch (error) {
-                core.warning(`Could not list stack #${stackNumber}: ${error.message}`);
-                members = '(see the stack view on this PR)';
-              }
-              stackSection = `
-            This PR is the top of stack #${stackNumber}. The images are built from its head, so they contain every PR in the stack:
-
-            ${members}
-
-            Lower PRs do not get images of their own; push a fix there and \`gh stack rebase && gh stack push\` to rebuild these.
-            `;
-            }
-
-            const body = `${marker}
-            Preview images for this PR are available in \`${registryAddress}/${registryProject}\` with tag \`${previewTag}\`.
-            ${stackSection}
-
-            - \`${registryAddress}/${registryProject}/harbor-core:${previewTag}\`
-            - \`${registryAddress}/${registryProject}/harbor-jobservice:${previewTag}\`
-            - \`${registryAddress}/${registryProject}/harbor-registryctl:${previewTag}\`
-            - \`${registryAddress}/${registryProject}/harbor-exporter:${previewTag}\`
-            - \`${registryAddress}/${registryProject}/harbor-portal:${previewTag}\`
-            - \`${registryAddress}/${registryProject}/harbor-registry:${previewTag}\`
-            - \`${registryAddress}/${registryProject}/trivy-adapter:${previewTag}\`
-
-            Verify a preview image:
-
-            \`\`\`
-            cosign verify \\
-              --certificate-identity-regexp="https://github.com/${repository}/.github/workflows/pr-ci.yml@.*" \\
-              --certificate-oidc-issuer="https://token.actions.githubusercontent.com" \\
-              ${registryAddress}/${registryProject}/harbor-core:${previewTag}
-            \`\`\`
-
-            Verify SBOM attestation:
-
-            \`\`\`
-            cosign verify-attestation \\
-              --certificate-identity-regexp="https://github.com/${repository}/.github/workflows/pr-ci.yml@.*" \\
-              --certificate-oidc-issuer="https://token.actions.githubusercontent.com" \\
-              --type spdxjson \\
-              ${registryAddress}/${registryProject}/harbor-core:${previewTag}
-            \`\`\``;
+                }).then(response => response.data).catch(error => {
+                  core.warning(`Could not list stack #${stackNumber}: ${error.message}`);
+                  return null;
+                })
+              : null;
 
             const comments = await github.paginate(github.rest.issues.listComments, {
-              owner,
-              repo,
-              issue_number: issueNumber,
-              per_page: 100,
+              owner, repo, issue_number: issueNumber, per_page: 100,
             });
+            const existing = comments.find(comment =>
+              comment.user?.login === 'github-actions[bot]' && comment.body?.startsWith(marker));
 
-            const existingComment = comments.find(comment =>
-              comment.user?.login === 'github-actions[bot]' &&
-              comment.body?.startsWith(marker)
-            );
+            const post = async body => {
+              if (existing) {
+                await github.rest.issues.updateComment({ owner, repo, comment_id: existing.id, body });
+                return;
+              }
+              await github.rest.issues.createComment({ owner, repo, issue_number: issueNumber, body });
+            };
 
-            if (existingComment) {
-              await github.rest.issues.updateComment({
-                owner,
-                repo,
-                comment_id: existingComment.id,
-                body,
-              });
+            // The notice is delimited rather than pattern-matched, so a second
+            // one replaces the first instead of stacking under it.
+            const withoutNotice = body => {
+              const kept = [];
+              let inNotice = false;
+              for (const line of body.split('\n')) {
+                if (line === staleStart) { inNotice = true; continue; }
+                if (line === staleEnd) { inNotice = false; continue; }
+                if (!inNotice && line !== marker) kept.push(line);
+              }
+              return kept.join('\n').trim();
+            };
+
+            if (process.env.BUILD_RESULT !== 'success') {
+              // Nothing was published, so there is nothing to correct unless an
+              // earlier revision left a reference behind.
+              if (!existing) return;
+              let reason;
+              if (process.env.CHANGES_RESULT === 'skipped') {
+                const top = stack?.pull_requests?.[stack.pull_requests.length - 1];
+                reason = `this PR is not the top of stack #${stackNumber}` +
+                  (top ? `, so the stack's preview image is published on #${top.number}` : '');
+              } else if (process.env.BUILD_RESULT === 'skipped') {
+                reason = `no image input changed between the base and \`${short}\``;
+              } else {
+                reason = `the preview image build for \`${short}\` did not succeed (${process.env.BUILD_RESULT})`;
+              }
+              await post([
+                marker,
+                staleStart,
+                '> [!WARNING]',
+                `> **Outdated:** ${reason}. What follows is from an earlier revision of this PR.`,
+                staleEnd,
+                '',
+                withoutNotice(existing.body),
+              ].join('\n'));
               return;
             }
 
-            await github.rest.issues.createComment({
-              owner,
-              repo,
-              issue_number: issueNumber,
-              body,
-            });
+            const matched = (process.env.MATCHED || '').split('\n').map(line => line.trim()).filter(Boolean);
+            const shown = matched.slice(0, 5).map(path => `\`${path}\``).join(', ');
+            const more = matched.length > 5 ? ` and ${matched.length - 5} more` : '';
+
+            const stackSection = [];
+            if (stackNumber) {
+              stackSection.push('', `This PR is the top of stack #${stackNumber}, so the images come from a head that contains every PR in it:`, '');
+              stackSection.push(...(stack
+                ? stack.pull_requests.map((pr, index) => `${index + 1}. #${pr.number} ${pr.title}`)
+                : ['(see the stack view on this PR)']));
+              if (matched.length) {
+                stackSection.push('', `Built because ${shown}${more} changed somewhere in the stack.`);
+              }
+              stackSection.push('', 'Lower PRs publish nothing of their own; push a fix there, then `gh stack rebase && gh stack push` to rebuild this one.');
+            }
+
+            const sibling = comments.find(comment =>
+              comment.user?.login === 'github-actions[bot]' && comment.body?.startsWith(siblingMarker));
+            const siblingSection = sibling
+              ? ['', `A preview chart for this PR is published too, and its comment carries the install command: ${sibling.html_url}`]
+              : [];
+
+            const body = [
+              marker,
+              `Preview images for this PR are available in \`${registryAddress}/${registryProject}\` with tag \`${previewTag}\`, built from \`${short}\`:`,
+              '',
+              ...components.map(name => `- \`${registryAddress}/${registryProject}/${name}:${previewTag}\``),
+              ...stackSection,
+              ...siblingSection,
+              '',
+              'Verify a preview image:',
+              '',
+              '```',
+              'cosign verify \\',
+              `  --certificate-identity-regexp="https://github.com/${repository}/.github/workflows/pr-ci.yml@.*" \\`,
+              '  --certificate-oidc-issuer="https://token.actions.githubusercontent.com" \\',
+              `  ${registryAddress}/${registryProject}/harbor-core:${previewTag}`,
+              '```',
+              '',
+              'Verify the SBOM attestation:',
+              '',
+              '```',
+              'cosign verify-attestation \\',
+              `  --certificate-identity-regexp="https://github.com/${repository}/.github/workflows/pr-ci.yml@.*" \\`,
+              '  --certificate-oidc-issuer="https://token.actions.githubusercontent.com" \\',
+              '  --type spdxjson \\',
+              `  ${registryAddress}/${registryProject}/harbor-core:${previewTag}`,
+              '```',
+            ].join('\n');
+
+            await post(body);

--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -342,6 +342,7 @@ jobs:
       STACK_NUMBER: ${{ github.event.pull_request.stack.number || '' }}
       MATCHED: ${{ needs.changes.outputs.matched }}
       CHANGES_RESULT: ${{ needs.changes.result }}
+      CHANGES_BUILD: ${{ needs.changes.outputs.build }}
       BUILD_RESULT: ${{ needs.sign.result }}
     steps:
       - name: Create or update PR comment
@@ -396,7 +397,9 @@ jobs:
               for (const line of body.split('\n')) {
                 if (line === staleStart) { inNotice = true; continue; }
                 if (line === staleEnd) { inNotice = false; continue; }
-                if (!inNotice && line !== marker) kept.push(line);
+                // `:stale` also matches the inline marker the first
+                // implementation used, so an old notice is not kept forever.
+                if (!inNotice && line !== marker && !/^<!--[^>]*:stale/.test(line)) kept.push(line);
               }
               return kept.join('\n').trim();
             };
@@ -414,10 +417,13 @@ jobs:
                 // A failed or cancelled input check publishes nothing either,
                 // and must not be reported as "no input changed".
                 reason = `the image input check for \`${short}\` did not complete (${process.env.CHANGES_RESULT})`;
-              } else if (process.env.BUILD_RESULT === 'skipped') {
+              } else if (process.env.CHANGES_BUILD !== 'true') {
                 reason = `no image input changed between the base and \`${short}\``;
               } else {
-                reason = `the preview image build for \`${short}\` did not succeed (${process.env.BUILD_RESULT})`;
+                // The publish step repoints the mutable reference before it
+                // signs, so a build that got that far has already replaced it.
+                reason = `the preview image build for \`${short}\` did not succeed (${process.env.BUILD_RESULT}). ` +
+                  'That build may already have repointed the preview reference, so trust the digest below rather than the tag';
               }
               await post([
                 marker,


### PR DESCRIPTION
Preview artifacts now follow what a pull request actually changes, including across a GitHub stack: the seven images when image inputs change, the chart when chart inputs change, always from the top of a stack. Same change as container-registry/harbor-scanner-trivy#92, applied to the inline seven-image workflow, plus the chart preview this repo did not have.

## Problem

On a native stack the trigger's `paths` filter saw only each PR's own slice: the top PR, the only one worth deploying, got no images when its slice was docs-only, while every lower PR rebuilt all fourteen platform images on each `gh stack push`. The chart had no preview at all; a chart change could only be tried after a release.

## How it worked before

`pr-ci.yml` filtered with `on.pull_request.paths`, evaluated against the PR's own diff; `build`, `merge`, `sign` and `pr-comment` each repeated the same `if:` and ran for every position of a stack.

## How it works now

- A workflow publishes when the PR's diff against `main` touches one of its inputs. The check is a job, not a `paths` trigger filter, so every PR gets a status and the diff is the real one.
- Stacked PRs (`gh stack`): only the top PR publishes; its head is the whole stack, so its ordinary `pr-<N>` artifacts are the stack artifacts. Lower PRs are skipped at the gate. Plain PRs behave as before.
- The workflows also subscribe to the `stacked` activity type: GitHub opens the PRs of a stack before it links them, so `opened` never carries `pull_request.stack`; the link does. Verified on trivy stack #96: linking fired both previews on the top with no push (gate logged `event=stacked stack=96`), the bottom was skipped.
- Image and chart are independent: a chart-only PR gets a chart, an app-only PR gets an image, both when both change, nothing when neither does.
- `pr-ci.yml`: the 15-entry allowlist moves into a `changes` job; the four jobs depend on it. The comment lists the stack members when stacked.
- New `pr-chart.yml`: `<chart version>-pr.<N>` into `PR_REGISTRY_PROJECT` with the `PR_REGISTRY_*` credentials, subcharts from `Chart.lock`, Artifact Hub annotation against the release project as on release, signed, sticky comment with the install command.

`build.yml` and `test.yml` are untouched: native stacks already trigger them as if targeting `main`. Manually chained PRs such as #753 -> #754 are not a stack to GitHub; their bottom PR gets ordinary previews, the ones above match no `branches` filter. `gh stack init` on those branches is the fix.

## Verification

- `actionlint` and `zizmor` findings identical to `main` (the `ubuntu-26.04` label and SC2086 notes are pre-existing); comment scripts pass `node --check`.
- This PR changes `pr-ci.yml` and adds `pr-chart.yml`, so its own runs exercise both plain paths: gate, 14 builds, 7 merges, sign, comment; chart packaged, pushed, signed, commented.
- The stack path was verified on harbor-scanner-trivy with a 2-PR stack (docs-only top built, bottom skipped, restack rebuilt only the top).


## Preview comments

Each preview comment names the commit it was built from, lists the inputs that triggered the build, links the sibling preview comment when one exists, and is rewritten with an outdated notice when a build is skipped, fails, or the pull request is not the top of its stack. The notice is delimited by markers, so a second one replaces the first and a later successful build clears it. Ported from container-registry/harbor-scanner-trivy#101.
