### PR TITLE
ci: Adopt GitHub self-repository syntax for local actions and workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,12 +36,12 @@ jobs:
         with:
           persist-credentials: false
 
-      - uses: ./.github/actions/setup-go-cached
+      - uses: $/.github/actions/setup-go-cached
         with:
           go-version-file: src/go.mod
           go-sum-path: src/go.sum
 
-      - uses: ./.github/actions/setup-task
+      - uses: $/.github/actions/setup-task
         with:
           version: 3.49.1
 

--- a/.github/workflows/chart-ci.yml
+++ b/.github/workflows/chart-ci.yml
@@ -39,7 +39,7 @@ jobs:
           } >> "$GITHUB_ENV"
 
       - name: Install Task
-        uses: ./.github/actions/setup-task
+        uses: $/.github/actions/setup-task
 
       - name: Install Helm
         uses: azure/setup-helm@9bc31f4ebc9c6b171d7bfbaa5d006ae7abdb4310 # v5.0.1

--- a/.github/workflows/compose-ci.yml
+++ b/.github/workflows/compose-ci.yml
@@ -25,7 +25,7 @@ jobs:
         run: grep -E '^[A-Z_]+=' versions.env >> "$GITHUB_ENV"
 
       - name: Install Task
-        uses: ./.github/actions/setup-task
+        uses: $/.github/actions/setup-task
 
       - name: Install ys (YAMLScript)
         run: |

--- a/.github/workflows/lint-actions.yml
+++ b/.github/workflows/lint-actions.yml
@@ -28,8 +28,8 @@ jobs:
             while IFS= read -r line; do
               if echo "$line" | grep -qE '^\s+uses:\s+'; then
                 ref=$(echo "$line" | sed 's/.*uses:[[:space:]]*//' | awk '{print $1}')
-                # Skip local actions (starting with ./) and docker:// references
-                if echo "$ref" | grep -qE '^(\.\/|docker://)'; then
+                # Skip local actions (./ or the self-repository $/ form) and docker:// references
+                if echo "$ref" | grep -qE '^(\.\/|\$\/|docker://)'; then
                   continue
                 fi
                 if ! echo "$ref" | grep -qE '@[a-f0-9]{40}'; then

--- a/.github/workflows/lint-go.yml
+++ b/.github/workflows/lint-go.yml
@@ -40,12 +40,12 @@ jobs:
         with:
           persist-credentials: false
 
-      - uses: ./.github/actions/setup-go-cached
+      - uses: $/.github/actions/setup-go-cached
         with:
           go-version-file: src/go.mod
           go-sum-path: src/go.sum
 
-      - uses: ./.github/actions/setup-task
+      - uses: $/.github/actions/setup-task
         with:
           version: 3.49.1
 

--- a/.github/workflows/lint-ui.yml
+++ b/.github/workflows/lint-ui.yml
@@ -42,7 +42,7 @@ jobs:
         with:
           persist-credentials: false
 
-      - uses: ./.github/actions/setup-task
+      - uses: $/.github/actions/setup-task
         with:
           version: 3.49.1
 

--- a/.github/workflows/main-images.yml
+++ b/.github/workflows/main-images.yml
@@ -38,7 +38,7 @@ jobs:
     permissions:
       contents: read
       id-token: write
-    uses: ./.github/workflows/publish-images.yml
+    uses: $/.github/workflows/publish-images.yml
     with:
       checkout_ref: ${{ github.event.workflow_run.head_sha }}
       image_tag: latest

--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -76,13 +76,13 @@ jobs:
         run: grep -E '^[A-Z_]+=' versions.env >> "$GITHUB_ENV"
 
       - name: Setup Go
-        uses: ./.github/actions/setup-go-cached
+        uses: $/.github/actions/setup-go-cached
         with:
           go-version-file: src/go.mod
           go-sum-path: src/go.sum
 
       - name: Install Task
