### PR TITLE
ci: Keep publiccode.yml version and release date current on releases

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -71,6 +71,30 @@ jobs:
           echo "GIT_ASKPASS=${askpass}" >> "${GITHUB_ENV}"
           echo "GIT_TERMINAL_PROMPT=0" >> "${GITHUB_ENV}"
 
+      - name: Stamp publiccode.yml release date
+        # Inline (not a Taskfile task): this job never installs task, and the
+        # sibling release-PR steps below already munge files with inline shell.
+        if: ${{ github.ref_name == 'main' && steps.release.outputs.prs_created == 'true' && steps.release.outputs.release_created != 'true' }}
+        run: |
+          if ! grep -q '^releaseDate: ' publiccode.yml; then
+            echo "::error::publiccode.yml has no releaseDate field to stamp"
+            exit 1
+          fi
+
+          today=$(date -u +%F)
+          sed -i "s/^releaseDate: .*/releaseDate: ${today}/" publiccode.yml
+
+          if git diff --quiet -- publiccode.yml; then
+            echo "releaseDate already ${today}"
+            exit 0
+          fi
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add publiccode.yml
+          git commit -s -m "chore: stamp publiccode.yml release date ${today}"
+          git push
+
       - name: Setup Node
         if: ${{ github.ref_name == 'main' && steps.release.outputs.prs_created == 'true' && steps.release.outputs.release_created != 'true' }}
         uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6.5.0

--- a/publiccode.yml
+++ b/publiccode.yml
@@ -3,7 +3,7 @@ name: Harbor
 url: https://github.com/container-registry/harbor-next
 landingURL: https://github.com/container-registry/harbor-next
 isBasedOn: https://github.com/goharbor/harbor
-softwareVersion: 2.15.8
+softwareVersion: 2.15.8 # x-release-please-version
 releaseDate: 2026-08-26
 logo: docs/img/harbor_logo.png
 platforms:

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -23,6 +23,8 @@
     {"type": "build",    "section": "Build System",   "hidden": true}
   ],
   "packages": {
-    ".": {}
+    ".": {
+      "extra-files": ["publiccode.yml"]
+    }
   }
 }


### PR DESCRIPTION
Automates `publiccode.yml` freshness so each harbor-next release keeps it current, instead of hand-edited values going stale.

## What

- **`softwareVersion`** — added `publiccode.yml` to `extra-files` in `release-please-config.json`; the generic updater rewrites the annotated line (`softwareVersion: 2.15.8 # x-release-please-version`) on every main release PR.
- **`releaseDate`** — new step in `release-please.yml` sed-stamps `releaseDate` with the current UTC date on the release PR branch, mirroring the existing "Advance main development version" step (same gating, same commit/push pattern). Inline shell rather than a Taskfile task because this job never installs `task` and its sibling release-PR steps are already inline.

## Verification

- Ran release-please 17.11.2 `Generic` updater against the annotated file: line becomes `softwareVersion: 2.16.0 # x-release-please-version`, annotation preserved, rest of file byte-identical. Action pin v5.0.0 bundles release-please 17.x.
- `italia/publiccode-parser-go` passes (only pre-existing warning: publiccodeYmlVersion 0.4 vs 0.7).
- `actionlint`: no findings in the new step (pre-existing `ubuntu-26.04` label warnings only, from actionlint's stale runner list).

## Notes / limitations

- Current values are already accurate: latest release is v2.15.8, tagged 2026-08-26 UTC — no staleness fix needed.
- `release-2.15` has no `publiccode.yml` and its maintenance config is frozen at branch cut, so `release-please-config-maintenance.json` is untouched. Patch releases cut from maintenance branches will not update the copy on main (which is what publiccode crawlers read); main refreshes on each minor release. Stamping maintenance-branch copies would update version but not date — worse than leaving them alone.
- `releaseDate` reflects the last release-PR refresh before merge; if a release PR idles for days without new main pushes, the date can lag by that gap. Release-please force-pushes the PR branch on every main push, re-stamping each time.
- Stamp commits use `GITHUB_TOKEN`, so they cannot retrigger workflows (same as the existing VERSION-advance commit).