### PR TITLE
fix: Skip empty component Secrets when identity is fully externalized

### DIFF
--- a/deploy/chart/README.md
+++ b/deploy/chart/README.md
@@ -684,6 +684,9 @@ ingress:
 
 Notes:
 
+- Chart-managed component Secrets that would end up empty (everything
+  externalized) are skipped entirely, together with their `envFrom`
+  references — a fully pinned install creates no empty Secrets.
 - A complete Flux setup (GitRepository + HelmRelease with drift detection
   + prerequisite Secret manifests with generation commands) lives at
   [`example/flux/`](example/flux/). The same values work unchanged in an

--- a/deploy/chart/README.md.gotmpl
+++ b/deploy/chart/README.md.gotmpl
@@ -685,6 +685,9 @@ ingress:
 
 Notes:
 
+- Chart-managed component Secrets that would end up empty (everything
+  externalized) are skipped entirely, together with their `envFrom`
+  references — a fully pinned install creates no empty Secrets.
 - A complete Flux setup (GitRepository + HelmRelease with drift detection
   + prerequisite Secret manifests with generation commands) lives at
   [`example/flux/`](example/flux/). The same values work unchanged in an

--- a/deploy/chart/templates/_helpers.tpl
+++ b/deploy/chart/templates/_helpers.tpl
@@ -512,6 +512,31 @@ Resolution order:
 
 {{/*
 =============================================================================
+Secret content predicates
+=============================================================================
+Each renders its component's secretData define (the single source of truth,
+colocated with the Secret template) and returns "true" only when it is
+non-empty, so a fully externalized (GitOps) install creates no empty
+Secrets and no dangling secretRefs.
+*/}}
+{{- define "harbor.core.secretHasData" -}}
+{{- if include "harbor.core.secretData" . | trim -}}true{{- end -}}
+{{- end -}}
+
+{{- define "harbor.registry.secretHasData" -}}
+{{- if include "harbor.registry.secretData" . | trim -}}true{{- end -}}
+{{- end -}}
+
+{{- define "harbor.jobservice.secretHasData" -}}
+{{- if include "harbor.jobservice.secretData" . | trim -}}true{{- end -}}
+{{- end -}}
+
+{{- define "harbor.registryctl.secretHasData" -}}
+{{- if include "harbor.registryctl.secretData" . | trim -}}true{{- end -}}
+{{- end -}}
+
+{{/*
+=============================================================================
 Validation helpers
 =============================================================================
 */}}

--- a/deploy/chart/templates/core.deployment.yaml
+++ b/deploy/chart/templates/core.deployment.yaml
@@ -68,13 +68,12 @@ spec:
           envFrom:
             - configMapRef:
                 name: {{ include "harbor.fullname" . }}-core
-            {{- /* Always the generated Secret: it carries the chart-managed
-                  keys (CSRF_KEY, REGISTRY_CREDENTIAL_PASSWORD, trace
-                  password) plus free-form `core.secret` entries. Pinned
-                  keys are overridden per-key via explicit env below —
-                  explicit env always beats envFrom. */}}
+            {{- /* Chart-managed keys; pinned keys are overridden by the
+                  explicit env below (explicit env beats envFrom). */}}
+            {{- if include "harbor.core.secretHasData" . }}
             - secretRef:
                 name: {{ include "harbor.core" . }}
+            {{- end }}
           env:
             {{- if .Values.existingSecretAdminPassword }}
             - name: HARBOR_ADMIN_PASSWORD

--- a/deploy/chart/templates/core.secret.yaml
+++ b/deploy/chart/templates/core.secret.yaml
@@ -1,16 +1,7 @@
+{{- /* Single source of truth for the core Secret's data block: the
+      Secret and its envFrom secretRef render only when this is non-empty. */}}
+{{- define "harbor.core.secretData" -}}
 {{- $existingSecret := (lookup "v1" "Secret" .Release.Namespace (include "harbor.core" .)) | default dict }}
-apiVersion: v1
-kind: Secret
-metadata:
-  name: {{ include "harbor.fullname" . }}-core
-  labels:
-    {{- include "harbor.componentLabels" (dict "root" . "component" "core") | nindent 4 }}
-  {{- with (include "harbor.annotations" (dict "root" . "local" nil)) }}
-  annotations:
-    {{- . | nindent 4 }}
-  {{- end }}
-type: Opaque
-data:
   {{- if not .Values.existingSecretAdminPassword }}
   HARBOR_ADMIN_PASSWORD: {{ .Values.harborAdminPassword | b64enc | quote }}
   {{- end }}
