### PR TITLE
chart: Add Argo CD example with pinned-secret Application setup

### DIFF
--- a/deploy/chart/README.md
+++ b/deploy/chart/README.md
@@ -237,6 +237,7 @@ The [`example/`](example/) directory contains one directory per scenario, each w
 | [`openshift/`](example/openshift/) | OpenShift deployment with edge-terminated routes |
 | [`aws-eks-irsa/`](example/aws-eks-irsa/) | AWS EKS with IRSA for S3 storage and RDS IAM Auth |
 | [`flux/`](example/flux/) | FluxCD GitOps: HelmRelease + drift detection + pinned secrets (`autoGenSecrets: false`), works for Argo CD too |
+| [`argocd/`](example/argocd/) | Argo CD Application: OCI chart + `$values` git source, pinned secrets (`autoGenSecrets: false` is mandatory under client-side rendering) |
 
 ```bash
 helm install harbor . -n harbor --create-namespace -f example/k3d-local/values.yaml

--- a/deploy/chart/README.md.gotmpl
+++ b/deploy/chart/README.md.gotmpl
@@ -238,6 +238,7 @@ The [`example/`](example/) directory contains one directory per scenario, each w
 | [`openshift/`](example/openshift/) | OpenShift deployment with edge-terminated routes |
 | [`aws-eks-irsa/`](example/aws-eks-irsa/) | AWS EKS with IRSA for S3 storage and RDS IAM Auth |
 | [`flux/`](example/flux/) | FluxCD GitOps: HelmRelease + drift detection + pinned secrets (`autoGenSecrets: false`), works for Argo CD too |
+| [`argocd/`](example/argocd/) | Argo CD Application: OCI chart + `$values` git source, pinned secrets (`autoGenSecrets: false` is mandatory under client-side rendering) |
 
 ```bash
 helm install harbor . -n harbor --create-namespace -f example/k3d-local/values.yaml

--- a/deploy/chart/example/README.md
+++ b/deploy/chart/example/README.md
@@ -14,6 +14,7 @@ the top level.
 | [`openshift/`](openshift/) | OpenShift deployment with ttl.sh images and edge-terminated routes |
 | [`aws-eks-irsa/`](aws-eks-irsa/) | AWS EKS with IRSA for S3 storage and RDS IAM Auth (Aurora PostgreSQL) |
 | [`flux/`](flux/) | FluxCD GitOps setup: HelmRelease with drift detection + fully pinned secrets (`autoGenSecrets: false`) for deterministic rendering — works for Argo CD too |