-        uses: ./.github/actions/setup-task
+        uses: $/.github/actions/setup-task
         with:
           version: 3.49.1
 
@@ -222,7 +222,7 @@ jobs:
           persist-credentials: false
 
       - name: Setup Go
-        uses: ./.github/actions/setup-go-cached
+        uses: $/.github/actions/setup-go-cached
         with:
           go-version-file: src/go.mod
           go-sum-path: src/go.sum

--- a/.github/workflows/publish-images.yml
+++ b/.github/workflows/publish-images.yml
@@ -71,7 +71,7 @@ jobs:
           persist-credentials: false
 
       - name: Install Task
-        uses: ./.github/actions/setup-task
+        uses: $/.github/actions/setup-task
         with:
           version: 3.49.1
 
@@ -103,7 +103,7 @@ jobs:
 
       # Root Taskfile evaluation reads Go cache paths, even for apply-patches.
       - name: Setup Go
-        uses: ./.github/actions/setup-go-cached
+        uses: $/.github/actions/setup-go-cached
         with:
           go-version-file: src/go.mod
           go-sum-path: src/go.sum

--- a/.github/workflows/release-notes-engine.yml
+++ b/.github/workflows/release-notes-engine.yml
@@ -60,12 +60,12 @@ jobs:
           node-version: 24
           package-manager-cache: false
 
-      - uses: ./.github/actions/setup-go-cached
+      - uses: $/.github/actions/setup-go-cached
         with:
           go-version-file: src/go.mod
           go-sum-path: src/go.sum
 
-      - uses: ./.github/actions/setup-task
+      - uses: $/.github/actions/setup-task
 
       - name: Install gh CLI
         run: |

--- a/.github/workflows/release-notes.yml
+++ b/.github/workflows/release-notes.yml
@@ -17,7 +17,7 @@ jobs:
   recreate:
     permissions:
       contents: write
-    uses: ./.github/workflows/release-notes-engine.yml
+    uses: $/.github/workflows/release-notes-engine.yml
     with:
       tag_name: ${{ inputs.tag_name || github.ref_name }}
       dry_run: ${{ inputs.dry_run }}

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -131,7 +131,7 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
-    uses: ./.github/workflows/release-notes-engine.yml
+    uses: $/.github/workflows/release-notes-engine.yml
     with:
       checkout_ref: ${{ fromJSON(needs.release-please.outputs.prs)[0].headBranchName }}
       preview_pr_number: ${{ fromJSON(needs.release-please.outputs.prs)[0].number }}
@@ -237,7 +237,7 @@ jobs:
     permissions:
       contents: read
       id-token: write
-    uses: ./.github/workflows/publish-images.yml
+    uses: $/.github/workflows/publish-images.yml
     with:
       checkout_ref: ${{ needs.release-please.outputs.tag_name }}
       image_tag: ${{ needs.release-please.outputs.tag_name }}
@@ -253,7 +253,7 @@ jobs:
     if: ${{ needs.release-please.outputs.release_created == 'true' }}
     permissions:
       contents: write
-    uses: ./.github/workflows/release-notes-engine.yml
+    uses: $/.github/workflows/release-notes-engine.yml
     with:
       tag_name: ${{ needs.release-please.outputs.tag_name }}
     secrets:
@@ -270,7 +270,7 @@ jobs:
     permissions:
       contents: read
       id-token: write
-    uses: ./.github/workflows/publish-chart.yml
+    uses: $/.github/workflows/publish-chart.yml
     with:
       tag_name: ${{ needs.release-please-chart.outputs.tag_name }}
     secrets:
@@ -283,7 +283,7 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
-    uses: ./.github/workflows/release-notes-engine.yml
+    uses: $/.github/workflows/release-notes-engine.yml
     with:
       checkout_ref: ${{ fromJSON(needs.release-please-chart.outputs.prs)[0].headBranchName }}
       preview_pr_number: ${{ fromJSON(needs.release-please-chart.outputs.prs)[0].number }}
