### PR TITLE
ci: Render Commercial Feature Deltas From Patch Changelog Files

### DIFF
--- a/.github/scripts/update-release-notes.sh
+++ b/.github/scripts/update-release-notes.sh
@@ -201,8 +201,9 @@ if [[ "${chart_mode}" == false && -f "${series}" ]]; then
     feature_title=""
     feature_entries=""
     if [[ -n "${changelog_blob}" ]]; then
+      # consume the whole blob (no exit) so awk never SIGPIPEs printf
       feature_title=$(printf '%s\n' "${changelog_blob}" \
-        | awk '/^# / { sub(/^# /, ""); print; exit }')
+        | awk '/^# / && !found { sub(/^# /, ""); print; found = 1 }')
       # No mid-stream exit: the whole file is always consumed so awk can
       # never SIGPIPE its producer under pipefail.
       feature_entries=$(printf '%s\n' "${changelog_blob}" \

--- a/.github/scripts/update-release-notes.sh
+++ b/.github/scripts/update-release-notes.sh
@@ -173,6 +173,14 @@ patch_notes="${tmp_dir}/commercial-patches.md"
 
 # The Harbor branch owns the ordered manifest. 8gcr only stores the branch
 # commits, so release notes and image builds always use the same exact list.
+# Each patch branch carries its own changelog at changelogs/<branch>.md
+# (humans append entries in their PRs; the release-cut stamps
+# "--- release vX.Y.Z (target <sha12>) ---" markers, newest first). The
+# unreleased block — entries above the first marker — is this release's
+# delta, because notes render BEFORE the marker is stamped. Re-rendering an
+# old tag reads that tag's own section instead.
+commercial_count=0
+unchanged_features=()
 if [[ "${chart_mode}" == false && -f "${series}" ]]; then
   while IFS= read -r branch; do
     branch="${branch%%#*}"
@@ -187,8 +195,63 @@ if [[ "${chart_mode}" == false && -f "${series}" ]]; then
 
     git -C "${tmp_dir}/patches-repo" fetch --depth=1 "${patches_remote}" \
       "${branch}:refs/remotes/origin/${branch}"
-    echo "- $(git -C "${tmp_dir}/patches-repo" log -1 --format=%s "refs/remotes/origin/${branch}")" \
-      >> "${patch_notes}"
+    commercial_count=$((commercial_count + 1))
+    changelog_blob=$(git -C "${tmp_dir}/patches-repo" cat-file -p \
+      "refs/remotes/origin/${branch}:changelogs/${branch}.md" 2>/dev/null || true)
+    feature_title=""
+    feature_entries=""
+    if [[ -n "${changelog_blob}" ]]; then
+      feature_title=$(printf '%s\n' "${changelog_blob}" \
+        | awk '/^# / { sub(/^# /, ""); print; exit }')
+      # No mid-stream exit: the whole file is always consumed so awk can
+      # never SIGPIPE its producer under pipefail.
+      feature_entries=$(printf '%s\n' "${changelog_blob}" \
+        | awk -v tag="${TAG_NAME}" '
+            function newer(a, b,   x, y, i) {
+              sub(/^v/, "", a); sub(/^v/, "", b)
+              split(a, x, "."); split(b, y, ".")
+              for (i = 1; i <= 3; i++) {
+                if (x[i] + 0 > y[i] + 0) return 1
+                if (x[i] + 0 < y[i] + 0) return 0
+              }
+              return 0
+            }
+            /^--- release / {
+              seenmarker = 1
+              intag = ($3 == tag)
+              if (intag) found = 1
+              if (newer($3, tag)) sawnewer = 1
+              next
+            }
+            !seentitle { if (/^# /) seentitle = 1; next }
+            /^- / || /^  / {
+              if (intag) { out = out $0 "\n" }
+              else if (!seenmarker) { unrel = unrel $0 "\n" }
+            }
+            END {
+              if (found) { printf "%s", out }
+              # No marker for the tag: the unreleased block is the delta —
+              # correct for the current release (notes render before the
+              # marker is stamped). A marker NEWER than the tag means this
+              # is a historical re-render of a pre-changelog tag: nothing.
+              else if (!sawnewer) { printf "%s", unrel }
+            }
+          ')
+    fi
+    if [[ -z "${feature_title}" ]]; then
+      feature_title=$(git -C "${tmp_dir}/patches-repo" log -1 --format=%s \
+        "refs/remotes/origin/${branch}")
+    fi
+    if [[ -n "${feature_entries}" ]]; then
+      {
+        echo "### ${feature_title}"
+        echo
+        printf '%s' "${feature_entries}"
+        echo
+      } >> "${patch_notes}"
+    else
+      unchanged_features+=("${feature_title}")
+    fi
   done < "${series}"
 fi
 
@@ -198,13 +261,19 @@ fi
     echo
   fi
 
-  if [[ -s "${patch_notes}" ]]; then
+  if [[ "${commercial_count}" -gt 0 ]]; then
     echo "## Commercial Features"
     echo
-    echo "This release includes the following commercial enhancements:"
-    echo
-    cat "${patch_notes}"
-    echo
+    if [[ -s "${patch_notes}" ]]; then
+      echo "Changes to commercial features in this release:"
+      echo
+      cat "${patch_notes}"
+    fi
+    if [[ "${#unchanged_features[@]}" -gt 0 ]]; then
+      printf -v unchanged_list '%s, ' "${unchanged_features[@]}"
+      echo "_No changes this release: ${unchanged_list%, }._"
+      echo
+    fi
   fi
 
   cat "${tmp_dir}/formatted-notes.md"


### PR DESCRIPTION
Part of the v3 patch-flow redesign (no-squash, merge-sync, per-patch changelog files).

Each 8gcr patch branch now carries `changelogs/<branch>.md`: humans append entries in their patch-branch PRs; the release cut stamps `--- release vX.Y.Z (target <sha12>) ---` markers (newest first, via a separate 8gcr PR). This PR teaches `update-release-notes.sh` to read that file per declared branch instead of printing the tip commit subject:

- **Fresh release**: notes render BEFORE the marker is stamped, so the unreleased block (entries above the first marker) is exactly this release's delta.
- **Old-tag re-render**: reads the section between that tag's marker and the next one; a tag older than every marker (pre-changelog era) renders no entries.
- Features without changes collapse into one `_No changes this release: …_` line; missing changelog file falls back to the tip subject and counts as unchanged.
- The whole file is consumed in a single END-based awk (no mid-stream exit that could SIGPIPE the producer under `pipefail`).

Verified against a fixture covering all four windows (tag-with-marker, fresh-unreleased, pre-changelog tag, middle marker) using the shipped awk extracted verbatim from the script.

Companion PRs (separate, single-concern): 8gcr merge-sync workflow, 8gcr marker/seed stamping, release-cut dispatch, octopus apply path, line-aware fork-sync dispatch.

---
**Stack position:** 3/4 (base: v3/octopus-apply, #841)
