### PR TITLE
ci: Segregate chart commits from app release notes with chart type

### DIFF
--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -29,7 +29,22 @@ jobs:
             revert
             upstream
             deps
+            chart
           requireScope: false
           subjectPattern: ^.{1,100}$
           subjectPatternError: |
             Subject must be 100 characters or less.
+
+      - name: Forbid breaking chart commits
+        # chart commits must never carry the breaking marker: release-please
+        # renders BREAKING CHANGE commits in app release notes even for
+        # hidden types, defeating the chart/app segregation.
+        env:
+          TITLE: ${{ github.event.pull_request.title }}
+        run: |
+          case "${TITLE}" in
+            chart!*|"chart("*")!:"*)
+              echo "::error::chart commits must not be breaking (chart!:). Breaking commits always surface in app release notes. Use a plain chart: commit; chart majors are driven by feat!/fix! under deploy/chart or a one-shot release-as."
+              exit 1
+              ;;
+          esac

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -15,6 +15,8 @@ jobs:
   validate-release-ref:
     name: Validate Release Ref
     runs-on: ubuntu-26.04
+    env:
+      GH_TOKEN: ${{ github.token }}
     steps:
       - name: Allow only release refs
         run: |
@@ -24,6 +26,25 @@ jobs:
 
           echo "::error::Release Please can only run on main or release-X.Y branches. Current ref: ${GITHUB_REF_NAME}"
           exit 1
+
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Reject leftover chart release-as
+        # release-as is a one-shot override that must be removed once its
+        # version ships; leaving it pins every future chart release to the
+        # same version (the #728 bug). Hard-fail the release pipeline the
+        # moment the pinned version's tag exists.
+        run: |
+          release_as=$(jq -r '.packages["deploy/chart"]["release-as"] // empty' release-please-config-chart.json)
+          if [ -z "${release_as}" ]; then
+            exit 0
+          fi
+          if gh api "repos/${GITHUB_REPOSITORY}/git/ref/tags/chart-v${release_as}" >/dev/null 2>&1; then
+            echo "::error file=release-please-config-chart.json::chart-v${release_as} is already published — remove the one-shot \"release-as\" from release-please-config-chart.json or every future chart release stays pinned to ${release_as}."
+            exit 1
+          fi
 
   release-please:
     needs: [validate-release-ref]

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -58,6 +58,7 @@ Common types:
 | `fix` | Bug fix | Patch version bump |
 | `upstream` | Cherry-picked upstream Harbor change | Patch version bump |
 | `feat!` / `fix!` | Breaking change | Major version bump |
+| `chart` | Helm chart change outside `deploy/chart` (release plumbing, chart workflows) | Chart release line only; hidden from app release notes. Never use `chart!:` or a `BREAKING CHANGE:` footer — breaking commits always render in app release notes (the pr-title check rejects `chart!:`) |
 | `refactor` | Code change, no behaviour change | No release |
 | `docs` | Documentation only | No release |
 | `ci` | CI/CD pipeline changes | No release |

--- a/release-please-config-chart.json
+++ b/release-please-config-chart.json
@@ -16,7 +16,8 @@
     {"type": "test",     "section": "Tests", "hidden": true},
     {"type": "chore",    "section": "Miscellaneous", "hidden": true},
     {"type": "ci",       "section": "CI/CD",        "hidden": true},
-    {"type": "build",    "section": "Build System", "hidden": true}
+    {"type": "build",    "section": "Build System", "hidden": true},
+    {"type": "chart",    "section": "Chart Changes"}
   ],
   "packages": {
     "deploy/chart": {
@@ -24,7 +25,8 @@
       "package-name": "harbor",
       "component": "chart",
       "include-component-in-tag": true,
-      "changelog-path": "CHANGELOG.md"
+      "changelog-path": "CHANGELOG.md",
+      "release-as": "2.0.0"
     }
   }
 }

--- a/release-please-config-maintenance.json
+++ b/release-please-config-maintenance.json
@@ -18,7 +18,8 @@
     {"type": "test",     "section": "Tests", "hidden": true},
     {"type": "chore",    "section": "Miscellaneous", "hidden": true},
     {"type": "ci",       "section": "CI/CD",          "hidden": true},
-    {"type": "build",    "section": "Build System",   "hidden": true}
+    {"type": "build",    "section": "Build System",   "hidden": true},
+    {"type": "chart",    "section": "Chart",          "hidden": true}
   ],
   "packages": {
     ".": {

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -20,7 +20,8 @@
     {"type": "test",     "section": "Tests", "hidden": true},
     {"type": "chore",    "section": "Miscellaneous", "hidden": true},
     {"type": "ci",       "section": "CI/CD",          "hidden": true},
-    {"type": "build",    "section": "Build System",   "hidden": true}
+    {"type": "build",    "section": "Build System",   "hidden": true},
+    {"type": "chart",    "section": "Chart",          "hidden": true}
   ],
   "packages": {
     ".": {}


### PR DESCRIPTION
Introduces the `chart:` commit type so Helm-chart work never surfaces in app release notes, and forces the chart release line back to **2.0.0** (fixes #818 proposing 1.1.0).

## What

- **App + maintenance release-please configs**: `chart` type added as hidden. Catches chart plumbing commits outside `deploy/chart` (which `exclude-paths` cannot catch — e.g. #812/#813 touched root configs, CONTRIBUTING.md, deploy/flux). Commits touching only `deploy/chart` were already path-excluded.
- **Chart release-please config**: `chart` commits render as a visible **Chart Changes** section; one-shot `"release-as": "2.0.0"` re-added so #818 regenerates as **harbor chart 2.0.0** (the rename commit is deliberately non-breaking `chart:` — a `chart!:` would re-leak a BREAKING CHANGES entry into app notes, since release-please always renders breaking commits even for hidden types).
- **pr-title check** accepts `chart`; **CONTRIBUTING** documents the type.

## ⚠ Follow-up required

Remove `"release-as": "2.0.0"` from `release-please-config-chart.json` immediately after harbor chart v2.0.0 ships — leftover release-as pins every future chart release (the #728 bug, removed once already in #812).

## Context

main history was rewritten (user-authorized force-push): `feat!:` #813 → `chart:`, `ci:` #812 → `chart:`, so the v2.16.0 release notes regenerate without the chart BREAKING CHANGES entry.