### PR TITLE
ci: Dispatch Release Cut To Patch Repo After Notes

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -286,6 +286,46 @@ jobs:
     secrets:
       SYNC_APP_PRIVATE_KEY: ${{ secrets.SYNC_APP_PRIVATE_KEY }}
 
+  mark-commercial-release:
+    # Stamp the release marker into each 8gcr patch branch's changelog file.
+    # Runs strictly AFTER the notes job: notes render the entries above the
+    # newest marker, then this marks them as shipped in this tag. Manual
+    # re-renders of old tags never dispatch (this job only runs on a fresh
+    # release), so old markers are never disturbed.
+    name: Mark Commercial Release
+    needs: [release-please, update-release-notes]
+    if: ${{ needs.release-please.outputs.release_created == 'true' }}
+    runs-on: ubuntu-26.04
+    timeout-minutes: 10
+    permissions:
+      # checkout of this repo (the app token below is scoped to 8gcr only)
+      contents: read
+    steps:
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          app-id: ${{ vars.SYNC_APP_ID }}
+          private-key: ${{ secrets.SYNC_APP_PRIVATE_KEY }}
+          owner: container-registry
+          repositories: 8gcr
+          # repository_dispatch needs contents write; request nothing else
+          permission-contents: write
+
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - uses: $/.github/actions/setup-task
+
+      - name: Dispatch release-cut
+        env:
+          DISPATCH_TOKEN: ${{ steps.app-token.outputs.token }}
+          TAG_NAME: ${{ needs.release-please.outputs.tag_name }}
+          TARGET_SHA: ${{ github.sha }}
+          LINE: ${{ github.ref_name }}
+        run: task release-notes:dispatch-release-cut
+
   chart:
     name: Publish Helm Chart
     # Driven by the chart's own release-please line (release-please-chart),

--- a/taskfile/release-notes.yml
+++ b/taskfile/release-notes.yml
@@ -24,6 +24,8 @@ tasks:
         msg: "DISPATCH_TOKEN is required (token with write access to container-registry/8gcr)"
       - sh: command -v jq >/dev/null 2>&1
         msg: "jq is required"
+      - sh: command -v curl >/dev/null 2>&1
+        msg: "curl is required"
     cmds:
       - |
         # jq serializes the payload so odd characters in a locally supplied

--- a/taskfile/release-notes.yml
+++ b/taskfile/release-notes.yml
@@ -11,6 +11,33 @@ tasks:
     cmds:
       - .github/scripts/update-release-notes.sh
 
+  dispatch-release-cut:
+    desc: "Tell 8gcr a release shipped so it stamps changelog markers (TAG_NAME, TARGET_SHA, LINE, DISPATCH_TOKEN)"
+    preconditions:
+      - sh: test -n "${TAG_NAME:-}"
+        msg: "TAG_NAME is required (for example, v2.16.0)"
+      - sh: test -n "${TARGET_SHA:-}"
+        msg: "TARGET_SHA is required (the released harbor-next commit)"
+      - sh: test -n "${LINE:-}"
+        msg: "LINE is required (main or release-X.Y)"
+      - sh: test -n "${DISPATCH_TOKEN:-}"
+        msg: "DISPATCH_TOKEN is required (token with write access to container-registry/8gcr)"
+      - sh: command -v jq >/dev/null 2>&1
+        msg: "jq is required"
+    cmds:
+      - |
+        # jq serializes the payload so odd characters in a locally supplied
+        # value can never break the JSON
+        payload=$(jq -n --arg tag "${TAG_NAME}" --arg sha "${TARGET_SHA}" --arg line "${LINE}" \
+          '{event_type: "release-cut", client_payload: {tag: $tag, target_sha: $sha, line: $line}}')
+        curl -f -X POST \
+          -H "Accept: application/vnd.github+json" \
+          -H "Content-Type: application/json" \
+          -H "X-GitHub-Api-Version: 2022-11-28" \
+          -H "Authorization: Bearer ${DISPATCH_TOKEN}" \
+          "https://api.github.com/repos/container-registry/8gcr/dispatches" \
+          -d "${payload}"
+
   preview:
     desc: "Render release notes locally without updating the GitHub Release (TAG_NAME=vX.Y.Z)"
     preconditions:


### PR DESCRIPTION
Part of the v3 patch-flow redesign (merge-sync + per-patch changelog files; supersedes the closed #794's dispatch piece).

After a fresh release's notes render, a new `mark-commercial-release` job dispatches `release-cut` (`{tag, target_sha, line}`) to `container-registry/8gcr`, which stamps `--- release vX.Y.Z ---` markers into each patch branch's changelog file.

**Ordering is the contract:** notes render the entries *above the newest marker* first, then this job stamps them as shipped — so the next release's delta starts clean. Manual re-renders of old tags never dispatch (the job only runs when `release_created == 'true'`), so old markers are never disturbed.

Security posture (carried from the review rounds on closed #794, zizmor-clean):
- App token requests `permission-contents: write` on 8gcr only — nothing inherited from the installation.
- Job itself holds `contents: read`; checkout uses `persist-credentials: false`.
- Dispatch payload built with `jq -n --arg` so no value can break the JSON; task inputs are env-only.
- Local action referenced via the $/ self-repository syntax.

No-op until 8gcr's release-marker workflow lands (dispatch to a repo with no listener is harmless); safe to merge independently.

---
**Stack position:** 4/4 (base: v3/changelog-notes, #843)
