### PR TITLE
chart: Remove one-shot release-as after harbor chart 2.0.0

### DIFF
--- a/release-please-config-chart.json
+++ b/release-please-config-chart.json
@@ -8,16 +8,50 @@
   "include-v-in-tag": true,
   "tag-separator": "-",
   "changelog-sections": [
-    {"type": "feat",     "section": "Features"},
-    {"type": "fix",      "section": "Bug Fixes"},
-    {"type": "perf",     "section": "Performance Improvements"},
-    {"type": "refactor", "section": "Code Refactoring"},
-    {"type": "docs",     "section": "Documentation"},
-    {"type": "test",     "section": "Tests", "hidden": true},
-    {"type": "chore",    "section": "Miscellaneous", "hidden": true},
-    {"type": "ci",       "section": "CI/CD",        "hidden": true},
-    {"type": "build",    "section": "Build System", "hidden": true},
-    {"type": "chart",    "section": "Chart Changes"}
+    {
+      "type": "feat",
+      "section": "Features"
+    },
+    {
+      "type": "fix",
+      "section": "Bug Fixes"
+    },
+    {
+      "type": "perf",
+      "section": "Performance Improvements"
+    },
+    {
+      "type": "refactor",
+      "section": "Code Refactoring"
+    },
+    {
+      "type": "docs",
+      "section": "Documentation"
+    },
+    {
+      "type": "test",
+      "section": "Tests",
+      "hidden": true
+    },
+    {
+      "type": "chore",
+      "section": "Miscellaneous",
+      "hidden": true
+    },
+    {
+      "type": "ci",
+      "section": "CI/CD",
+      "hidden": true
+    },
+    {
+      "type": "build",
+      "section": "Build System",
+      "hidden": true
+    },
+    {
+      "type": "chart",
+      "section": "Chart Changes"
+    }
   ],
   "packages": {
     "deploy/chart": {
@@ -25,8 +59,7 @@
       "package-name": "harbor",
       "component": "chart",
       "include-component-in-tag": true,
-      "changelog-path": "CHANGELOG.md",
-      "release-as": "2.0.0"
+      "changelog-path": "CHANGELOG.md"
     }
   }
 }


### PR DESCRIPTION
harbor chart v2.0.0 has shipped (#822); this removes the one-shot `release-as: "2.0.0"` from the chart release-please config. Leaving it pins every future chart release to 2.0.0 (the #728 bug, removed once already in #812).

**Merge before the next release run** — the `Reject leftover chart release-as` gate (#820) fails the release pipeline while this line coexists with the chart-v2.0.0 tag.