+| [`argocd/`](argocd/) | Argo CD Application: OCI chart + `$values` git source, pinned secrets (`autoGenSecrets: false` is mandatory under Argo CD's client-side rendering) |
 | [`upstream-goharbor/`](upstream-goharbor/) | Run upstream goharbor images (`docker.io/goharbor/*`) instead of the 8gcr default via `image.source: upstream` |
 
 Every `example/*/values*.yaml` is render-checked in CI

--- a/deploy/chart/example/argocd/README.md
+++ b/deploy/chart/example/argocd/README.md
@@ -1,0 +1,46 @@
+# Argo CD (GitOps)
+
+Argo CD `Application` for the `harbor` chart: published OCI chart plus
+pinned-secret values tracked in git.
+
+## Why `autoGenSecrets: false` is mandatory here
+
+Argo CD renders charts **client-side** with `helm template` on every
+sync. Helm's `lookup` function returns nothing there, so with the
+default `autoGenSecrets: true` every sync regenerates all generated
+secret material (encryption key, component identities, CSRF key,
+registry htpasswd) and rolls every workload through the
+`checksum/secret` annotations — a perpetual sync loop that also breaks
+registry authentication mid-flight.
+
+With `autoGenSecrets: false` the chart instead **fails at render time**
+naming any value that still needs pinning, and rendering becomes
+byte-for-byte deterministic — no `ignoreDifferences` workarounds needed.
+
+## Usage
+
+Requires Argo CD **2.6+** (multi-source Applications / `$values`).
+
+1. Create the namespace and the identity Secrets. Names, keys, and
+   generation commands are documented in
+   [`../flux/identity-secrets.yaml`](../flux/identity-secrets.yaml) —
+   they are identical for Argo CD. Manage them with ExternalSecrets,
+   SealedSecrets, or SOPS; never commit plaintext.
+2. Adjust [`values.yaml`](values.yaml): `externalURL`, database
+   coordinates, ingress host/issuer, storage size.
+3. Point [`application.yaml`](application.yaml) at your fork/values
+   location, register the OCI repository with Argo CD
+   (`argocd repo add 8gears.container-registry.com/8gcr/charts --type helm --enable-oci`),
+   and apply:
+
+   ```bash
+   kubectl apply -f application.yaml
+   ```
+
+## Notes
+
+- Rotating a pinned Secret does not restart pods — trigger a rollout
+  (`kubectl rollout restart`) or run [Reloader](https://github.com/stakater/Reloader).
+- The chart's deterministic-rendering property is CI-enforced
+  (`task helm:gitops-determinism`); see the README's GitOps section for
+  the full pinning reference.

--- a/deploy/chart/example/argocd/application.yaml
+++ b/deploy/chart/example/argocd/application.yaml
@@ -1,0 +1,32 @@
+# Argo CD Application for the harbor chart: published OCI chart + values
+# tracked in git (multi-source `$values` pattern).
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: harbor
+  namespace: argocd
+spec:
+  project: default
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: harbor
+  sources:
+    - repoURL: 8gears.container-registry.com/8gcr/charts
+      chart: harbor
+      # Pin an exact chart version; bump deliberately, never track latest.
+      targetRevision: 2.0.0
+      helm:
+        valueFiles:
+          - $values/deploy/chart/example/argocd/values.yaml
+    # Values pinned to the tag matching targetRevision above so chart and
+    # values move together; point at your own repo/revision in production.
+    - repoURL: https://github.com/container-registry/harbor-next
+      targetRevision: chart-v2.0.0
+      ref: values
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true
+      - ServerSideApply=true

--- a/deploy/chart/example/argocd/values.yaml
+++ b/deploy/chart/example/argocd/values.yaml
@@ -1,0 +1,48 @@
+# Argo CD values for the harbor chart. Argo CD renders client-side
+# (`helm template`), where `lookup` returns nothing — with the default
+# autoGenSecrets: true every sync would regenerate all secret material
+# and roll every workload through the checksum annotations. Pinning all
+# identities makes rendering byte-for-byte deterministic; the chart then
+# also skips its would-be-empty component Secrets entirely.
+#
+# Prerequisite Secrets (names + keys + generation commands):
+# see ../flux/identity-secrets.yaml — identical for Argo CD.
+externalURL: https://harbor.example.com
+
+autoGenSecrets: false
+
+existingSecretAdminPassword: harbor-admin
+existingSecretSecretKey: harbor-encryption
+
+database:
+  host: postgres.database.svc
+  username: harbor
+  existingSecret: harbor-database
+
+core:
+  existingSecret: harbor-core-identity
+  existingXsrfSecret: harbor-core-identity
+  tokenSecretName: harbor-token-cert
+
+registry:
+  existingSecret: harbor-registry-identity
+  credentials:
+    existingSecret: harbor-registry-credentials
+  persistence:
+    enabled: true
+    size: 50Gi
+
+jobservice:
+  existingSecret: harbor-jobservice-identity
+
+ingress:
+  enabled: true
+  autoGenCert: false
+  annotations:
+    cert-manager.io/cluster-issuer: letsencrypt
+  hosts:
+    - host: harbor.example.com
+  tls:
+    - secretName: harbor-tls
+      hosts:
+        - harbor.example.com

--- a/taskfile/helm.yml
+++ b/taskfile/helm.yml
@@ -96,6 +96,7 @@ tasks:
       # WARN findings (inline credentials, consistency advisories) are
       # informational.
       - for:
+          - example/argocd/values.yaml
           - example/aws-eks-irsa/values-aws-irsa.yaml
           - example/k3d-local/values.yaml
           - example/openshift/values.yaml
@@ -132,6 +133,7 @@ tasks:
       - defer: rm -f {{.CHART_DIR}}/.rendered-config.yaml
       - cmd: helm template test {{.CHART_DIR}} {{.HELM_SET}} > {{.CHART_DIR}}/.rendered-config.yaml && cd {{.CHART_DIR}} && ys tools/rendered-config-check.ys .rendered-config.yaml
       - for:
+          - example/argocd/values.yaml
           - example/aws-eks-irsa/values-aws-irsa.yaml
           - example/k3d-local/values.yaml
           - example/openshift/values.yaml


### PR DESCRIPTION
Third usecase from #414: the reporter deploys with Argo CD and had to discover the `autoGenSecrets` sync-loop the hard way — the only Argo CD guidance was a one-line "works for Argo CD too" on the Flux example.

## Changes

- New `example/argocd/`:
  - `application.yaml` — Argo CD `Application` using the published OCI chart plus the `$values` multi-source pattern for git-tracked values, `ServerSideApply` + automated sync.
  - `values.yaml` — fully pinned values (mirrors the Flux example), render-checked by `task helm:examples` automatically.
  - `README.md` — why `autoGenSecrets: false` is mandatory under Argo CD client-side rendering (lookup no-op → secret rotation → checksum rollout loop), setup steps, pointer to `../flux/identity-secrets.yaml` for the Secret generation commands (shared, not duplicated).
- Example tables in `example/README.md` and the chart README updated; `values-lint` and `rendered-config` CI lists include the new values file.

## Verification

`task helm:examples` (argocd values render OK), `task helm:values-lint` (0 errors), `task helm:rendered-config`, `task helm:docs` regenerated.

Depends on nothing; complements #834 and #835.