@@ -298,7 +298,7 @@ jobs:
     if: ${{ needs.release-please-chart.outputs.release_created == 'true' }}
     permissions:
       contents: write
-    uses: ./.github/workflows/release-notes-engine.yml
+    uses: $/.github/workflows/release-notes-engine.yml
     with:
       tag_name: ${{ needs.release-please-chart.outputs.tag_name }}
       component: chart
@@ -356,7 +356,7 @@ jobs:
           } >> "$GITHUB_ENV"
 
       - name: Install Task
-        uses: ./.github/actions/setup-task
+        uses: $/.github/actions/setup-task
 
       - name: Install Helm
         uses: azure/setup-helm@dda3372f752e03dde6b3237bc9431cdc2f7a02a2 # v5.0.0

--- a/.github/workflows/release-ready.yml
+++ b/.github/workflows/release-ready.yml
@@ -24,7 +24,7 @@ jobs:
           # without mutating the workflow's source tree.
           fetch-depth: 0
 
-      - uses: ./.github/actions/setup-task
+      - uses: $/.github/actions/setup-task
         with:
           version: 3.49.1
 
@@ -56,7 +56,7 @@ jobs:
 
       # Root Taskfile evaluation reads Go cache paths.
       - name: Setup Go
-        uses: ./.github/actions/setup-go-cached
+        uses: $/.github/actions/setup-go-cached
         with:
           go-version-file: src/go.mod
           go-sum-path: src/go.sum

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -42,12 +42,12 @@ jobs:
         with:
           persist-credentials: false
 
-      - uses: ./.github/actions/setup-go-cached
+      - uses: $/.github/actions/setup-go-cached
         with:
           go-version-file: src/go.mod
           go-sum-path: src/go.sum
 
-      - uses: ./.github/actions/setup-task
+      - uses: $/.github/actions/setup-task
         with:
           version: 3.49.1
 
@@ -144,12 +144,12 @@ jobs:
             exit 1
           fi
 
-      - uses: ./.github/actions/setup-go-cached
+      - uses: $/.github/actions/setup-go-cached
         with:
           go-version-file: src/go.mod
           go-sum-path: src/go.sum
 
-      - uses: ./.github/actions/setup-task
+      - uses: $/.github/actions/setup-task
         with:
           version: 3.49.1
 
@@ -183,12 +183,12 @@ jobs:
         with:
           persist-credentials: false
 
-      - uses: ./.github/actions/setup-go-cached
+      - uses: $/.github/actions/setup-go-cached
         with:
           go-version-file: src/go.mod
           go-sum-path: src/go.sum
 
-      - uses: ./.github/actions/setup-task
+      - uses: $/.github/actions/setup-task
         with:
           version: 3.49.1
 

--- a/.github/workflows/vulnerability-check.yml
+++ b/.github/workflows/vulnerability-check.yml
@@ -25,7 +25,7 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
 
-      - uses: ./.github/actions/setup-go-cached
+      - uses: $/.github/actions/setup-go-cached
         with:
           go-version-file: src/go.mod
           go-sum-path: src/go.sum
@@ -35,7 +35,7 @@ jobs:
           node-version: 24
           package-manager-cache: false
 
-      - uses: ./.github/actions/setup-task
+      - uses: $/.github/actions/setup-task
         with:
           version: 3.49.1
 


### PR DESCRIPTION
Repo-wide sweep: every `uses: ./…` → `uses: $/…` (GitHub's July-2026 self-repository form), clearing all zizmor `self-repository` code-scanning notes.

Why it's better than `./`: the `$/` form resolves from the repository at the workflow's commit, not from runtime filesystem state — a checkout cloned mid-job can never substitute a local action, and GitHub can enforce a fully-pinned policy on it.

Also updates the pinned-SHA check (`lint-actions.yml`) to exempt `$/` refs the same way it exempts `./`.

**Merge before #814/#796** — their branches adopt `$/` on their new lines and need the updated pinned-SHA exemption from this PR.