### PR TITLE
ci: Unstick chart release line for the harbor chart re-release

### DIFF
--- a/.release-please-manifest-chart.json
+++ b/.release-please-manifest-chart.json
@@ -1,3 +1,3 @@
 {
-  "deploy/chart": "2.0.0"
+  "deploy/chart": "1.0.0"
 }

--- a/release-please-config-chart.json
+++ b/release-please-config-chart.json
@@ -24,8 +24,7 @@
       "package-name": "harbor-next",
       "component": "chart",
       "include-component-in-tag": true,
-      "changelog-path": "CHANGELOG.md",
-      "release-as": "2.0.0"
+      "changelog-path": "CHANGELOG.md"
     }
   }
 }


### PR DESCRIPTION
Fixes the stuck chart release line, prepares the chart-v2.0.0 re-release under the new chart name.

## What / why

- **Drop `"release-as": "2.0.0"`** from `release-please-config-chart.json`. This one-shot override was left in after chart-v2.0.0 shipped (2026-08-18), so release-please proposes 2.0.0 *forever* — that is why #728 is still open offering "chart 2.0.0" a month after it was released. No chart release after 2.0.0 can happen until this line is removed.
- **Reset `.release-please-manifest-chart.json` to `1.0.0`.** The `chart-v2.0.0` tag + GitHub release are being deleted so the chart can be re-released under its new name. From 1.0.0, the upcoming `feat!:` chart-rename commit majors to exactly **2.0.0** — the renamed `harbor` chart re-releases as v2.0.0 with no sticky override.

## Merge order

1. **Merge this PR first**, before the chart-rename PR.
2. Delete the `chart: v2.0.0` GitHub release and `chart-v2.0.0` tag (manual, owner action).
3. Merge the rename PR (`feat!:`); release-please then rewrites the open chart release PR (#728) to "harbor chart 2.0.0" — **do not close #728 manually**, release-please manages it.

Chart releases stay their own release-please line; the app release line is untouched.