### PR TITLE
ci: Install oras via direct release download in publish-chart

### DIFF
--- a/.github/workflows/publish-chart.yml
+++ b/.github/workflows/publish-chart.yml
@@ -185,10 +185,24 @@ jobs:
             "${REGISTRY_ADDRESS}/${REGISTRY_PROJECT}/charts/harbor@${CHART_DIGEST}"
 
       - name: Install oras
-        uses: oras-project/setup-oras@1d808f7d7f6995cc68b7bf507bfe5c5446e1dc9d # v2.0.1
-        with:
-          # Retry source may be an old release tag with a stale versions.env.
-          version: ${{ env.ORAS_VERSION }}
+        # Direct download: setup-oras rejects versions its list lags behind.
+        run: |
+          set -euo pipefail
+          case "$(uname -m)" in
+            x86_64|amd64) goarch="amd64" ;;
+            aarch64|arm64) goarch="arm64" ;;
+            *) echo "unsupported arch: $(uname -m)" >&2; exit 1 ;;
+          esac
+          archive="oras_${ORAS_VERSION}_linux_${goarch}.tar.gz"
+          tool_dir="${RUNNER_TEMP}/oras"
+          release_url="https://github.com/oras-project/oras/releases/download/v${ORAS_VERSION}"
+          mkdir -p "${tool_dir}/bin"
+          curl -fsSL "${release_url}/${archive}" -o "${tool_dir}/${archive}"
+          curl -fsSL "${release_url}/oras_${ORAS_VERSION}_checksums.txt" -o "${tool_dir}/checksums.txt"
+          # Anchored match: checksums.txt also lists ${archive}.sbom.json.
+          (cd "${tool_dir}" && grep "  ${archive}$" checksums.txt | sha256sum -c -)
+          tar -xzf "${tool_dir}/${archive}" -C "${tool_dir}/bin" oras
+          echo "${tool_dir}/bin" >> "$GITHUB_PATH"
 
       - name: Push Artifact Hub repository metadata
         # artifacthub-repo.yml rides next to the chart as an OCI artifact


### PR DESCRIPTION
The chart-v2.0.0 publish failed at `Install oras`: renovate bumped `ORAS_VERSION` to 1.3.4, and `setup-oras` (even its main branch) validates against a built-in checksum list that lags oras releases — it refuses versions it does not know. The chart itself pushed and signed fine; only the Artifact Hub metadata step was skipped.

Replaces the action with a checksum-verified direct download (identical pattern to the `ah` CLI step in the same job — this job holds registry credentials, so downloads stay sha256-verified). Removes the action-lag failure class entirely; renovate can keep bumping `ORAS_VERSION` freely.

**After merge:** re-run via `Publish Helm Chart` workflow_dispatch with `tag_name=chart-v2.0.0` to complete the skipped Artifact Hub metadata push (chart push/sign are idempotent).