### PR TITLE
chore: Declare commercial patch branch stacking

### DIFF
--- a/taskfile/commercial-patch-stacks
+++ b/taskfile/commercial-patch-stacks
@@ -1,0 +1,4 @@
+# Declared stacking between commercial patch branches: "child parent".
+# A stacked child's chain roots on its parent's tip instead of the pinned
+# baseline. Gates verify this exact shape — stacking is never inferred.
+0006-aws-rds-iam-auth 0005-pgx-monitoring


### PR DESCRIPTION
⚠️ **Split 4/4 of #819 — DO NOT MERGE until the 8gcr Patch Stream restack (8gcr#389) cutover.** Declares 0006-aws-rds-iam-auth stacked on 0005-pgx-monitoring; against the current octopus-merged topology this declaration makes `task apply-patches`/`release-ready` fail (cubic's finding on #819).