### PR TITLE
ci: Render chart release notes with the release-notes engine

### DIFF
--- a/.github/scripts/extract-changelog-release.mjs
+++ b/.github/scripts/extract-changelog-release.mjs
@@ -7,7 +7,9 @@ if (!changelogPath || !version || !outputPath) {
 }
 
 const lines = readFileSync(changelogPath, 'utf8').split(/\r?\n/);
-const headings = [`## [${version}]`, `## [v${version}]`];
+// release-please writes "## [x.y.z](compare-url) (date)" when a previous tag
+// exists and "## x.y.z (date)" for a line's first release (e.g. the chart).
+const headings = [`## [${version}]`, `## [v${version}]`, `## ${version} `, `## v${version} `];
 const start = lines.findIndex(line => headings.some(heading => line.startsWith(heading)));
 
 if (start === -1) {

--- a/.github/scripts/update-release-notes.sh
+++ b/.github/scripts/update-release-notes.sh
@@ -18,7 +18,12 @@ github_retry() {
 }
 
 preview_pr_number="${RELEASE_NOTES_PREVIEW_PR_NUMBER:-}"
-if [[ -n "${preview_pr_number}" && ! "${TAG_NAME:-}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+component="${RELEASE_NOTES_COMPONENT:-}"
+if [[ -n "${preview_pr_number}" && "${component}" == "chart" ]]; then
+  # A chart release PR bumps the chart manifest on its branch to the new version.
+  preview_version=$(node -e "const manifest = require('./.release-please-manifest-chart.json'); const version = manifest['deploy/chart']; if (!version) { throw new Error('missing chart release version'); } console.log(version);")
+  TAG_NAME="chart-v${preview_version}"
+elif [[ -n "${preview_pr_number}" && ! "${TAG_NAME:-}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
   preview_version=$(node -e "const manifest = require('./.release-please-manifest.json'); const version = manifest['.']; if (!version) { throw new Error('missing root release version'); } console.log(version);")
   TAG_NAME="v${preview_version}"
 fi
@@ -31,12 +36,16 @@ if [[ -z "${GITHUB_REPOSITORY:-}" ]]; then
   GITHUB_REPOSITORY="${GITHUB_REPOSITORY:-$(gh repo view --json nameWithOwner --jq .nameWithOwner)}"
 fi
 
-if [[ ! "${TAG_NAME}" =~ ^v([0-9]+\.[0-9]+\.[0-9]+)$ ]]; then
-  echo "TAG_NAME must be a semantic version tag such as v2.15.4" >&2
+chart_mode=false
+if [[ "${TAG_NAME}" =~ ^chart-v([0-9]+\.[0-9]+\.[0-9]+)$ ]]; then
+  chart_mode=true
+  version="${BASH_REMATCH[1]}"
+elif [[ "${TAG_NAME}" =~ ^v([0-9]+\.[0-9]+\.[0-9]+)$ ]]; then
+  version="${BASH_REMATCH[1]}"
+else
+  echo "TAG_NAME must be vX.Y.Z (app release) or chart-vX.Y.Z (chart release)" >&2
   exit 1
 fi
-
-version="${BASH_REMATCH[1]}"
 registry_address="${REGISTRY_ADDRESS:-8gears.container-registry.com}"
 registry_project="${REGISTRY_PROJECT:-8gcr}"
 registry="${registry_address}/${registry_project}"
@@ -53,14 +62,23 @@ else
   chart_yaml_source="$(git show "${TAG_NAME}:deploy/chart/Chart.yaml" 2>/dev/null || true)"
 fi
 chart_version="$(printf '%s\n' "${chart_yaml_source}" | awk -F'[:[:space:]]+' '$1 == "version" { gsub(/"/, "", $2); print $2; exit }')"
+chart_name="$(printf '%s\n' "${chart_yaml_source}" | awk -F'[:[:space:]]+' '$1 == "name" { gsub(/"/, "", $2); print $2; exit }')"
+chart_name="${chart_name:-harbor-next}"
+if [[ "${chart_mode}" == true ]]; then
+  chart_version="${version}"
+fi
 
 tmp_dir=$(mktemp -d)
 trap 'rm -rf "${tmp_dir}"' EXIT
 
+changelog_path="CHANGELOG.md"
+if [[ "${chart_mode}" == true ]]; then
+  changelog_path="deploy/chart/CHANGELOG.md"
+fi
 if [[ -n "${preview_pr_number}" ]]; then
-  cp CHANGELOG.md "${tmp_dir}/CHANGELOG.md"
+  cp "${changelog_path}" "${tmp_dir}/CHANGELOG.md"
 else
-  git show "${TAG_NAME}:CHANGELOG.md" > "${tmp_dir}/CHANGELOG.md"
+  git show "${TAG_NAME}:${changelog_path}" > "${tmp_dir}/CHANGELOG.md"
 fi
 node .github/scripts/extract-changelog-release.mjs \
   "${tmp_dir}/CHANGELOG.md" \
@@ -68,12 +86,37 @@ node .github/scripts/extract-changelog-release.mjs \
   "${tmp_dir}/release-source.md"
 
 generated_notes_args=(-f "tag_name=${TAG_NAME}")
+skip_generated_notes=""
+if [[ "${chart_mode}" == true ]]; then
+  # Without an explicit previous tag GitHub diffs against the latest app
+  # release and attributes unrelated PRs. The predecessor is the greatest
+  # chart tag LOWER than the target (descending sort, line after the
+  # target), so recreating an older release never diffs against a newer
+  # tag; previews (target tag not created yet) fall back to the newest
+  # existing chart tag.
+  previous_chart_tag=$(git tag --list 'chart-v*' --sort=-v:refname \
+    | awk -v t="${TAG_NAME}" 'found { print; exit } $0 == t { found = 1 }')
+  if [[ -z "${previous_chart_tag}" ]]; then
+    previous_chart_tag=$(git tag --list 'chart-v*' --sort=-v:refname | grep -vx "${TAG_NAME}" | head -n 1 || true)
+  fi
+  if [[ -n "${previous_chart_tag}" ]]; then
+    generated_notes_args+=(-f "previous_tag_name=${previous_chart_tag}")
+  else
+    # Bootstrap chart release: no chart tag exists at all, so any range
+    # GitHub picks would attribute unrelated app PRs. Skip What's Changed.
+    skip_generated_notes="yes"
+  fi
+fi
 if [[ -n "${preview_pr_number}" ]]; then
   generated_notes_args+=(-f "target_commitish=$(git rev-parse HEAD)")
 fi
-github_retry gh api "repos/${GITHUB_REPOSITORY}/releases/generate-notes" \
-  "${generated_notes_args[@]}" \
-  --jq .body > "${tmp_dir}/generated-notes.md"
+if [[ -n "${skip_generated_notes}" ]]; then
+  : > "${tmp_dir}/generated-notes.md"
+else
+  github_retry gh api "repos/${GITHUB_REPOSITORY}/releases/generate-notes" \
+    "${generated_notes_args[@]}" \
+    --jq .body > "${tmp_dir}/generated-notes.md"
+fi
 
 node .github/scripts/format-release-notes.mjs \
   "${tmp_dir}/release-source.md" \
@@ -86,7 +129,11 @@ node .github/scripts/extract-pr-summary.mjs \
   "${GITHUB_REPOSITORY}" \
   "${tmp_dir}/summary.md"
 
-if [[ -n "${preview_pr_number}" ]]; then
+if [[ "${chart_mode}" == true ]]; then
+  # Chart releases run on main only, and their target_commitish is a pinned
+  # SHA rather than a branch, so the app-path lookup does not apply.
+  release_branch="main"
+elif [[ -n "${preview_pr_number}" ]]; then
   release_branch="${GITHUB_REF_NAME:?GITHUB_REF_NAME is required for a release PR preview}"
 elif [[ "${GITHUB_REF_TYPE:-}" == "branch" && -n "${GITHUB_REF_NAME:-}" ]]; then
   # push-triggered path only. Tag-triggered runs (manual recreate on a
@@ -126,7 +173,7 @@ patch_notes="${tmp_dir}/commercial-patches.md"
 
 # The Harbor branch owns the ordered manifest. 8gcr only stores the branch
 # commits, so release notes and image builds always use the same exact list.
-if [[ -f "${series}" ]]; then
+if [[ "${chart_mode}" == false && -f "${series}" ]]; then
   while IFS= read -r branch; do
     branch="${branch%%#*}"
     branch="${branch#"${branch%%[![:space:]]*}"}"
@@ -168,37 +215,57 @@ fi
     echo "## Helm Chart"
     echo
     echo '```sh'
-    echo "helm install harbor oci://${registry}/charts/harbor-next \\"
+    echo "helm install harbor oci://${registry}/charts/${chart_name} \\"
     echo "  --version ${chart_version} -n harbor --create-namespace -f my-values.yaml"
     echo '```'
     echo
+    if [[ "${chart_mode}" == true ]]; then
+      echo "Signed with [cosign](https://github.com/sigstore/cosign). **Verify the chart signature:**"
+      echo '```sh'
+      echo "cosign verify \\"
+      echo "  --certificate-identity \"https://github.com/${GITHUB_REPOSITORY}/.github/workflows/publish-chart.yml@refs/heads/main\" \\"
+      echo '  --certificate-oidc-issuer "https://token.actions.githubusercontent.com" \'
+      echo "  ${registry}/charts/${chart_name}:${chart_version}"
+      echo '```'
+      echo
+    fi
     echo "---"
     echo
   fi
 
-  echo "## Container Images"
-  echo
-  echo "Multi-arch images (\`linux/amd64\`, \`linux/arm64\`) signed with [cosign](https://github.com/sigstore/cosign)."
-  echo
-  echo "| Image | Reference |"
-  echo "|-------|-----------|"
+  if [[ "${chart_mode}" == false ]]; then
+    echo "## Container Images"
+    echo
+    echo "Multi-arch images (\`linux/amd64\`, \`linux/arm64\`) signed with [cosign](https://github.com/sigstore/cosign)."
+    echo
+    echo "| Image | Reference |"
+    echo "|-------|-----------|"
 
-  for image in "${images[@]}"; do
-    image_name="harbor-${image}"
-    [[ "${image}" == "trivy-adapter" ]] && image_name="trivy-adapter"
-    echo "| \`${image_name}\` | \`${registry}/${image_name}:${TAG_NAME}\` |"
-  done
+    for image in "${images[@]}"; do
+      image_name="harbor-${image}"
+      [[ "${image}" == "trivy-adapter" ]] && image_name="trivy-adapter"
+      echo "| \`${image_name}\` | \`${registry}/${image_name}:${TAG_NAME}\` |"
+    done
 
-  echo
-  echo "**Verify an image signature:**"
-  echo '```sh'
-  echo "cosign verify \\"
-  echo "  --certificate-identity \"https://github.com/${GITHUB_REPOSITORY}/.github/workflows/publish-images.yml@refs/heads/${release_branch}\" \\"
-  echo '  --certificate-oidc-issuer "https://token.actions.githubusercontent.com" \'
-  echo "  ${registry}/harbor-core:${TAG_NAME}"
-  echo '```'
+    echo
+    echo "**Verify an image signature:**"
+    echo '```sh'
+    echo "cosign verify \\"
+    echo "  --certificate-identity \"https://github.com/${GITHUB_REPOSITORY}/.github/workflows/publish-images.yml@refs/heads/${release_branch}\" \\"
+    echo '  --certificate-oidc-issuer "https://token.actions.githubusercontent.com" \'
+    echo "  ${registry}/harbor-core:${TAG_NAME}"
+    echo '```'
+  else
+    # The chart's default image tags: the appVersion committed at the tag.
+    app_version="$(printf '%s\n' "${chart_yaml_source}" | awk -F'[:[:space:]]+' '$1 == "appVersion" { gsub(/"/, "", $2); print $2; exit }')"
+    if [[ -n "${app_version}" ]]; then
+      echo "Default Harbor image tags follow the chart appVersion: \`${app_version}\`."
+    fi
+  fi
 
