### PR TITLE
ci: Dispatch Fork Sync From Release Branches With Line Payload

### DIFF
--- a/.github/workflows/notify-fork-sync.yml
+++ b/.github/workflows/notify-fork-sync.yml
@@ -20,11 +20,18 @@ jobs:
           repositories: 8gcr
 
       - name: Trigger sync
+        env:
+          DISPATCH_TOKEN: ${{ steps.app-token.outputs.token }}
+          SHA: ${{ github.sha }}
+          LINE: ${{ github.ref_name }}
         run: |
+          # jq builds the payload so ref names can never inject into it
+          payload=$(jq -n --arg sha "${SHA}" --arg line "${LINE}" \
+            '{event_type: "upstream-sync", client_payload: {sha: $sha, line: $line}}')
           curl -f -X POST \
             -H "Accept: application/vnd.github+json" \
             -H "Content-Type: application/json" \
             -H "X-GitHub-Api-Version: 2022-11-28" \
-            -H "Authorization: Bearer ${{ steps.app-token.outputs.token }}" \
+            -H "Authorization: Bearer ${DISPATCH_TOKEN}" \
             "https://api.github.com/repos/container-registry/8gcr/dispatches" \
-            -d '{"event_type":"upstream-sync","client_payload":{"sha":"${{ github.sha }}","line":"${{ github.ref_name }}"}}'
+            -d "${payload}"

--- a/.github/workflows/notify-fork-sync.yml
+++ b/.github/workflows/notify-fork-sync.yml
@@ -2,7 +2,7 @@ name: Notify Fork Sync
 
 on:
   push:
-    branches: [main]
+    branches: [main, "release-[0-9]*.[0-9]*"]
 
 permissions: {}
 
@@ -27,4 +27,4 @@ jobs:
             -H "X-GitHub-Api-Version: 2022-11-28" \
             -H "Authorization: Bearer ${{ steps.app-token.outputs.token }}" \
             "https://api.github.com/repos/container-registry/8gcr/dispatches" \
-            -d '{"event_type":"upstream-sync","client_payload":{"sha":"${{ github.sha }}"}}'
+            -d '{"event_type":"upstream-sync","client_payload":{"sha":"${{ github.sha }}","line":"${{ github.ref_name }}"}}'


### PR DESCRIPTION
Part of the v3 merge-sync patch flow: notify-fork-sync now fires on pushes to release-X.Y branches as well as main, and the upstream-sync dispatch payload carries a `line` field naming the pushed branch. 8gcr's sync-patches workflow consumes `line` to sync the matching patch set (main patches or release-X.Y/000N mirrors) onto the right tip. Supersedes closed #798 with identical intent on the current workflow.

---
**Stack position:** 1/4 (base: main) → then #841 → #843 → #842. Squash-merge bottom-up; after each merge I rebase the next onto main.
