### PR TITLE
ci: Consume Patch Stream chains in release notes and dispatch release cuts

### DIFF
--- a/.github/scripts/update-release-notes.sh
+++ b/.github/scripts/update-release-notes.sh
@@ -169,27 +169,103 @@ export GIT_ASKPASS="${askpass_script}" GIT_TERMINAL_PROMPT=0 PATCHES_TOKEN
 git init --bare "${tmp_dir}/patches-repo"
 patches_remote="https://x-access-token@github.com/container-registry/8gcr"
 series="taskfile/commercial-patches"
+stacks_file="taskfile/commercial-patch-stacks"
 patch_notes="${tmp_dir}/commercial-patches.md"
+prepo() { git -C "${tmp_dir}/patches-repo" "$@"; }
 
 # The Harbor branch owns the ordered manifest. 8gcr only stores the branch
 # commits, so release notes and image builds always use the same exact list.
+#
+# Patch Stream: this release's delta per branch = chain PRs not in the previous
+# patch-record tag's "prs=" set. No patch-base ref yet -> flat tip-subject list.
 if [[ "${chart_mode}" == false && -f "${series}" ]]; then
+  branches=()
   while IFS= read -r branch; do
     branch="${branch%%#*}"
     branch="${branch#"${branch%%[![:space:]]*}"}"
     branch="${branch%"${branch##*[![:space:]]}"}"
     [[ -z "${branch}" ]] && continue
-
     if ! git check-ref-format --branch "${branch}" >/dev/null 2>&1; then
       echo "Invalid commercial branch name in series: ${branch}" >&2
       exit 1
     fi
-
-    git -C "${tmp_dir}/patches-repo" fetch --depth=1 "${patches_remote}" \
-      "${branch}:refs/remotes/origin/${branch}"
-    echo "- $(git -C "${tmp_dir}/patches-repo" log -1 --format=%s "refs/remotes/origin/${branch}")" \
-      >> "${patch_notes}"
+    branches+=("${branch}")
   done < "${series}"
+
+  base_ref="patch-base/${release_branch}"
+  if prepo fetch --depth=1 "${patches_remote}" \
+      "+refs/heads/${base_ref}:refs/heads/${base_ref}" 2>/dev/null; then
+    # previous record: highest patch-record semver strictly below this tag
+    record_ver=$( {
+        prepo ls-remote "${patches_remote}" 'refs/tags/patch-record/*' \
+          | awk '{ sub(/\^\{\}$/, "", $2); sub(/^refs\/tags\/patch-record\/v/, "", $2); print $2 }'
+        echo "${version}"
+      } | sort -u -V | awk -v c="${version}" '$0 == c { exit } { last = $0 } END { if (last != "") print last }')
+    record_tag=""
+    [[ -n "${record_ver}" ]] && record_tag="patch-record/v${record_ver}"
+    seen_file="${tmp_dir}/record-msg.txt"
+    : > "${seen_file}"
+    if [[ -n "${record_tag}" ]]; then
+      prepo fetch --depth=1 "${patches_remote}" \
+        "+refs/tags/${record_tag}:refs/tags/${record_tag}"
+      prepo tag -l --format='%(contents)' "${record_tag}" > "${seen_file}"
+    fi
+
+    unchanged=()
+    for branch in "${branches[@]}"; do
+      # chains only: everything newer than the pinned baseline
+      prepo fetch --shallow-exclude="${base_ref}" "${patches_remote}" \
+        "+refs/heads/${branch}:refs/remotes/origin/${branch}"
+      excl=()
+      if [[ -f "${stacks_file}" ]]; then
+        stack_parent=$(awk -v b="${branch}" '{ sub(/#.*/, "") } NF == 2 && $1 == b { print $2 }' "${stacks_file}")
+        [[ -n "${stack_parent}" ]] && excl=("^refs/remotes/origin/${stack_parent}")
+      fi
+      mapfile -t chain < <(prepo log --reverse --format=%H \
+        "refs/remotes/origin/${branch}" "${excl[@]}" 2>/dev/null || true)
+      if [[ "${#chain[@]}" -eq 0 ]]; then
+        echo "commercial branch has no chain above ${base_ref}: ${branch}" >&2
+        exit 1
+      fi
+      title=$(prepo log -1 --format=%s "${chain[0]}")
+      seen=$(awk -v b="${branch}" '$1 == b { sub(/^prs=/, "", $3); gsub(/,/, "\n", $3); print $3 }' "${seen_file}")
+      section=""
+      for c in "${chain[@]}"; do
+        subj=$(prepo log -1 --format=%s "${c}")
+        pr=$(sed -n 's/.* (#\([0-9][0-9]*\))$/\1/p' <<< "${subj}")
+        [[ -z "${pr}" ]] && continue
+        grep -qx "${pr}" <<< "${seen}" && continue
+        section+="- ${subj}"$'\n'
+        section+=$(prepo log -1 --format=%b "${c}" | awk '
+          /^## Release Notes[[:space:]]*$/ { grab=1; next }
+          /^## / { grab=0 }
+          grab && NF { print "  " $0 }
+        ')
+        section="${section%$'\n'}"$'\n'
+      done
+      if [[ -n "${section}" ]]; then
+        {
+          echo "### ${title}"
+          printf '%s' "${section}"
+          echo
+        } >> "${patch_notes}"
+      else
+        unchanged+=("${title}")
+      fi
+    done
+    if [[ "${#unchanged[@]}" -gt 0 && -s "${patch_notes}" ]]; then
+      titles=$(printf '%s, ' "${unchanged[@]}")
+      echo "_No changes this release:_ ${titles%, }" >> "${patch_notes}"
+    fi
+  else
+    # legacy (pre-Patch-Stream): flat list of branch tip subjects
+    for branch in "${branches[@]}"; do
+      prepo fetch --depth=1 "${patches_remote}" \
+        "+refs/heads/${branch}:refs/remotes/origin/${branch}"
+      echo "- $(prepo log -1 --format=%s "refs/remotes/origin/${branch}")" \
+        >> "${patch_notes}"
+    done
+  fi
 fi
 
 {

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -286,6 +286,48 @@ jobs:
     secrets:
       SYNC_APP_PRIVATE_KEY: ${{ secrets.SYNC_APP_PRIVATE_KEY }}
 
+  # After notes render (render first, stamp second), tell 8gcr to bump
+  # patch baselines onto the released commit and stamp patch-record/<tag>.
+  dispatch-release-cut:
+    name: Dispatch Release Cut
+    needs: [release-please, update-release-notes]
+    if: ${{ needs.release-please.outputs.release_created == 'true' }}
+    runs-on: ubuntu-26.04
+    timeout-minutes: 5
+    permissions:
+      contents: read
+    steps:
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          app-id: ${{ vars.SYNC_APP_ID }}
+          private-key: ${{ secrets.SYNC_APP_PRIVATE_KEY }}
+          owner: container-registry
+          repositories: 8gcr
+          # Explicit scope (zizmor github-app): repository_dispatch needs
+          # contents write; without this the token inherits every
+          # permission of the app installation.
+          permission-contents: write
+
+      - name: Trigger patch-bump + record
+        env:
+          TOKEN: ${{ steps.app-token.outputs.token }}
+          TAG: ${{ needs.release-please.outputs.tag_name }}
+          TARGET_SHA: ${{ github.sha }}
+          LINE: ${{ github.ref_name }}
+        run: |
+          # jq --arg: tag/branch values must be JSON-escaped, not interpolated.
+          jq -cn --arg tag "${TAG}" --arg sha "${TARGET_SHA}" --arg line "${LINE}" \
+            '{event_type: "release-cut", client_payload: {tag: $tag, target_sha: $sha, line: $line}}' \
+            | curl -f -X POST \
+                -H "Accept: application/vnd.github+json" \
+                -H "Content-Type: application/json" \
+                -H "X-GitHub-Api-Version: 2022-11-28" \
+                -H "Authorization: Bearer ${TOKEN}" \
+                "https://api.github.com/repos/container-registry/8gcr/dispatches" \
+                --data-binary @-
+
   chart:
     name: Publish Helm Chart
     # Driven by the chart's own release-please line (release-please-chart),


### PR DESCRIPTION
Split 2/4 of #819 (core; backward-compatible — falls back to today's flat tip-subject list until 8gcr seeds `patch-base/*`): release notes compute each release's commercial delta as chain PRs absent from the previous `patch-record` tag (rebase-proof), and a post-notes `dispatch-release-cut` job tells 8gcr to bump baselines and stamp `patch-record/<tag>`. Payloads jq-built, token contents-scoped.

Open cubic finding inherited from #819 for the author: the patch-record selector should match records by `line:` before computing the seen-PR set.