### PR TITLE
ci: Support Patch Stream Multi-Commit Chains In Release Pipeline

### DIFF
--- a/.github/scripts/update-release-notes.sh
+++ b/.github/scripts/update-release-notes.sh
@@ -176,12 +176,8 @@ prepo() { git -C "${tmp_dir}/patches-repo" "$@"; }
 # The Harbor branch owns the ordered manifest. 8gcr only stores the branch
 # commits, so release notes and image builds always use the same exact list.
 #
-# Patch Stream: each branch is a chain of squash-merged PRs on the pinned
-# patch-base/<line> baseline. The per-feature delta of this release is every
-# chain PR that is NOT in the previous patch-record tag's PR set (recorded
-# per branch as "prs=…" lines in the tag message) — a rebase-proof set
-# difference. Before the stream is seeded (no patch-base ref), fall back to
-# the old flat tip-subject list.
+# Patch Stream: this release's delta per branch = chain PRs not in the previous
+# patch-record tag's "prs=" set. No patch-base ref yet -> flat tip-subject list.
 if [[ "${chart_mode}" == false && -f "${series}" ]]; then
   branches=()
   while IFS= read -r branch; do

--- a/.github/scripts/update-release-notes.sh
+++ b/.github/scripts/update-release-notes.sh
@@ -169,27 +169,107 @@ export GIT_ASKPASS="${askpass_script}" GIT_TERMINAL_PROMPT=0 PATCHES_TOKEN
 git init --bare "${tmp_dir}/patches-repo"
 patches_remote="https://x-access-token@github.com/container-registry/8gcr"
 series="taskfile/commercial-patches"
+stacks_file="taskfile/commercial-patch-stacks"
 patch_notes="${tmp_dir}/commercial-patches.md"
+prepo() { git -C "${tmp_dir}/patches-repo" "$@"; }
 
 # The Harbor branch owns the ordered manifest. 8gcr only stores the branch
 # commits, so release notes and image builds always use the same exact list.
+#
+# Patch Stream: each branch is a chain of squash-merged PRs on the pinned
+# patch-base/<line> baseline. The per-feature delta of this release is every
+# chain PR that is NOT in the previous patch-record tag's PR set (recorded
+# per branch as "prs=…" lines in the tag message) — a rebase-proof set
+# difference. Before the stream is seeded (no patch-base ref), fall back to
+# the old flat tip-subject list.
 if [[ "${chart_mode}" == false && -f "${series}" ]]; then
