### PR TITLE
ci: Render chart commits under Updates in release notes

### DIFF
--- a/.github/scripts/format-release-notes.mjs
+++ b/.github/scripts/format-release-notes.mjs
@@ -20,6 +20,7 @@ const sectionNames = new Map([
   ['Bug Fixes', 'Fixes'],
   ['Performance Improvements', 'Updates'],
   ['Code Refactoring', 'Updates'],
+  ['Chart Changes', 'Updates'],
 ]);
 const droppedSections = new Set(['Documentation']);
 const sectionOrder = ['Commercial Features', 'Features', 'Fixes', 'Updates', 'Upstream', 'Reverts'];


### PR DESCRIPTION
Folds the `Chart Changes` changelog section into the existing **Updates** bucket in engine-rendered release notes (same treatment as Performance Improvements / Code Refactoring). The chart CHANGELOG.md keeps its own heading; only the rendered What's Changed grouping changes.

Bonus: merging this pushes main, and thanks to #824 the open chart release PR #822 re-renders its preview automatically — the rename entry will move under Updates there.