-  if [[ -s "${tmp_dir}/contributors.md" ]]; then
+  # New Contributors spans every PR between the tags, which for the chart
+  # line would credit unrelated app work — app releases only.
+  if [[ "${chart_mode}" == false && -s "${tmp_dir}/contributors.md" ]]; then
     echo
     echo "---"
     echo

--- a/.github/workflows/release-notes-engine.yml
+++ b/.github/workflows/release-notes-engine.yml
@@ -20,6 +20,11 @@ on:
         required: false
         default: false
         type: boolean
+      component:
+        description: Release line to render ('' = app, 'chart' = Helm chart)
+        required: false
+        default: ''
+        type: string
     secrets:
       SYNC_APP_PRIVATE_KEY:
         description: Private key for reading commercial branch metadata
@@ -41,6 +46,7 @@ jobs:
       RELEASE_NOTES_DRY_RUN: ${{ inputs.dry_run || false }}
       TAG_NAME: ${{ inputs.tag_name || github.ref_name }}
       RELEASE_NOTES_PREVIEW_PR_NUMBER: ${{ inputs.preview_pr_number }}
+      RELEASE_NOTES_COMPONENT: ${{ inputs.component }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -156,6 +156,8 @@ jobs:
       release_created: ${{ steps.release.outputs['deploy/chart--release_created'] }}
       tag_name: ${{ steps.release.outputs['deploy/chart--tag_name'] }}
       version: ${{ steps.release.outputs['deploy/chart--version'] }}
+      prs_created: ${{ steps.release.outputs.prs_created }}
+      prs: ${{ steps.release.outputs.prs }}
     steps:
       - uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7 # v5.0.0
         id: release
@@ -273,3 +275,32 @@ jobs:
       tag_name: ${{ needs.release-please-chart.outputs.tag_name }}
     secrets:
       REGISTRY_PASSWORD: ${{ secrets.REGISTRY_PASSWORD }}
+
+  preview-chart-release-notes:
+    name: Preview Chart Release Notes
+    needs: [release-please-chart]
+    if: ${{ needs.release-please-chart.outputs.prs_created == 'true' && needs.release-please-chart.outputs.release_created != 'true' }}
+    permissions:
+      contents: write
+      pull-requests: write
+    uses: ./.github/workflows/release-notes-engine.yml
+    with:
+      checkout_ref: ${{ fromJSON(needs.release-please-chart.outputs.prs)[0].headBranchName }}
+      preview_pr_number: ${{ fromJSON(needs.release-please-chart.outputs.prs)[0].number }}
+      component: chart
+    secrets:
+      SYNC_APP_PRIVATE_KEY: ${{ secrets.SYNC_APP_PRIVATE_KEY }}
+
+  update-chart-release-notes:
+    name: Update Chart Release Notes
+    # After publish, so the install snippet points at a pullable chart.
+    needs: [release-please-chart, chart]
+    if: ${{ needs.release-please-chart.outputs.release_created == 'true' }}
+    permissions:
+      contents: write
+    uses: ./.github/workflows/release-notes-engine.yml
+    with:
+      tag_name: ${{ needs.release-please-chart.outputs.tag_name }}
+      component: chart
+    secrets:
+      SYNC_APP_PRIVATE_KEY: ${{ secrets.SYNC_APP_PRIVATE_KEY }}

--- a/taskfile/release-notes.yml
+++ b/taskfile/release-notes.yml
@@ -5,7 +5,7 @@ tasks:
     desc: "Recreate release notes (TAG_NAME=vX.Y.Z)"
     preconditions:
       - sh: test -n "${TAG_NAME:-}"
-        msg: "TAG_NAME is required (for example, v2.15.4)"
+        msg: "TAG_NAME is required (for example, v2.15.4 or chart-v2.0.0)"
       - sh: test -n "${GH_TOKEN:-}"
         msg: "GH_TOKEN is required"
     cmds:
@@ -15,7 +15,7 @@ tasks:
     desc: "Render release notes locally without updating the GitHub Release (TAG_NAME=vX.Y.Z)"
     preconditions:
       - sh: test -n "${TAG_NAME:-}"
-        msg: "TAG_NAME is required (for example, v2.15.4)"
+        msg: "TAG_NAME is required (for example, v2.15.4 or chart-v2.0.0)"
       - sh: test -n "${GH_TOKEN:-}"
         msg: "GH_TOKEN is required"
     cmds:


### PR DESCRIPTION
Chart releases currently ship release-please's generic changelog. This gives them the same treatment as app releases: **Summary** (verbatim `## Release Notes` sections from the merged PRs, `(#N)` references only — nothing synthesized), attributed **What's Changed**, an install snippet, and cosign verification for the chart artifact.

## Design: chart mode in the existing engine, not a second pipeline

`update-release-notes.sh` already does 90% of the work; the What's-Changed content comes from the release-please CHANGELOG, and the chart line has its own `deploy/chart/CHANGELOG.md` that is *already scoped to chart commits* — so path-scoping came for free. Changes:

- **`update-release-notes.sh`**: accepts `chart-vX.Y.Z` tags → chart mode. Sources `deploy/chart/CHANGELOG.md`; passes `previous_tag_name=<previous chart-v* tag>` to `generate-notes` so authorship is computed between *chart* tags, never against the latest app release. Skips app-only blocks (commercial patches, container-image table, New Contributors — the latter would credit unrelated app PRs in a chart tag range). Adds a chart cosign-verify block (`publish-chart.yml@refs/heads/main` identity) and a "default image tags follow appVersion" footer. The chart name is read from `Chart.yaml` at the tag — the upcoming harbor-next→harbor rename needs **no change** here, and the app-release "Helm Chart" snippet now uses the same dynamic name instead of a hardcoded `harbor-next`.
- **`extract-changelog-release.mjs`**: also matches release-please's unbracketed first-release heading style (`## 2.0.0 (date)`), which the chart changelog uses.
- **`release-notes-engine.yml`**: new optional `component` input (`''` = app, `chart`), plumbed as `RELEASE_NOTES_COMPONENT`. App callers unchanged.
- **`release-please.yml`**: `update-chart-release-notes` job runs the engine after `chart` publish (install snippet points at a pullable artifact); `preview-chart-release-notes` mirrors the app preview on the chart release PR (reads the bumped `.release-please-manifest-chart.json` on the PR branch). `release-please-chart` exposes `prs_created`/`prs` (top-level action outputs, not path-prefixed).

## Verified

Full dry run in chart mode against the chart 2.0.0 changelog + PR #56: Summary renders #56's Release Notes section verbatim, What's Changed attributes @Vad1mo via generate-notes, install/verify snippets carry the right chart name and version. `bash -n` + `node --check` + actionlint clean (its stale builtin runner list flags `ubuntu-26.04` as always; the "component input not defined" it reports when run from the repo root is a false positive from resolving the reusable workflow in a different worktree).

## Composes with

- The rename PR (harbor-next → harbor): nothing here hardcodes the chart name.
- The release-as unstick + PR 796 (appVersion bump): independent files except `release-please.yml` job additions at the end — trivial rebase if they land first.