+  branches=()
   while IFS= read -r branch; do
     branch="${branch%%#*}"
     branch="${branch#"${branch%%[![:space:]]*}"}"
     branch="${branch%"${branch##*[![:space:]]}"}"
     [[ -z "${branch}" ]] && continue
-
     if ! git check-ref-format --branch "${branch}" >/dev/null 2>&1; then
       echo "Invalid commercial branch name in series: ${branch}" >&2
       exit 1
     fi
-
-    git -C "${tmp_dir}/patches-repo" fetch --depth=1 "${patches_remote}" \
-      "${branch}:refs/remotes/origin/${branch}"
-    echo "- $(git -C "${tmp_dir}/patches-repo" log -1 --format=%s "refs/remotes/origin/${branch}")" \
-      >> "${patch_notes}"
+    branches+=("${branch}")
   done < "${series}"
+
+  base_ref="patch-base/${release_branch}"
+  if prepo fetch --depth=1 "${patches_remote}" \
+      "+refs/heads/${base_ref}:refs/heads/${base_ref}" 2>/dev/null; then
+    # previous record: highest patch-record semver strictly below this tag
+    record_ver=$( {
+        prepo ls-remote "${patches_remote}" 'refs/tags/patch-record/*' \
+          | awk '{ sub(/\^\{\}$/, "", $2); sub(/^refs\/tags\/patch-record\/v/, "", $2); print $2 }'
+        echo "${version}"
+      } | sort -u -V | awk -v c="${version}" '$0 == c { exit } { last = $0 } END { if (last != "") print last }')
+    record_tag=""
+    [[ -n "${record_ver}" ]] && record_tag="patch-record/v${record_ver}"
+    seen_file="${tmp_dir}/record-msg.txt"
+    : > "${seen_file}"
+    if [[ -n "${record_tag}" ]]; then
+      prepo fetch --depth=1 "${patches_remote}" \
+        "+refs/tags/${record_tag}:refs/tags/${record_tag}"
+      prepo tag -l --format='%(contents)' "${record_tag}" > "${seen_file}"
+    fi
+
+    unchanged=()
+    for branch in "${branches[@]}"; do
+      # chains only: everything newer than the pinned baseline
+      prepo fetch --shallow-exclude="${base_ref}" "${patches_remote}" \
+        "+refs/heads/${branch}:refs/remotes/origin/${branch}"
+      excl=()
+      if [[ -f "${stacks_file}" ]]; then
+        stack_parent=$(awk -v b="${branch}" '{ sub(/#.*/, "") } NF == 2 && $1 == b { print $2 }' "${stacks_file}")
+        [[ -n "${stack_parent}" ]] && excl=("^refs/remotes/origin/${stack_parent}")
+      fi
+      mapfile -t chain < <(prepo log --reverse --format=%H \
+        "refs/remotes/origin/${branch}" "${excl[@]}" 2>/dev/null || true)
+      if [[ "${#chain[@]}" -eq 0 ]]; then
+        echo "commercial branch has no chain above ${base_ref}: ${branch}" >&2
+        exit 1
+      fi
+      title=$(prepo log -1 --format=%s "${chain[0]}")
+      seen=$(awk -v b="${branch}" '$1 == b { sub(/^prs=/, "", $3); gsub(/,/, "\n", $3); print $3 }' "${seen_file}")
+      section=""
+      for c in "${chain[@]}"; do
+        subj=$(prepo log -1 --format=%s "${c}")
+        pr=$(sed -n 's/.* (#\([0-9][0-9]*\))$/\1/p' <<< "${subj}")
+        [[ -z "${pr}" ]] && continue
+        grep -qx "${pr}" <<< "${seen}" && continue
+        section+="- ${subj}"$'\n'
+        section+=$(prepo log -1 --format=%b "${c}" | awk '
+          /^## Release Notes[[:space:]]*$/ { grab=1; next }
+          /^## / { grab=0 }
+          grab && NF { print "  " $0 }
+        ')
+        section="${section%$'\n'}"$'\n'
+      done
+      if [[ -n "${section}" ]]; then
+        {
+          echo "### ${title}"
+          printf '%s' "${section}"
+          echo
+        } >> "${patch_notes}"
+      else
+        unchanged+=("${title}")
+      fi
+    done
+    if [[ "${#unchanged[@]}" -gt 0 && -s "${patch_notes}" ]]; then
+      titles=$(printf '%s, ' "${unchanged[@]}")
+      echo "_No changes this release:_ ${titles%, }" >> "${patch_notes}"
+    fi
+  else
+    # legacy (pre-Patch-Stream): flat list of branch tip subjects
+    for branch in "${branches[@]}"; do
+      prepo fetch --depth=1 "${patches_remote}" \
+        "+refs/heads/${branch}:refs/remotes/origin/${branch}"
+      echo "- $(prepo log -1 --format=%s "refs/remotes/origin/${branch}")" \
+        >> "${patch_notes}"
+    done
+  fi
 fi
 
 {

--- a/.github/workflows/notify-fork-sync.yml
+++ b/.github/workflows/notify-fork-sync.yml
@@ -2,13 +2,16 @@ name: Notify Fork Sync
 
 on:
   push:
-    branches: [main]
+    branches:
+      - main
+      - "release-[0-9]*.[0-9]*"
 
 permissions: {}
 
 jobs:
   dispatch:
     runs-on: ubuntu-26.04
+    timeout-minutes: 5
     steps:
       - name: Generate GitHub App token
         id: app-token
@@ -19,12 +22,17 @@ jobs:
           owner: container-registry
           repositories: 8gcr
 
-      - name: Trigger sync
+      # 8gcr's upstream-check runs a DRY conflict check per line — no pushes
+      - name: Trigger upstream check
+        env:
+          TOKEN: ${{ steps.app-token.outputs.token }}
+          SHA: ${{ github.sha }}
+          LINE: ${{ github.ref_name }}
         run: |
           curl -f -X POST \
             -H "Accept: application/vnd.github+json" \
             -H "Content-Type: application/json" \
             -H "X-GitHub-Api-Version: 2022-11-28" \
-            -H "Authorization: Bearer ${{ steps.app-token.outputs.token }}" \
+            -H "Authorization: Bearer ${TOKEN}" \
             "https://api.github.com/repos/container-registry/8gcr/dispatches" \
-            -d '{"event_type":"upstream-sync","client_payload":{"sha":"${{ github.sha }}"}}'
+            -d "{\"event_type\":\"upstream-sync\",\"client_payload\":{\"sha\":\"${SHA}\",\"line\":\"${LINE}\"}}"

--- a/.github/workflows/notify-fork-sync.yml
+++ b/.github/workflows/notify-fork-sync.yml
@@ -33,10 +33,13 @@ jobs:
           SHA: ${{ github.sha }}
           LINE: ${{ github.ref_name }}
         run: |
-          curl -f -X POST \
-            -H "Accept: application/vnd.github+json" \
-            -H "Content-Type: application/json" \
-            -H "X-GitHub-Api-Version: 2022-11-28" \
-            -H "Authorization: Bearer ${TOKEN}" \
-            "https://api.github.com/repos/container-registry/8gcr/dispatches" \
-            -d "{\"event_type\":\"upstream-sync\",\"client_payload\":{\"sha\":\"${SHA}\",\"line\":\"${LINE}\"}}"
+          # jq --arg: branch names must be JSON-escaped, not interpolated.
+          jq -cn --arg sha "${SHA}" --arg line "${LINE}" \
+            '{event_type: "upstream-sync", client_payload: {sha: $sha, line: $line}}' \
+            | curl -f -X POST \
+                -H "Accept: application/vnd.github+json" \
+                -H "Content-Type: application/json" \
+                -H "X-GitHub-Api-Version: 2022-11-28" \
+                -H "Authorization: Bearer ${TOKEN}" \
+                "https://api.github.com/repos/container-registry/8gcr/dispatches" \
+                --data-binary @-

--- a/.github/workflows/notify-fork-sync.yml
+++ b/.github/workflows/notify-fork-sync.yml
@@ -21,6 +21,10 @@ jobs:
           private-key: ${{ secrets.SYNC_APP_PRIVATE_KEY }}
           owner: container-registry
           repositories: 8gcr
+          # Explicit scope (zizmor github-app): repository_dispatch needs
+          # contents write; without this the token inherits every
+          # permission of the app installation.
+          permission-contents: write
 
       # 8gcr's upstream-check runs a DRY conflict check per line — no pushes
       - name: Trigger upstream check

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -286,6 +286,42 @@ jobs:
     secrets:
       SYNC_APP_PRIVATE_KEY: ${{ secrets.SYNC_APP_PRIVATE_KEY }}
 
+  # Patch Stream: after the notes are rendered (windows read "PRs since the
+  # last record", so render first, stamp second), tell 8gcr to bump the
+  # patch baselines onto the released commit and stamp patch-record/<tag>.
+  dispatch-release-cut:
+    name: Dispatch Release Cut
+    needs: [release-please, update-release-notes]
+    if: ${{ needs.release-please.outputs.release_created == 'true' }}
+    runs-on: ubuntu-26.04
+    timeout-minutes: 5
+    permissions:
+      contents: read
+    steps:
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          app-id: ${{ vars.SYNC_APP_ID }}
+          private-key: ${{ secrets.SYNC_APP_PRIVATE_KEY }}
+          owner: container-registry
+          repositories: 8gcr
+
+      - name: Trigger patch-bump + record
+        env:
+          TOKEN: ${{ steps.app-token.outputs.token }}
+          TAG: ${{ needs.release-please.outputs.tag_name }}
+          TARGET_SHA: ${{ github.sha }}
+          LINE: ${{ github.ref_name }}
+        run: |
+          curl -f -X POST \
+            -H "Accept: application/vnd.github+json" \
+            -H "Content-Type: application/json" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            -H "Authorization: Bearer ${TOKEN}" \
+            "https://api.github.com/repos/container-registry/8gcr/dispatches" \
+            -d "{\"event_type\":\"release-cut\",\"client_payload\":{\"tag\":\"${TAG}\",\"target_sha\":\"${TARGET_SHA}\",\"line\":\"${LINE}\"}}"
+
   chart:
     name: Publish Helm Chart
     # Driven by the chart's own release-please line (release-please-chart),

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -306,6 +306,10 @@ jobs:
           private-key: ${{ secrets.SYNC_APP_PRIVATE_KEY }}
           owner: container-registry
           repositories: 8gcr
+          # Explicit scope (zizmor github-app): repository_dispatch needs
+          # contents write; without this the token inherits every
+          # permission of the app installation.
+          permission-contents: write
 
       - name: Trigger patch-bump + record
         env:

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -286,8 +286,7 @@ jobs:
     secrets:
       SYNC_APP_PRIVATE_KEY: ${{ secrets.SYNC_APP_PRIVATE_KEY }}
 
-  # Patch Stream: after the notes are rendered (windows read "PRs since the
-  # last record", so render first, stamp second), tell 8gcr to bump the
+  # After notes render (render first, stamp second), tell 8gcr to bump
   # patch baselines onto the released commit and stamp patch-record/<tag>.
   dispatch-release-cut:
     name: Dispatch Release Cut
@@ -318,13 +317,16 @@ jobs:
           TARGET_SHA: ${{ github.sha }}
           LINE: ${{ github.ref_name }}
         run: |
-          curl -f -X POST \
-            -H "Accept: application/vnd.github+json" \
-            -H "Content-Type: application/json" \
-            -H "X-GitHub-Api-Version: 2022-11-28" \
-            -H "Authorization: Bearer ${TOKEN}" \
-            "https://api.github.com/repos/container-registry/8gcr/dispatches" \
-            -d "{\"event_type\":\"release-cut\",\"client_payload\":{\"tag\":\"${TAG}\",\"target_sha\":\"${TARGET_SHA}\",\"line\":\"${LINE}\"}}"
+          # jq --arg: tag/branch values must be JSON-escaped, not interpolated.
+          jq -cn --arg tag "${TAG}" --arg sha "${TARGET_SHA}" --arg line "${LINE}" \
+            '{event_type: "release-cut", client_payload: {tag: $tag, target_sha: $sha, line: $line}}' \
+            | curl -f -X POST \
+                -H "Accept: application/vnd.github+json" \
+                -H "Content-Type: application/json" \
+                -H "X-GitHub-Api-Version: 2022-11-28" \
+                -H "Authorization: Bearer ${TOKEN}" \
+                "https://api.github.com/repos/container-registry/8gcr/dispatches" \
+                --data-binary @-
 
   chart:
     name: Publish Helm Chart

--- a/taskfile/commercial-patch-stacks
+++ b/taskfile/commercial-patch-stacks
@@ -1,0 +1,4 @@
+# Declared stacking between commercial patch branches: "child parent".
+# A stacked child's chain roots on its parent's tip instead of the pinned
+# baseline. Gates verify this exact shape — stacking is never inferred.
+0006-aws-rds-iam-auth 0005-pgx-monitoring

--- a/taskfile/release-ready.yml
+++ b/taskfile/release-ready.yml
@@ -122,12 +122,8 @@ tasks:
       DECLARED_PATCH_BRANCHES: '{{.PATCH_BRANCHES}}'
       PATCHES_STACKS_FILE: '{{.PATCHES_STACKS}}'
     cmds:
-      # Each branch is a linear chain of non-merge commits (Patch Stream:
-      # one commit per squash-merged PR; single-commit branches are just a
-      # chain of one). The chain root's parent must sit on the target, or —
-      # for a branch declared in commercial-patch-stacks — anywhere on its
-      # parent branch's chain (the parent's tip moves on every landed PR).
-      # Chain-shape gates on the 8gcr side reject undeclared stacking.
+      # Branch = linear chain of non-merge commits. Its root must parent on
+      # the target, or on its declared parent's chain (commercial-patch-stacks).
       - |
         base=$(git rev-parse HEAD)
         stacks=""
@@ -206,11 +202,8 @@ tasks:
         patchset_id=$(printf '%s' "${patch_revset}" | git hash-object --stdin)
         test "$(jj log -r @ --no-graph -T 'description.first_line()')" = "release patches ${patchset_id}"
     cmds:
-      # Duplicate every branch's FULL chain (Patch Stream: one commit per
-      # squash-merged PR) as one connected set: `~ ::@` strips everything
-      # already on the target, chain roots re-parent onto @, and declared
-      # stacking survives because a stacked root's parent is inside the
-      # duplicated set. Single-commit branches behave exactly as before.
+      # Duplicate each branch's full chain as one set: `~ ::@` drops what
+      # the target already has; stacked roots keep their in-set parents.
       - |
         patch_revset=$(printf '%s\n' "${DECLARED_PATCH_BRANCHES}" | while IFS= read -r branch; do
           git rev-parse "refs/remotes/patches/${branch}^{commit}"

--- a/taskfile/release-ready.yml
+++ b/taskfile/release-ready.yml
@@ -4,6 +4,7 @@ vars:
   PATCHES_REPO: '{{.PATCHES_REPO | default "github.com/container-registry/8gcr"}}'
   PATCHES_CLONE_URL: '{{.PATCHES_CLONE_URL | default "git@github.com:container-registry/8gcr.git"}}'
   PATCHES_SERIES: '{{.PATCHES_SERIES | default (printf "%s/taskfile/commercial-patches" .ROOT_DIR)}}'
+  PATCHES_STACKS: '{{.PATCHES_STACKS | default (printf "%s/taskfile/commercial-patch-stacks" .ROOT_DIR)}}'
   PATCH_AUTH_DIR: '{{.PATCH_AUTH_DIR | default ".opencode/tmp/patch-auth"}}'
   RELEASE_READY_DIR: '{{.RELEASE_READY_DIR | default ".opencode/tmp/release-ready"}}'
   PATCHES_REMOTE_URL:
@@ -119,39 +120,66 @@ tasks:
     internal: true
     env:
       DECLARED_PATCH_BRANCHES: '{{.PATCH_BRANCHES}}'
+      PATCHES_STACKS_FILE: '{{.PATCHES_STACKS}}'
     cmds:
+      # Each branch is a linear chain of non-merge commits (Patch Stream:
+      # one commit per squash-merged PR; single-commit branches are just a
+      # chain of one). The chain root's parent must sit on the target, or —
+      # for a branch declared in commercial-patch-stacks — anywhere on its
+      # parent branch's chain (the parent's tip moves on every landed PR).
+      # Chain-shape gates on the 8gcr side reject undeclared stacking.
       - |
         base=$(git rev-parse HEAD)
-        patch_commits=()
-        while IFS= read -r branch; do
-          patch_commits+=("$(git rev-parse "refs/remotes/patches/${branch}^{commit}")")
-        done <<< "${DECLARED_PATCH_BRANCHES}"
+        stacks=""
+        if [ -f "${PATCHES_STACKS_FILE}" ]; then
+          stacks=$(awk '
+            { sub(/#.*/, "") }
+            NF == 2 { print $1 " " $2 }
+            NF == 1 || NF > 2 { print "malformed stacks line: " $0 > "/dev/stderr"; exit 1 }
+          ' "${PATCHES_STACKS_FILE}")
+        fi
 
         while IFS= read -r branch; do
-          ref="refs/remotes/patches/${branch}"
-          parents=$(git show -s --format='%P' "${ref}")
-          if [ "$(wc -w <<< "${parents}")" -ne 1 ]; then
-            echo "commercial patch branch must point to one non-merge commit: ${branch}" >&2
-            exit 1
+          tip=$(git rev-parse "refs/remotes/patches/${branch}^{commit}")
+          stack_parent=$(printf '%s\n' "${stacks}" | awk -v b="${branch}" '$1 == b { print $2 }')
+          expected=""
+          if [ -n "${stack_parent}" ]; then
+            printf '%s\n' "${DECLARED_PATCH_BRANCHES}" | grep -qx "${stack_parent}" || {
+              echo "stack parent of ${branch} is not a declared branch: ${stack_parent}" >&2
+              exit 1
+            }
+            expected=$(git rev-parse "refs/remotes/patches/${stack_parent}^{commit}")
           fi
 
-          parent=${parents}
-          valid_parent=false
-          if git merge-base --is-ancestor "${parent}" "${base}"; then
-            valid_parent=true
-          else
-            for patch_commit in "${patch_commits[@]}"; do
-              if [ "${parent}" = "${patch_commit}" ]; then
-                valid_parent=true
-                break
+          c="${tip}"
+          depth=0
+          while :; do
+            parents=$(git show -s --format='%P' "${c}")
+            if [ "$(wc -w <<< "${parents}")" -ne 1 ]; then
+              echo "commercial patch chain contains a merge commit: ${branch} at ${c}" >&2
+              exit 1
+            fi
+            # a stacked root may sit anywhere on its declared parent's
+            # chain (the parent's tip moves on every landed PR)
+            if [ -n "${expected}" ] \
+                && git merge-base --is-ancestor "${parents}" "${expected}" \
+                && ! git merge-base --is-ancestor "${parents}" "${base}"; then
+              break
+            fi
+            if git merge-base --is-ancestor "${parents}" "${base}"; then
+              if [ -n "${expected}" ]; then
+                echo "declared stacked branch is rooted on the target instead of ${stack_parent}: ${branch}" >&2
+                exit 1
               fi
-            done
-          fi
-
-          if [ "${valid_parent}" != true ]; then
-            echo "commercial patch branch is not based on the target or another declared patch: ${branch}" >&2
-            exit 1
-          fi
+              break
+            fi
+            depth=$((depth + 1))
+            if [ "${depth}" -gt 200 ]; then
+              echo "commercial patch chain did not reach the target or its declared stack parent: ${branch}" >&2
+              exit 1
+            fi
+            c="${parents}"
+          done
         done <<< "${DECLARED_PATCH_BRANCHES}"
 
   _import-patches:
@@ -178,13 +206,19 @@ tasks:
         patchset_id=$(printf '%s' "${patch_revset}" | git hash-object --stdin)
         test "$(jj log -r @ --no-graph -T 'description.first_line()')" = "release patches ${patchset_id}"
     cmds:
+      # Duplicate every branch's FULL chain (Patch Stream: one commit per
+      # squash-merged PR) as one connected set: `~ ::@` strips everything
+      # already on the target, chain roots re-parent onto @, and declared
+      # stacking survives because a stacked root's parent is inside the
+      # duplicated set. Single-commit branches behave exactly as before.
       - |
         patch_revset=$(printf '%s\n' "${DECLARED_PATCH_BRANCHES}" | while IFS= read -r branch; do
           git rev-parse "refs/remotes/patches/${branch}^{commit}"
         done | paste -sd '|' -)
         patchset_id=$(printf '%s' "${patch_revset}" | git hash-object --stdin)
+        chain_revset=$(printf '%s' "${patch_revset}" | sed 's/^/::/; s/|/ | ::/g')
         base=$(jj log -r @ --no-graph -T commit_id)
-        jj duplicate "(${patch_revset})" --onto @
+        jj duplicate "(${chain_revset}) ~ ::${base}" --onto @
         jj new "heads(${base}::) ~ ${base}" -m "release patches ${patchset_id}"
 
   _verify-patches:


### PR DESCRIPTION
## Summary

Companion to **container-registry/8gcr#389 (Patch Stream)** — patch branches become linear chains of squash-merged PRs on a pinned baseline; this PR teaches the harbor-next release pipeline to consume them. **Merge this BEFORE 8gcr#389's flow goes live** (everything here is backward-compatible with today's single-commit branches, so merge order relative to current operation is safe).

### Changes

- **`taskfile/release-ready.yml`** — `_validate-patches` walks each branch as a chain: every commit non-merge, root parented on the target or (for branches declared in the new `taskfile/commercial-patch-stacks`) anywhere on the declared parent's chain. `_duplicate-patches` duplicates full chains as one connected jj set (`(::tips) ~ ::target`) — stacking topology survives, single-commit branches are a chain of one.
- **`taskfile/commercial-patch-stacks`** (new) — declared stacking: `0006-aws-rds-iam-auth 0005-pgx-monitoring`. Gates verify the declared shape; nothing is inferred from ancestry.
- **`.github/scripts/update-release-notes.sh`** — commercial section becomes per-feature: chain PRs whose `(#N)` is not in the previous `patch-record/<tag>` tag's recorded PR set (rebase-proof set diff), rendered with each PR's `## Release Notes` body lines; "_No changes this release_" collapse; shallow fetches bounded by `--shallow-exclude=patch-base/<line>`. Legacy fallback (flat tip-subject list) until the stream is seeded.
- **`.github/workflows/notify-fork-sync.yml`** — fires from `main` **and** `release-X.Y`, payload carries `line` (feeds 8gcr's dry `upstream-check`; supersedes #798).
- **`.github/workflows/release-please.yml`** — new `dispatch-release-cut` job after notes render: sends `release-cut {tag, target_sha, line}` to 8gcr (bump + record). Render first, stamp second.

### Verified

Sandbox (chain + stacked + mid-chain-rooted states): chain-aware validation accepts single-commit, full-chain, and mid-chain-stacked shapes; rejects merge commits and orphan-rooted stacked branches loudly; `jj duplicate` of the connected set preserves chain order + stacking onto a fresh target with zero conflicts. `bash -n` + `actionlint` clean (only pre-existing `ubuntu-26.04` label gripes from a stale local label DB).

Supersedes #794 and #798 — both close with this. 8gcr#389 carries the flow itself (taskfile/patch-flow.yml, patch-gate/upstream-check/patch-bump workflows, weave integration, full 32-case suite).
