### PR TITLE
chore: Sync Patch Release Changelog Sections To Main Automatically

### DIFF
--- a/.github/scripts/insert-changelog-section.mjs
+++ b/.github/scripts/insert-changelog-section.mjs
@@ -1,0 +1,56 @@
+import { readFileSync, writeFileSync } from 'node:fs';
+
+const [changelogPath, sectionPath, version] = process.argv.slice(2);
+
+if (!changelogPath || !sectionPath || !version) {
+  throw new Error('usage: insert-changelog-section.mjs <changelog> <section> <version>');
+}
+
+if (!/^\d+\.\d+\.\d+$/.test(version)) {
+  throw new Error(`version must be X.Y.Z, got: ${version}`);
+}
+
+const section = `${readFileSync(sectionPath, 'utf8').trim()}\n`;
+const changelog = readFileSync(changelogPath, 'utf8');
+const escapedVersion = version.replaceAll('.', '\\.');
+
+// Idempotent: a heading for this version is already present, in either the
+// release-please form (## [X.Y.Z]) or a legacy nested form (### vX.Y.Z).
+if (new RegExp(`^#{2,3} \\[?v?${escapedVersion}\\]?\\b`, 'm').test(changelog)) {
+  process.exit(0);
+}
+
+function compareVersions(a, b) {
+  const x = a.split('.').map(Number);
+  const y = b.split('.').map(Number);
+  for (let i = 0; i < 3; i++) {
+    if (x[i] !== y[i]) {
+      return x[i] - y[i];
+    }
+  }
+  return 0;
+}
+
+const lines = changelog.split('\n');
+// Insert before the first release section older than this version, so a
+// patch release lands below any newer minor already on main. Legacy
+// unbracketed blocks ("## v2.14.x") are always older than new releases.
+let insertLine = -1;
+for (let i = 0; i < lines.length; i++) {
+  const release = lines[i].match(/^## \[v?(\d+\.\d+\.\d+)\]/)?.[1];
+  if (release && compareVersions(release, version) < 0) {
+    insertLine = i;
+    break;
+  }
+  const legacy = lines[i].match(/^## v(\d+)\.(\d+)\.x/);
+  if (legacy && compareVersions(`${legacy[1]}.${legacy[2]}.0`, version) < 0) {
+    insertLine = i;
+    break;
+  }
+}
+
+const output = insertLine === -1
+  ? `${changelog.trimEnd()}\n\n${section}`
+  : [...lines.slice(0, insertLine), section, ...lines.slice(insertLine)].join('\n');
+
+writeFileSync(changelogPath, output);

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -207,6 +207,90 @@ jobs:
           git commit -s -m "chore: initialize ${branch} version"
           git push origin "HEAD:refs/heads/${branch}"
 
+  sync-main-changelog:
+    # Patch releases update only the release-X.Y branch's CHANGELOG.md, so
+    # main's changelog silently stops at X.Y.0. After a maintenance release,
+    # open a PR that inserts the released section into main's changelog in
+    # version-sorted position. Runs from the release branch's workflow copy —
+    # keep this job cherry-picked onto active release-X.Y branches.
+    name: Sync Patch Changelog To Main
+    needs: [release-please]
+    if: ${{ startsWith(github.ref_name, 'release-') && needs.release-please.outputs.release_created == 'true' }}
+    runs-on: ubuntu-26.04
+    permissions:
+      contents: write
+      pull-requests: write
+    env:
+      GH_TOKEN: ${{ github.token }}
+      TAG_NAME: ${{ needs.release-please.outputs.tag_name }}
+      VERSION: ${{ needs.release-please.outputs.version }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Setup Node
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6.5.0
+        with:
+          node-version: 24
+          package-manager-cache: false
+
+      - name: Extract released changelog section
+        run: |
+          node .github/scripts/extract-changelog-release.mjs \
+            CHANGELOG.md "${VERSION}" "${RUNNER_TEMP}/released-section.md"
+
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: main
+          persist-credentials: false
+
+      - name: Configure ephemeral Git authentication
+        run: |
+          askpass="${RUNNER_TEMP}/git-askpass"
+          cat > "${askpass}" <<'EOF'
+          #!/usr/bin/env bash
+          case "$1" in
+            *Username*) printf '%s\n' 'x-access-token' ;;
+            *Password*) printf '%s\n' "${GH_TOKEN}" ;;
+            *) exit 1 ;;
+          esac
+          EOF
+          chmod 700 "${askpass}"
+          echo "GIT_ASKPASS=${askpass}" >> "${GITHUB_ENV}"
+          echo "GIT_TERMINAL_PROMPT=0" >> "${GITHUB_ENV}"
+
+      - name: Open changelog sync PR against main
+        run: |
+          node .github/scripts/insert-changelog-section.mjs \
+            CHANGELOG.md "${RUNNER_TEMP}/released-section.md" "${VERSION}"
+
+          if git diff --quiet -- CHANGELOG.md; then
+            echo "main CHANGELOG.md already contains ${TAG_NAME}"
+            exit 0
+          fi
+
+          branch="chore/sync-changelog-${TAG_NAME}"
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git switch -c "${branch}"
+          git add CHANGELOG.md
+          git commit -s -m "chore: Sync ${TAG_NAME} changelog section to main"
+          # Force-push so a rerun after a partial failure (branch pushed, PR
+          # creation failed) recovers instead of dying on the existing branch.
+          git push --force origin "HEAD:refs/heads/${branch}"
+
+          if [[ -n "$(gh pr list --base main --head "${branch}" --state open --json number --jq '.[].number')" ]]; then
+            echo "Sync PR for ${TAG_NAME} already open"
+            exit 0
+          fi
+
+          gh pr create \
+            --base main \
+            --head "${branch}" \
+            --title "chore: Sync ${TAG_NAME} changelog section to main" \
+            --body "Automated by the Sync Patch Changelog To Main job: inserts the ${TAG_NAME} section released from ${GITHUB_REF_NAME} into main's CHANGELOG.md in version-sorted position."
+
   publish-images:
     name: Publish Release Images
     needs: [release-please]


### PR DESCRIPTION
Companion to the 2.15.x backfill PR. Patch releases cut from `release-X.Y` update only that branch's `CHANGELOG.md`, so main's changelog silently stops at `X.Y.0`.

Adds a `sync-main-changelog` job to `release-please.yml`: when a maintenance release publishes, it extracts the released section (existing `extract-changelog-release.mjs`), inserts it into main's `CHANGELOG.md` in version-sorted position via the new `insert-changelog-section.mjs` (idempotent — re-runs and already-present versions no-op; a 2.15.9 section lands below an existing 2.16.0), and opens a `chore:` PR against main for a maintainer to merge.

**Cherry-pick note:** the workflow runs from the *release branch's* copy on patch releases, so this needs to be cherry-picked onto `release-2.15` (before v2.15.9) to take effect there — `chore:` type keeps that cherry-pick from bumping a release.

Known limitation: the sync PR is created with `GITHUB_TOKEN`, so it won't trigger PR CI automatically (changelog-only change; close/reopen re-triggers if checks are required).