@@ -60,6 +51,23 @@ data:
   CSRF_KEY: {{ $csrfKey | b64enc | quote }}
   {{- end }}
   {{- template "harbor.trace.jaeger.password" . }}
+{{- end }}
+{{- $data := include "harbor.core.secretData" . }}
+{{- if $data | trim }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "harbor.fullname" . }}-core
+  labels:
+    {{- include "harbor.componentLabels" (dict "root" . "component" "core") | nindent 4 }}
+  {{- with (include "harbor.annotations" (dict "root" . "local" nil)) }}
+  annotations:
+    {{- . | nindent 4 }}
+  {{- end }}
+type: Opaque
+data:
+{{- $data }}
+{{- end }}
 
 ---
 {{- if not .Values.database.existingSecret }}

--- a/deploy/chart/templates/jobservice.deployment.yaml
+++ b/deploy/chart/templates/jobservice.deployment.yaml
@@ -63,8 +63,10 @@ spec:
           envFrom:
             - configMapRef:
                 name: {{ template "harbor.jobservice" . }}-env
+            {{- if include "harbor.jobservice.secretHasData" . }}
             - secretRef:
                 name: {{ include "harbor.fullname" . }}-jobservice
+            {{- end }}
           env:
             - name: CORE_SECRET
               valueFrom:

--- a/deploy/chart/templates/jobservice.secret.yaml
+++ b/deploy/chart/templates/jobservice.secret.yaml
@@ -1,4 +1,24 @@
+{{- /* Single source of truth for the jobservice Secret's data block: the
+      Secret and its envFrom secretRef render only when this is non-empty. */}}
+{{- define "harbor.jobservice.secretData" -}}
 {{- $existingSecret := (lookup "v1" "Secret" .Release.Namespace (include "harbor.jobservice" .)) | default dict }}
