### PR TITLE
fix(orm): Detach AfterCommit hooks from a cloned or copied context

### DIFF
--- a/src/lib/orm/orm.go
+++ b/src/lib/orm/orm.go
@@ -85,6 +85,17 @@ func NewContext(ctx context.Context, o orm.QueryExecutor) context.Context {
 	if ctx == nil {
 		ctx = context.Background()
 	}
+	if _, isTx := o.(orm.TxOrmer); !isTx {
+		// A non-transactional ormer opens its own database session, so a hooks
+		// sink inherited through ctx (Clone, Copy) belongs to a transaction this
+		// session is not part of. Detach it, otherwise AfterCommit would queue
+		// into a scope that may already have committed and drained, and
+		// WithTransaction would hand its hooks to that scope instead of firing
+		// them after its own commit.
+		if _, inherited := ctx.Value(hooksKey{}).(*txHooks); inherited {
+			ctx = context.WithValue(ctx, hooksKey{}, (*txHooks)(nil))
+		}
+	}
 	return context.WithValue(ctx, ormKey{}, o)
 }
 

--- a/src/lib/orm/test/orm_test.go
+++ b/src/lib/orm/test/orm_test.go
@@ -569,6 +569,60 @@ func (suite *OrmSuite) TestAfterCommit_RejectsCompletedNestedContext() {
 	suite.False(secondScopeRan, "a completed transaction context must be rejected before starting DB work")
 }
 
+// TestAfterCommit_IndependentTxFromCopiedContext asserts that a transaction
+// started from a Copy or Clone of a transaction context is independent: it
+// fires its own hooks on its own commit instead of handing them to the scope
+// it was copied from. This is the background-handler pattern (notifier,
+// retention, proxy) where the enclosing scope may already have drained by the
+// time the copied context is used.
+func (suite *OrmSuite) TestAfterCommit_IndependentTxFromCopiedContext() {
+	for name, derive := range map[string]func(context.Context) context.Context{
+		"copy":  Copy,
+		"clone": Clone,
+	} {
+		suite.Run(name, func() {
+			ctx := NewContext(context.TODO(), orm.NewOrm())
+
+			var ranInner, ranInnerBeforeOuterCommit, ranOuter bool
+			err := WithTransaction(func(outerCtx context.Context) error {
+				AfterCommit(outerCtx, func() { ranOuter = true })
+
+				err := WithTransaction(func(innerCtx context.Context) error {
+					AfterCommit(innerCtx, func() { ranInner = true })
+					return nil
+				})(derive(outerCtx))
+				if err != nil {
+					return err
+				}
+				// The derived transaction has committed on its own session.
+				ranInnerBeforeOuterCommit = ranInner
+				suite.False(ranOuter, "outer hook must wait for the outer commit")
+				return nil
+			})(ctx)
+
+			suite.NoError(err)
+			suite.True(ranInnerBeforeOuterCommit, "independent tx must fire its hooks on its own commit, not be adopted by the enclosing scope")
+			suite.True(ranOuter)
+		})
+	}
+}
+
+// TestAfterCommit_CopiedContextOutsideTxRunsInline asserts that AfterCommit
+// called with a Copy of a transaction context, but outside any transaction of
+// its own, runs the callback inline rather than queueing it into the sink of
+// the transaction it was copied from.
+func (suite *OrmSuite) TestAfterCommit_CopiedContextOutsideTxRunsInline() {
+	ctx := NewContext(context.TODO(), orm.NewOrm())
+
+	var ranInline bool
+	err := WithTransaction(func(txCtx context.Context) error {
+		AfterCommit(Copy(txCtx), func() { ranInline = true })
+		suite.True(ranInline, "a copied context is not inside this transaction; the hook must run inline")
+		return nil
+	})(ctx)
+	suite.NoError(err)
+}
+
 func (suite *OrmSuite) TestReadOrCreate() {
 	ctx := NewContext(context.TODO(), orm.NewOrm())
 

--- a/src/pkg/cached/artifact/redis/manager_test.go
+++ b/src/pkg/cached/artifact/redis/manager_test.go
@@ -238,17 +238,24 @@ func (m *managerTestSuite) TestDelete_ConcurrentInlineCleanup() {
 	m.cache.On("Fetch", mock.Anything, mock.Anything, mock.Anything).Return(nil)
 	m.cache.On("Delete", mock.Anything, mock.Anything).Return(nil)
 
+	const deletes = 2
+	errs := make(chan error, deletes)
 	var wg sync.WaitGroup
-	for i := 0; i < 2; i++ {
+	for i := 0; i < deletes; i++ {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			_ = m.cachedManager.Delete(m.ctx, 1)
+			errs <- m.cachedManager.Delete(m.ctx, 1)
 		}()
 	}
 	wg.Wait()
+	close(errs)
+	for err := range errs {
+		m.NoError(err)
+	}
 
-	m.cache.AssertCalled(m.T(), "Delete", mock.Anything, mock.Anything)
+	// each Delete evicts two keys (by id and by repository+digest)
+	m.cache.AssertNumberOfCalls(m.T(), "Delete", deletes*2)
 }
 
 // TestScheduleCleanUp_DefersViaAfterCommit verifies the in-transaction


### PR DESCRIPTION
## Summary

`orm.Clone` and `orm.Copy` install a fresh `orm.NewOrm()` but keep the parent's context values, so a transaction started from a copied transaction context still found the enclosing `AfterCommit` hooks sink. It committed on its own session and then handed its hooks to a scope that had possibly already committed and drained. The same context used outside any transaction of its own queued the callback into that foreign sink instead of running it inline. Either way the cache eviction was delayed or lost. This is the background-handler pattern in `pkg/notifier`, `controller/retention` and `controller/proxy`.

`NewContext` now detaches an inherited sink whenever it installs a non-transactional ormer, so a `Clone` or `Copy` carries no scope: a transaction started from it fires its own hooks after its own commit, and `AfterCommit` on it runs inline.

Found by Copilot review on goharbor/harbor#23114; this PR mirrors the upstream fix so the cherry-pick applies without conflicts.

## Tests

- `TestAfterCommit_IndependentTxFromCopiedContext` (Copy and Clone subtests) and `TestAfterCommit_CopiedContextOutsideTxRunsInline` in `lib/orm/test`. Both fail before this change and pass after.
- `TestDelete_ConcurrentInlineCleanup` in `pkg/cached/artifact/redis` now collects the `Delete` errors and asserts the exact eviction count (2 deletes × 2 keys) instead of "called at least once".
- `OrmSuite` (`-tags db`) and `pkg/cached/...` pass under `-race` against Postgres.

## Upstream sync note

After this merges, the cherry-pick of goharbor/harbor#23114 applies cleanly except for `src/pkg/cached/project_metadata/redis/manager.go`, whose remaining hunk comes from goharbor/harbor#23762 (`UpdateWithValidation` + `cleanUpAll`), already open as #731. Resolve #731 so that file matches the upstream version of #23114 and the later pick is conflict-free. Verified by simulating the squash-and-cherry-pick locally.