+  {{- if .Values.jobservice.secret }}
+  {{- include "harbor.toEnvVars" (dict "values" .Values.jobservice.secret "prefix" "" "isSecret" true) | nindent 2 }}
+  {{- end }}
+  {{- if not .Values.jobservice.existingSecret }}
+  {{- $jsSecret := include "harbor.secretKeyHelper" (dict "key" "JOBSERVICE_SECRET" "data" ($existingSecret.data | default dict)) }}
+  {{- if not $jsSecret }}
+  {{- $jsSecret = include "harbor.autoGenValue" (dict "root" $ "len" 16 "hint" "jobservice.existingSecret") }}
+  {{- end }}
+  JOBSERVICE_SECRET: {{ $jsSecret | b64enc | quote }}
+  {{- end }}
+  {{- if not .Values.registry.credentials.existingSecret }}
+  REGISTRY_CREDENTIAL_PASSWORD: {{ .Values.registry.credentials.password | b64enc | quote }}
+  {{- end }}
+  {{- template "harbor.trace.jaeger.password" . }}
+{{- end }}
+{{- $data := include "harbor.jobservice.secretData" . }}
+{{- if $data | trim }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -11,19 +31,5 @@ metadata:
   {{- end }}
 type: Opaque
 data:
-  {{- if .Values.jobservice.secret }}
-  {{- include "harbor.toEnvVars" (dict "values" .Values.jobservice.secret "prefix" "" "isSecret" true) | nindent 2 }}
-  {{- end }}
-  # Placeholder to ensure secret is always created
-  _PLACEHOLDER: {{ "placeholder" | b64enc | quote }}
-  {{- if not .Values.jobservice.existingSecret }}
-  {{- $jsSecret := include "harbor.secretKeyHelper" (dict "key" "JOBSERVICE_SECRET" "data" ($existingSecret.data | default dict)) }}
-  {{- if not $jsSecret }}
-  {{- $jsSecret = include "harbor.autoGenValue" (dict "root" $ "len" 16 "hint" "jobservice.existingSecret") }}
-  {{- end }}
-  JOBSERVICE_SECRET: {{ $jsSecret | b64enc | quote }}
-  {{- end }}
-  {{- if not .Values.registry.credentials.existingSecret }}
-  REGISTRY_CREDENTIAL_PASSWORD: {{ .Values.registry.credentials.password | b64enc | quote }}
-  {{- end }}
-  {{- template "harbor.trace.jaeger.password" . }}
+{{- $data }}
+{{- end }}

--- a/deploy/chart/templates/registry.deployment.yaml
+++ b/deploy/chart/templates/registry.deployment.yaml
@@ -72,9 +72,11 @@ spec:
             - name: metrics
               containerPort: 5001
               protocol: TCP
+          {{- if include "harbor.registry.secretHasData" . }}
           envFrom:
             - secretRef:
                 name: {{ include "harbor.registry.name" . }}
+          {{- end }}
           {{- if or .Values.registry.existingSecret $redisAuth $s3Ext $azureExt $ossExt $caExt .Values.registry.extraEnv }}
           env:
             {{- if .Values.registry.existingSecret }}
@@ -158,12 +160,16 @@ spec:
           envFrom:
             - configMapRef:
                 name: {{ .Values.registry.existingConfigMap | default (include "harbor.registry.name" .) }}
+            {{- if include "harbor.registry.secretHasData" . }}
             - secretRef:
                 name: {{ include "harbor.registry.name" . }}
+            {{- end }}
             - configMapRef:
                 name: {{ include "harbor.fullname" . }}-registryctl
+            {{- if include "harbor.registryctl.secretHasData" . }}
             - secretRef:
                 name: {{ include "harbor.fullname" . }}-registryctl
+            {{- end }}
           env:
             {{- if .Values.registry.existingSecret }}
             - name: REGISTRY_HTTP_SECRET

--- a/deploy/chart/templates/registry.secret.yaml
+++ b/deploy/chart/templates/registry.secret.yaml
@@ -1,4 +1,21 @@
+{{- /* Single source of truth for the registry Secret's data block: the
+      Secret and its envFrom secretRefs render only when this is non-empty. */}}
+{{- define "harbor.registry.secretData" -}}
 {{- $existingSecret := (lookup "v1" "Secret" .Release.Namespace (include "harbor.registry" .)) | default dict }}
+  {{- if not .Values.registry.existingSecret }}
+  {{- $httpSecret := include "harbor.secretKeyHelper" (dict "key" "REGISTRY_HTTP_SECRET" "data" ($existingSecret.data | default dict)) }}
+  {{- if not $httpSecret }}
+  {{- $httpSecret = include "harbor.autoGenValue" (dict "root" $ "len" 16 "hint" "registry.existingSecret") }}
+  {{- end }}
+  REGISTRY_HTTP_SECRET: {{ $httpSecret | b64enc | quote }}
+  {{- end }}
+  {{- /* Free-form sensitive env; prefer storageCredentials.<backend>.existingSecret in production. */}}
+  {{- if .Values.registry.secret }}
+  {{- include "harbor.toEnvVars" (dict "values" .Values.registry.secret "prefix" "" "isSecret" true) | nindent 2 }}
+  {{- end }}
+{{- end }}
+{{- $data := include "harbor.registry.secretData" . }}
+{{- if $data | trim }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -11,18 +28,8 @@ metadata:
   {{- end }}
 type: Opaque
 data:
-  {{- if not .Values.registry.existingSecret }}
-  {{- $httpSecret := include "harbor.secretKeyHelper" (dict "key" "REGISTRY_HTTP_SECRET" "data" ($existingSecret.data | default dict)) }}
-  {{- if not $httpSecret }}
-  {{- $httpSecret = include "harbor.autoGenValue" (dict "root" $ "len" 16 "hint" "registry.existingSecret") }}
-  {{- end }}
-  REGISTRY_HTTP_SECRET: {{ $httpSecret | b64enc | quote }}
-  {{- end }}
-  # Free-form sensitive env via toEnvVars (e.g. inline REGISTRY_STORAGE_S3_ACCESSKEY/SECRETKEY).
-  # For production prefer registry.storageCredentials.<backend>.existingSecret instead.
-  {{- if .Values.registry.secret }}
-  {{- include "harbor.toEnvVars" (dict "values" .Values.registry.secret "prefix" "" "isSecret" true) | nindent 2 }}
-  {{- end }}
+{{- $data }}
+{{- end }}
 {{- if not .Values.registry.credentials.existingSecret }}
 ---
 apiVersion: v1

--- a/deploy/chart/templates/registryctl.secret.yaml
+++ b/deploy/chart/templates/registryctl.secret.yaml
@@ -1,3 +1,10 @@
+{{- /* Single source of truth for the registryctl Secret's data block: the
+      Secret and its envFrom secretRef render only when this is non-empty. */}}
+{{- define "harbor.registryctl.secretData" -}}
+  {{- template "harbor.trace.jaeger.password" . }}
+{{- end }}
+{{- $data := include "harbor.registryctl.secretData" . }}
+{{- if $data | trim }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -10,5 +17,5 @@ metadata:
   {{- end }}
 type: Opaque
 data:
-  _PLACEHOLDER: {{ "placeholder" | b64enc | quote }}
-  {{- template "harbor.trace.jaeger.password" . }}
+{{- $data }}
+{{- end }}

--- a/deploy/chart/tests/core_test.yaml
+++ b/deploy/chart/tests/core_test.yaml
@@ -417,3 +417,24 @@ tests:
       - equal:
           path: data.POSTGRESQL_MIN_CONNS
           value: "8"
+
+  # Pins: with every core key externalized the generated Secret is skipped,
+  # so the envFrom secretRef must disappear with it.
+  - it: should drop the generated Secret envFrom when core is fully externalized
+    template: templates/core.deployment.yaml
+    set:
+      externalURL: https://harbor.example.com
+      database.host: postgres.example.com
+      autoGenSecrets: false
+      existingSecretAdminPassword: harbor-admin
+      existingSecretSecretKey: enc-key
+      core.existingSecret: core-id
+      core.existingXsrfSecret: core-id
+      core.tokenSecretName: token-cert
+      registry.credentials.existingSecret: reg-creds
+    asserts:
+      - notContains:
+          path: spec.template.spec.containers[0].envFrom
+          content:
+            secretRef:
+              name: RELEASE-NAME-harbor-core

--- a/deploy/chart/tests/gitops_test.yaml
+++ b/deploy/chart/tests/gitops_test.yaml
@@ -14,6 +14,7 @@ templates:
   - templates/core.secret.yaml
   - templates/registry.secret.yaml
   - templates/jobservice.secret.yaml
+  - templates/registryctl.secret.yaml
   - templates/ingress.secret.yaml
 tests:
   # ============================================================================
@@ -236,3 +237,60 @@ tests:
       - equal:
           path: data["tls.crt"]
           value: "Q0VSVFBFTQ=="
+
+  # ============================================================================
+  # Fully externalized: chart-managed component Secrets are skipped entirely
+  # so client-side renderers (Argo CD) create no empty Secrets.
+  # ============================================================================
+  - it: should render no core Secret documents when fully externalized
+    template: templates/core.secret.yaml
+    set: &fully-externalized
+      externalURL: https://harbor.example.com
+      database.host: postgres.example.com
+      autoGenSecrets: false
+      existingSecretAdminPassword: harbor-admin
+      existingSecretSecretKey: enc-key
+      database.existingSecret: harbor-database
+      core.existingSecret: core-id
+      core.existingXsrfSecret: core-id
+      core.tokenSecretName: token-cert
+      registry.existingSecret: reg-id
+      registry.credentials.existingSecret: reg-creds
+      jobservice.existingSecret: js-id
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should render no registry Secret documents when fully externalized
+    template: templates/registry.secret.yaml
+    set: *fully-externalized
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should render no jobservice Secret documents when fully externalized
+    template: templates/jobservice.secret.yaml
+    set: *fully-externalized
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should render no registryctl Secret when tracing is off
+    template: templates/registryctl.secret.yaml
+    set:
+      externalURL: https://harbor.example.com
+      database.host: postgres.example.com
+      harborAdminPassword: Harbor12345
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should render no core Secret when core.secret holds only nested empty maps
+    template: templates/core.secret.yaml
+    set:
+      <<: *fully-externalized
+      core.secret:
+        nested: {}
+    asserts:
+      - hasDocuments:
+          count: 0

--- a/deploy/chart/tests/jobservice_test.yaml
+++ b/deploy/chart/tests/jobservice_test.yaml
@@ -380,3 +380,25 @@ tests:
     asserts:
       - exists:
           path: spec.template.metadata.annotations["checksum/configmap-env"]
+
+  # Pins: with every jobservice key externalized the generated Secret is
+  # skipped, so the envFrom secretRef must disappear with it.
+  - it: should drop the generated Secret envFrom when jobservice is fully externalized
+    template: templates/jobservice.deployment.yaml
+    set:
+      externalURL: https://harbor.example.com
+      database.host: postgres.example.com
+      harborAdminPassword: Harbor12345
+      autoGenSecrets: false
+      existingSecretSecretKey: enc-key
+      core.existingSecret: core-id
+      core.existingXsrfSecret: core-id
+      core.tokenSecretName: token-cert
+      jobservice.existingSecret: js-id
+      registry.credentials.existingSecret: reg-creds
+    asserts:
+      - notContains:
+          path: spec.template.spec.containers[0].envFrom
+          content:
+            secretRef:
+              name: RELEASE-NAME-harbor-jobservice

--- a/deploy/chart/tests/registry_test.yaml
+++ b/deploy/chart/tests/registry_test.yaml
@@ -324,19 +324,19 @@ tests:
   # key value can't render `secretKeyRef.key: ""`.
   # ============================================================================
 
-  - it: should strip REGISTRY_HTTP_SECRET from generated Secret when existingSecret is set
+  - it: should skip the generated registry Secret entirely when existingSecret is set
     template: templates/registry.secret.yaml
     set:
       externalURL: https://harbor.example.com
       database.host: postgres.example.com
       harborAdminPassword: Harbor12345
       registry.existingSecret: my-reg
-    documentSelector:
-      path: metadata.name
-      value: RELEASE-NAME-harbor-registry
     asserts:
-      - notExists:
-          path: data.REGISTRY_HTTP_SECRET
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-harbor-registry-htpasswd
 
   - it: should inject REGISTRY_HTTP_SECRET into the registry container from existingSecret
     template: templates/registry.deployment.yaml
@@ -638,3 +638,42 @@ tests:
                 - key: REGISTRY_HTPASSWD
                   path: passwd
               secretName: reg-creds
+
+  # Pins: registry.existingSecret skips the generated Secret, so both
+  # containers must drop its secretRef; the default-empty registryctl
+  # Secret (tracing off) is likewise unreferenced.
+  - it: should drop generated Secret envFrom when registry is fully externalized
+    template: templates/registry.deployment.yaml
+    set:
+      externalURL: https://harbor.example.com
+      database.host: postgres.example.com
+      harborAdminPassword: Harbor12345
+      registry.existingSecret: my-reg
+    asserts:
+      - notExists:
+          path: spec.template.spec.containers[0].envFrom
+      - notContains:
+          path: spec.template.spec.containers[1].envFrom
+          content:
+            secretRef:
+              name: RELEASE-NAME-harbor-registry
+      - notContains:
+          path: spec.template.spec.containers[1].envFrom
+          content:
+            secretRef:
+              name: RELEASE-NAME-harbor-registryctl
+
+  - it: should reference the registryctl Secret when jaeger tracing is enabled
+    template: templates/registry.deployment.yaml
+    set:
+      externalURL: https://harbor.example.com
+      database.host: postgres.example.com
+      harborAdminPassword: Harbor12345
+      trace.enabled: true
+      trace.provider: jaeger
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[1].envFrom
+          content:
+            secretRef:
+              name: RELEASE-NAME-harbor-registryctl


### PR DESCRIPTION
Fixes the empty-Secrets usecase from #414: with `autoGenSecrets: false` and every key pinned to existing Secrets, the chart still created an empty `-core` Secret, an empty `-registry` Secret, and placeholder-only `-jobservice` / `-registryctl` Secrets (the `_PLACEHOLDER: placeholder` hack existed only because deployments referenced them unconditionally). Argo CD renders client-side and faithfully creates all four as junk objects.

## Changes

- New shared `harbor.<component>.secretHasData` predicates (core, registry, jobservice, registryctl), each mirroring the data keys of its Secret template.
- Each chart-managed component Secret is skipped entirely when it would carry no keys; the matching `envFrom` secretRef in the Deployment is gated on the same predicate, so nothing references a Secret that is not rendered.
- `_PLACEHOLDER` removed from jobservice and registryctl Secrets.
- Partial pinning is untouched: any remaining chart-managed key keeps the Secret and its secretRef (explicit per-key env overrides continue to beat envFrom).
- Tests: fully-externalized zero-document assertions in the gitops suite, secretRef-absence/presence assertions in core/registry/jobservice suites, registryctl secretRef appears again when jaeger tracing is enabled. One registry test updated: `registry.existingSecret` now skips the generated Secret instead of stripping its key.
- README GitOps section notes the behavior.

## Verification

- `task helm:unittest` — 257/257, 106 snapshots unchanged (secret templates are not snapshotted).
- `task helm:gitops-determinism`, `task helm:helm-lint`, `task helm:examples` — all green.
- `helm template -f ci/gitops-values.yaml`: 0 chart-managed Secrets, 0 secretRefs (previously 4 junk Secrets). Default install renders identically minus placeholders.

Known follow-up (separate concern): the `-registryctl` ConfigMap still uses a `_PLACEHOLDER` entry.

## Release Notes

A fully externalized (GitOps) install with `autoGenSecrets: false` no longer creates empty or placeholder-only component Secrets: the chart skips each chart-managed Secret and its `envFrom` reference when every key it would carry is pinned to an existing Secret.