### PR TITLE
feat: Report Registry Volume Usage via registryctl

### DIFF
--- a/api/v2.0/swagger.yaml
+++ b/api/v2.0/swagger.yaml
@@ -8314,6 +8314,7 @@ definitions:
       measured_at:
         type: string
         format: date-time
+        x-nullable: true
         description: When the volume was measured. Only set when measured is true.
   GeneralInfo:
     type: object

--- a/api/v2.0/swagger.yaml
+++ b/api/v2.0/swagger.yaml
@@ -4264,10 +4264,13 @@ paths:
           $ref: '#/responses/500'
   /systeminfo/volumes:
     get:
-      summary: Get system volume info (total/free size).
+      summary: Get system volume info (total/free/used size).
       operationId: getVolumes
       description: |
-        This endpoint is for retrieving system volume info that only provides for admin user.  Note that the response only reflects the storage status of local disk.
+        Get the total, free and used size of the registry storage volume. Only system administrators can call this API.
+        The numbers are measured by registryctl on the registry's own volume for the filesystem storage driver; for
+        other drivers, or when registryctl cannot be reached, they fall back to the local disk of the core service and
+        `measured` is false.
       tags:
         - systeminfo
       parameters:
@@ -8293,6 +8296,25 @@ definitions:
         type: integer
         format: uint64
         description: Free volume size.
+      used:
+        type: integer
+        format: uint64
+        description: Used volume size.
+        x-omitempty: false
+      driver:
+        type: string
+        description: The registry storage driver the numbers describe, e.g. filesystem.
+      measured:
+        type: boolean
+        description: |
+          True when the numbers were measured on the registry's own storage volume through registryctl.
+          False when they only reflect the local disk of the core service, which is the case for object
+          storage drivers and when registryctl is unreachable.
+        x-omitempty: false
+      measured_at:
+        type: string
+        format: date-time
+        description: When the volume was measured. Only set when measured is true.
   GeneralInfo:
     type: object
     properties:

--- a/docs/storage-usage-reporting.md
+++ b/docs/storage-usage-reporting.md
@@ -1,0 +1,57 @@
+# Storage usage reporting
+
+How Harbor learns the real size and usage of its registry storage volume.
+
+Decision record: [harbor-next #839](https://github.com/container-registry/harbor-next/issues/839), theme B.
+
+## What it is
+
+The registry's storage is mounted into the registry process and into `registryctl`, never into `harbor-core`. That is why the old `GET /systeminfo/volumes` was wrong on Kubernetes: it measured the core container's own disk.
+
+With storage usage reporting, `registryctl` measures the volume (`statfs` on the registry's `rootdirectory`) and core pulls that measurement:
+
+```
+harbor-core  --GET /api/registry/storage-->  registryctl  --statfs-->  registry volume
+```
+
+Nothing has to be deployed or configured. The Helm chart already runs `registryctl` next to the registry with the same volume, the Compose install already bind-mounts `/data/registry` into it, and core already knows `REGISTRY_CONTROLLER_URL` and the secret registryctl accepts.
+
+## Scope
+
+- Supported: the `filesystem` storage driver (a PVC, hostPath or bind mount).
+- Not supported for now: object storage drivers (S3, GCS, Azure, Swift). They expose no capacity API. For them the numbers fall back to core's local disk and are flagged `measured: false`; the global storage quota keeps using Harbor's own blob accounting.
+
+## Where the numbers show up
+
+- `GET /api/v2.0/systeminfo/volumes` (system administrators): `total`, `free`, `used`, `driver`, `measured`, `measured_at`.
+- The [global storage quota](global-quota.md): when a measurement is available, its `used` value replaces the accounted one and `used_source` becomes `measured`. Enforcement uses the measured value too.
+- Prometheus (in-core exporter mode): `harbor_storage_volume_bytes{kind="total|free|used",driver="..."}` and `harbor_storage_volume_measured`.
+
+## Behaviour details
+
+- Core caches the measurement for one minute, shared across core replicas through Redis, so the global quota gate on the push path does not call registryctl per push.
+- registryctl unreachable: core logs a warning and falls back to its local disk with `measured: false`. Nothing fails.
+- Several registry replicas on a shared (RWX) volume: every registryctl reports the same filesystem; core uses whichever replica the Service answers with. The numbers are not summed.
+- `used` is `total - free` as seen by the filesystem, which includes upload temp directories and blobs waiting for garbage collection. That is intended: it is the physical usage.
+
+## registryctl endpoint
+
+`GET /api/registry/storage`, authenticated with the same secret header as the other registryctl APIs:
+
+```json
+{
+  "driver": "filesystem",
+  "supported": true,
+  "path": "/storage",
+  "total": 107374182400,
+  "free": 32212254720,
+  "used": 75161927680,
+  "measured_at": "2026-09-08T12:00:00Z"
+}
+```
+
+For an object store the response is `{"driver": "s3", "supported": false, ...}` with zero sizes.
+
+## Development
+
+The harbor-next dev environment starts registryctl only with `docker compose --profile registryctl up`. Without it, core reports `measured: false`.

--- a/docs/storage-usage-reporting.md
+++ b/docs/storage-usage-reporting.md
@@ -19,7 +19,7 @@ Nothing has to be deployed or configured. The Helm chart already runs `registryc
 ## Scope
 
 - Supported: the `filesystem` storage driver (a PVC, hostPath or bind mount).
-- Not supported for now: object storage drivers (S3, GCS, Azure, Swift). They expose no capacity API. For them the numbers fall back to core's local disk and are flagged `measured: false`; the global storage quota keeps using Harbor's own blob accounting.
+- Not supported for now: object storage drivers (S3, GCS, Azure, Swift). They expose no capacity API. For them `/systeminfo/volumes` reports the real driver name with zero sizes and `measured: false`; the global storage quota keeps using Harbor's own blob accounting.
 
 ## Where the numbers show up
 
@@ -30,7 +30,8 @@ Nothing has to be deployed or configured. The Helm chart already runs `registryc
 ## Behaviour details
 
 - Core caches the measurement for one minute, shared across core replicas through Redis, so the global quota gate on the push path does not call registryctl per push.
-- registryctl unreachable: core logs a warning and falls back to its local disk with `measured: false`. Nothing fails.
+- registryctl unreachable or not answering within five seconds: core logs a warning and falls back to its local disk (`total`, `free` and `used` of the core container) with `measured: false`. Nothing fails, and the fallback numbers are never published as Prometheus volume bytes.
+- registryctl configured with a `rootdirectory` that does not exist: the endpoint answers with an error instead of a zero-sized "measurement", and core falls back as above.
 - Several registry replicas on a shared (RWX) volume: every registryctl reports the same filesystem; core uses whichever replica the Service answers with. The numbers are not summed.
 - `used` is `total - free` as seen by the filesystem, which includes upload temp directories and blobs waiting for garbage collection. That is intended: it is the physical usage.
 

--- a/src/controller/systeminfo/controller.go
+++ b/src/controller/systeminfo/controller.go
@@ -18,12 +18,14 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"math"
 	"os"
 	"strings"
 	"time"
 
 	"github.com/goharbor/harbor/src/common"
 	"github.com/goharbor/harbor/src/common/utils"
+	"github.com/goharbor/harbor/src/controller/systemquota"
 	"github.com/goharbor/harbor/src/lib/config"
 	"github.com/goharbor/harbor/src/lib/config/models"
 	"github.com/goharbor/harbor/src/lib/errors"
@@ -152,6 +154,32 @@ func OIDCProviderName(cfg map[string]any) string {
 func (c *controller) GetCapacity(_ context.Context) (*imagestorage.Capacity, error) {
 	systeminfo.Init()
 	return imagestorage.GlobalDriver.Cap()
+}
+
+// NewMeasurer adapts the capacity of the registry volume to the global storage
+// quota's Measurer (harbor-next #839): a measured value replaces the accounted
+// one, an unmeasured capacity yields nil so accounting stays in charge.
+func NewMeasurer() systemquota.Measurer {
+	return &measurer{ctl: Ctl}
+}
+
+type measurer struct {
+	ctl Controller
+}
+
+func (m *measurer) Measure(ctx context.Context) (*systemquota.Measurement, error) {
+	capacity, err := m.ctl.GetCapacity(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if capacity == nil || !capacity.Measured {
+		//nolint:nilnil // a nil measurement means "not measured", per the Measurer contract
+		return nil, nil
+	}
+	if capacity.Used > math.MaxInt64 {
+		return nil, fmt.Errorf("measured usage %d exceeds int64", capacity.Used)
+	}
+	return &systemquota.Measurement{Used: int64(capacity.Used), At: capacity.MeasuredAt}, nil
 }
 
 func (c *controller) GetCA(ctx context.Context) (io.ReadCloser, error) {

--- a/src/controller/systeminfo/measurer_test.go
+++ b/src/controller/systeminfo/measurer_test.go
@@ -1,0 +1,56 @@
+// Copyright Project Harbor Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package systeminfo
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/goharbor/harbor/src/pkg/systeminfo/imagestorage"
+)
+
+type fakeCapacityCtl struct {
+	Controller
+	capacity *imagestorage.Capacity
+	err      error
+}
+
+func (f fakeCapacityCtl) GetCapacity(context.Context) (*imagestorage.Capacity, error) {
+	return f.capacity, f.err
+}
+
+func TestMeasurer(t *testing.T) {
+	at := time.Now()
+	m := &measurer{ctl: fakeCapacityCtl{capacity: &imagestorage.Capacity{Used: 42, Measured: true, MeasuredAt: at}}}
+	got, err := m.Measure(context.Background())
+	assert.NoError(t, err)
+	if assert.NotNil(t, got) {
+		assert.Equal(t, int64(42), got.Used)
+		assert.Equal(t, at, got.At)
+	}
+
+	m = &measurer{ctl: fakeCapacityCtl{capacity: &imagestorage.Capacity{Used: 42, Measured: false}}}
+	got, err = m.Measure(context.Background())
+	assert.NoError(t, err)
+	assert.Nil(t, got)
+
+	m = &measurer{ctl: fakeCapacityCtl{err: errors.New("boom")}}
+	_, err = m.Measure(context.Background())
+	assert.Error(t, err)
+}

--- a/src/controller/systeminfo/measurer_test.go
+++ b/src/controller/systeminfo/measurer_test.go
@@ -17,6 +17,7 @@ package systeminfo
 import (
 	"context"
 	"errors"
+	"math"
 	"testing"
 	"time"
 
@@ -51,6 +52,17 @@ func TestMeasurer(t *testing.T) {
 	assert.Nil(t, got)
 
 	m = &measurer{ctl: fakeCapacityCtl{err: errors.New("boom")}}
+	_, err = m.Measure(context.Background())
+	assert.Error(t, err)
+
+	// nil capacity without error means "not measured"
+	m = &measurer{ctl: fakeCapacityCtl{}}
+	got, err = m.Measure(context.Background())
+	assert.NoError(t, err)
+	assert.Nil(t, got)
+
+	// a value beyond int64 cannot be represented as a quota usage
+	m = &measurer{ctl: fakeCapacityCtl{capacity: &imagestorage.Capacity{Used: math.MaxUint64, Measured: true}}}
 	_, err = m.Measure(context.Background())
 	assert.Error(t, err)
 }

--- a/src/core/main.go
+++ b/src/core/main.go
@@ -34,11 +34,14 @@ import (
 	"github.com/goharbor/harbor/src/common/dao"
 	common_http "github.com/goharbor/harbor/src/common/http"
 	"github.com/goharbor/harbor/src/common/models"
+	"github.com/goharbor/harbor/src/common/registryctl"
 	configCtl "github.com/goharbor/harbor/src/controller/config"
 	_ "github.com/goharbor/harbor/src/controller/event/handler"
 	"github.com/goharbor/harbor/src/controller/health"
 	"github.com/goharbor/harbor/src/controller/registry"
 	"github.com/goharbor/harbor/src/controller/systemartifact"
+	"github.com/goharbor/harbor/src/controller/systeminfo"
+	"github.com/goharbor/harbor/src/controller/systemquota"
 	"github.com/goharbor/harbor/src/controller/task"
 	"github.com/goharbor/harbor/src/core/api"
 	_ "github.com/goharbor/harbor/src/core/auth/authproxy"
@@ -184,6 +187,11 @@ func main() {
 	log.Info("initializing configurations...")
 	config.Init()
 	log.Info("configurations initialization completed")
+
+	// registryctl measures the registry volume for /systeminfo/volumes and the
+	// global storage quota (harbor-next #839); core pulls, so the client lives here.
+	registryctl.Init()
+	systemquota.SetMeasurer(systeminfo.NewMeasurer())
 
 	// default beego max memory and max upload size is 128GB, consider from some AI related image would be large,
 	// also support customize it from the environment variables if the default value cannot satisfy some scenarios.

--- a/src/pkg/exporter/exporter.go
+++ b/src/pkg/exporter/exporter.go
@@ -70,6 +70,7 @@ func newCollectorSet(opt *Opt, backend Backend) *Exporter {
 		NewJobServiceCollector(backend),
 		NewStatisticsCollector(),
 		NewSystemQuotaCollector(),
+		NewStorageVolumeCollector(),
 	)
 	if err != nil {
 		log.Warningf("calling RegisterCollector() errored out, error: %v", err)

--- a/src/pkg/exporter/storage_volume_collector.go
+++ b/src/pkg/exporter/storage_volume_collector.go
@@ -1,0 +1,97 @@
+// Copyright Project Harbor Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package exporter
+
+import (
+	"context"
+
+	"github.com/prometheus/client_golang/prometheus"
+
+	si "github.com/goharbor/harbor/src/controller/systeminfo"
+	"github.com/goharbor/harbor/src/lib/log"
+	"github.com/goharbor/harbor/src/lib/orm"
+)
+
+// StorageVolumeCollectorName is the name of the registry volume collector.
+const StorageVolumeCollectorName = "StorageVolumeCollector"
+
+var (
+	storageVolumeBytes = typedDesc{
+		desc:      newDescWithLabels("", "storage_volume_bytes", "Size of the registry storage volume in bytes", "kind", "driver"),
+		valueType: prometheus.GaugeValue,
+	}
+	storageVolumeMeasured = typedDesc{
+		desc:      newDescWithLabels("", "storage_volume_measured", "Whether the volume numbers were measured on the registry volume through registryctl (1) or only reflect core's local disk (0)"),
+		valueType: prometheus.GaugeValue,
+	}
+)
+
+// StorageVolumeCollector exposes the registry storage volume as measured by
+// registryctl (harbor-next #839, theme B). It reads the controller directly and
+// therefore only works when the collectors run inside core.
+type StorageVolumeCollector struct {
+	ctl    si.Controller
+	newCtx func() context.Context
+}
+
+// NewStorageVolumeCollector ...
+func NewStorageVolumeCollector() *StorageVolumeCollector {
+	return &StorageVolumeCollector{ctl: si.Ctl, newCtx: orm.Context}
+}
+
+// GetName ...
+func (c StorageVolumeCollector) GetName() string {
+	return StorageVolumeCollectorName
+}
+
+// Describe ...
+func (c StorageVolumeCollector) Describe(ch chan<- *prometheus.Desc) {
+	ch <- storageVolumeBytes.Desc()
+	ch <- storageVolumeMeasured.Desc()
+}
+
+// Collect ...
+func (c StorageVolumeCollector) Collect(ch chan<- prometheus.Metric) {
+	for _, m := range c.getMetrics() {
+		ch <- m
+	}
+}
+
+func (c StorageVolumeCollector) getMetrics() []prometheus.Metric {
+	if CacheEnabled() {
+		if value, ok := CacheGet(StorageVolumeCollectorName); ok {
+			return value.([]prometheus.Metric)
+		}
+	}
+	capacity, err := c.ctl.GetCapacity(c.newCtx())
+	if err != nil {
+		log.Errorf("get storage volume capacity error: %v", err)
+		return nil
+	}
+	measured := 0.0
+	if capacity.Measured {
+		measured = 1
+	}
+	result := []prometheus.Metric{
+		storageVolumeBytes.MustNewConstMetric(float64(capacity.Total), "total", capacity.Driver),
+		storageVolumeBytes.MustNewConstMetric(float64(capacity.Free), "free", capacity.Driver),
+		storageVolumeBytes.MustNewConstMetric(float64(capacity.Used), "used", capacity.Driver),
+		storageVolumeMeasured.MustNewConstMetric(measured),
+	}
+	if CacheEnabled() {
+		CachePut(StorageVolumeCollectorName, result)
+	}
+	return result
+}

--- a/src/pkg/exporter/storage_volume_collector.go
+++ b/src/pkg/exporter/storage_volume_collector.go
@@ -80,15 +80,17 @@ func (c StorageVolumeCollector) getMetrics() []prometheus.Metric {
 		log.Errorf("get storage volume capacity error: %v", err)
 		return nil
 	}
-	measured := 0.0
+	// Fallback numbers describe the local disk of whatever process runs the
+	// collector (core, or the standalone exporter), not the registry volume, so
+	// only a measurement is published as volume bytes.
+	result := []prometheus.Metric{storageVolumeMeasured.MustNewConstMetric(0)}
 	if capacity.Measured {
-		measured = 1
-	}
-	result := []prometheus.Metric{
-		storageVolumeBytes.MustNewConstMetric(float64(capacity.Total), "total", capacity.Driver),
-		storageVolumeBytes.MustNewConstMetric(float64(capacity.Free), "free", capacity.Driver),
-		storageVolumeBytes.MustNewConstMetric(float64(capacity.Used), "used", capacity.Driver),
-		storageVolumeMeasured.MustNewConstMetric(measured),
+		result = []prometheus.Metric{
+			storageVolumeBytes.MustNewConstMetric(float64(capacity.Total), "total", capacity.Driver),
+			storageVolumeBytes.MustNewConstMetric(float64(capacity.Free), "free", capacity.Driver),
+			storageVolumeBytes.MustNewConstMetric(float64(capacity.Used), "used", capacity.Driver),
+			storageVolumeMeasured.MustNewConstMetric(1),
+		}
 	}
 	if CacheEnabled() {
 		CachePut(StorageVolumeCollectorName, result)

--- a/src/pkg/exporter/storage_volume_collector_test.go
+++ b/src/pkg/exporter/storage_volume_collector_test.go
@@ -1,0 +1,61 @@
+// Copyright Project Harbor Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package exporter
+
+import (
+	"context"
+	"io"
+	"testing"
+
+	dto "github.com/prometheus/client_model/go"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	si "github.com/goharbor/harbor/src/controller/systeminfo"
+	"github.com/goharbor/harbor/src/pkg/systeminfo/imagestorage"
+)
+
+type fakeVolumeSysInfoCtl struct{ capacity *imagestorage.Capacity }
+
+func (f fakeVolumeSysInfoCtl) GetInfo(context.Context, si.Options) (*si.Data, error) { return nil, nil }
+func (f fakeVolumeSysInfoCtl) GetCA(context.Context) (io.ReadCloser, error)          { return nil, nil }
+func (f fakeVolumeSysInfoCtl) GetCapacity(context.Context) (*imagestorage.Capacity, error) {
+	return f.capacity, nil
+}
+
+func TestStorageVolumeCollector(t *testing.T) {
+	c := StorageVolumeCollector{
+		ctl:    fakeVolumeSysInfoCtl{capacity: &imagestorage.Capacity{Total: 100, Free: 30, Used: 70, Driver: "filesystem", Measured: true}},
+		newCtx: context.Background,
+	}
+	metrics := c.getMetrics()
+	require.Len(t, metrics, 4)
+	values := map[string]float64{}
+	for _, m := range metrics[:3] {
+		d := &dto.Metric{}
+		require.NoError(t, m.Write(d))
+		// the DTO sorts labels by name, so look them up rather than by position
+		labels := map[string]string{}
+		for _, l := range d.Label {
+			labels[l.GetName()] = l.GetValue()
+		}
+		values[labels["kind"]] = d.Gauge.GetValue()
+		assert.Equal(t, "filesystem", labels["driver"])
+	}
+	assert.Equal(t, map[string]float64{"total": 100, "free": 30, "used": 70}, values)
+	d := &dto.Metric{}
+	require.NoError(t, metrics[3].Write(d))
+	assert.Equal(t, float64(1), d.Gauge.GetValue())
+}

--- a/src/pkg/exporter/storage_volume_collector_test.go
+++ b/src/pkg/exporter/storage_volume_collector_test.go
@@ -16,6 +16,7 @@ package exporter
 
 import (
 	"context"
+	"errors"
 	"io"
 	"testing"
 
@@ -27,15 +28,42 @@ import (
 	"github.com/goharbor/harbor/src/pkg/systeminfo/imagestorage"
 )
 
-type fakeVolumeSysInfoCtl struct{ capacity *imagestorage.Capacity }
+type fakeVolumeSysInfoCtl struct {
+	capacity *imagestorage.Capacity
+	err      error
+}
 
 func (f fakeVolumeSysInfoCtl) GetInfo(context.Context, si.Options) (*si.Data, error) { return nil, nil }
 func (f fakeVolumeSysInfoCtl) GetCA(context.Context) (io.ReadCloser, error)          { return nil, nil }
 func (f fakeVolumeSysInfoCtl) GetCapacity(context.Context) (*imagestorage.Capacity, error) {
-	return f.capacity, nil
+	return f.capacity, f.err
+}
+
+func TestStorageVolumeCollectorUnmeasured(t *testing.T) {
+	CacheDelete(StorageVolumeCollectorName)
+	c := StorageVolumeCollector{
+		ctl:    fakeVolumeSysInfoCtl{capacity: &imagestorage.Capacity{Total: 100, Free: 30, Used: 70, Driver: "s3", Measured: false}},
+		newCtx: context.Background,
+	}
+	metrics := c.getMetrics()
+	require.Len(t, metrics, 1, "fallback numbers are not published as volume bytes")
+	d := &dto.Metric{}
+	require.NoError(t, metrics[0].Write(d))
+	assert.Equal(t, float64(0), d.Gauge.GetValue())
+}
+
+func TestStorageVolumeCollectorError(t *testing.T) {
+	CacheDelete(StorageVolumeCollectorName)
+	c := StorageVolumeCollector{
+		ctl:    fakeVolumeSysInfoCtl{err: errors.New("boom")},
+		newCtx: context.Background,
+	}
+	assert.Empty(t, c.getMetrics())
 }
 
 func TestStorageVolumeCollector(t *testing.T) {
+	CacheDelete(StorageVolumeCollectorName)
+	t.Cleanup(func() { CacheDelete(StorageVolumeCollectorName) })
 	c := StorageVolumeCollector{
 		ctl:    fakeVolumeSysInfoCtl{capacity: &imagestorage.Capacity{Total: 100, Free: 30, Used: 70, Driver: "filesystem", Measured: true}},
 		newCtx: context.Background,

--- a/src/pkg/systeminfo/imagestorage/driver.go
+++ b/src/pkg/systeminfo/imagestorage/driver.go
@@ -14,6 +14,8 @@
 
 package imagestorage
 
+import "time"
+
 // GlobalDriver is a global image storage driver
 var GlobalDriver Driver
 
@@ -23,6 +25,29 @@ type Capacity struct {
 	Total uint64 `json:"total"`
 	// available size(byte)
 	Free uint64 `json:"free"`
+	// used size(byte)
+	Used uint64 `json:"used"`
+	// Driver is the registry storage driver the numbers describe.
+	Driver string `json:"driver"`
+	// Measured is true when the numbers were read on the registry's own storage
+	// volume (harbor-next #839, theme B) rather than on core's local disk.
+	Measured bool `json:"measured"`
+	// MeasuredAt is when the measurement was taken; zero when not measured.
+	MeasuredAt time.Time `json:"measured_at"`
+}
+
+// VolumeInfo is what registryctl reports about the registry's storage volume.
+type VolumeInfo struct {
+	// Driver is the registry storage driver name.
+	Driver string `json:"driver"`
+	// Supported is false when the driver cannot be measured (object stores).
+	Supported bool `json:"supported"`
+	// Path is the measured root directory for the filesystem driver.
+	Path       string    `json:"path,omitempty"`
+	Total      uint64    `json:"total"`
+	Free       uint64    `json:"free"`
+	Used       uint64    `json:"used"`
+	MeasuredAt time.Time `json:"measured_at"`
 }
 
 // Driver defines methods that an image storage driver must implement

--- a/src/pkg/systeminfo/imagestorage/registryctl/driver.go
+++ b/src/pkg/systeminfo/imagestorage/registryctl/driver.go
@@ -1,0 +1,108 @@
+// Copyright Project Harbor Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package registryctl is the image storage driver that asks registryctl for
+// the registry volume's usage (harbor-next #839, theme B: core pulls, because
+// the core-to-registryctl edge and its secret already exist). registryctl
+// shares the registry's mount, so its statfs is truthful where core's own disk
+// is not. Results are cached briefly so the global quota gate on the push path
+// does not turn into one HTTP call per push.
+package registryctl
+
+import (
+	"context"
+	"time"
+
+	"github.com/goharbor/harbor/src/lib/cache"
+	"github.com/goharbor/harbor/src/lib/log"
+	storage "github.com/goharbor/harbor/src/pkg/systeminfo/imagestorage"
+	"github.com/goharbor/harbor/src/registryctl/client"
+)
+
+const (
+	driverName = "registryctl"
+	cacheKey   = "systeminfo:registryctl_volume"
+	cacheTTL   = time.Minute
+)
+
+type driver struct {
+	client   client.Client
+	fallback storage.Driver
+	cache    func() cache.Cache
+}
+
+// NewDriver returns a driver that measures through registryctl and degrades to
+// the fallback driver (with Measured=false) when registryctl is unreachable or
+// the registry storage driver cannot be measured.
+func NewDriver(c client.Client, fallback storage.Driver) storage.Driver {
+	return &driver{client: c, fallback: fallback, cache: cache.Default}
+}
+
+// Name ...
+func (d *driver) Name() string {
+	return driverName
+}
+
+// Cap ...
+func (d *driver) Cap() (*storage.Capacity, error) {
+	info, err := d.volume()
+	if err != nil {
+		log.Warningf("registryctl storage measurement unavailable, falling back to local disk: %v", err)
+		return d.unmeasured()
+	}
+	if !info.Supported {
+		return d.unmeasured()
+	}
+	return &storage.Capacity{
+		Total:      info.Total,
+		Free:       info.Free,
+		Used:       info.Used,
+		Driver:     info.Driver,
+		Measured:   true,
+		MeasuredAt: info.MeasuredAt,
+	}, nil
+}
+
+func (d *driver) unmeasured() (*storage.Capacity, error) {
+	if d.fallback == nil {
+		return &storage.Capacity{}, nil
+	}
+	c, err := d.fallback.Cap()
+	if err != nil {
+		return nil, err
+	}
+	c.Measured = false
+	if c.Driver == "" {
+		c.Driver = d.fallback.Name()
+	}
+	return c, nil
+}
+
+func (d *driver) volume() (*storage.VolumeInfo, error) {
+	if d.client == nil {
+		return nil, errNoClient
+	}
+	ca := d.cache()
+	if ca == nil {
+		return d.client.Storage()
+	}
+	info := &storage.VolumeInfo{}
+	err := cache.FetchOrSave(context.Background(), ca, cacheKey, info, func() (any, error) {
+		return d.client.Storage()
+	}, cacheTTL)
+	if err != nil {
+		return nil, err
+	}
+	return info, nil
+}

--- a/src/pkg/systeminfo/imagestorage/registryctl/driver.go
+++ b/src/pkg/systeminfo/imagestorage/registryctl/driver.go
@@ -34,6 +34,9 @@ const (
 	driverName = "registryctl"
 	cacheKey   = "systeminfo:registryctl_volume"
 	cacheTTL   = time.Minute
+	// callTimeout bounds one registryctl round trip; Cap runs on the push path
+	// through the global quota gate, so a hung registryctl must fall back fast.
+	callTimeout = 5 * time.Second
 )
 
 type driver struct {
@@ -62,7 +65,9 @@ func (d *driver) Cap() (*storage.Capacity, error) {
 		return d.unmeasured()
 	}
 	if !info.Supported {
-		return d.unmeasured()
+		// Object stores expose no capacity; report the real driver with zero
+		// sizes rather than core's local disk, which would describe the wrong volume.
+		return &storage.Capacity{Driver: info.Driver, Measured: false}, nil
 	}
 	return &storage.Capacity{
 		Total:      info.Total,
@@ -86,6 +91,9 @@ func (d *driver) unmeasured() (*storage.Capacity, error) {
 	if c.Driver == "" {
 		c.Driver = d.fallback.Name()
 	}
+	if c.Used == 0 && c.Total >= c.Free {
+		c.Used = c.Total - c.Free
+	}
 	return c, nil
 }
 
@@ -93,13 +101,15 @@ func (d *driver) volume() (*storage.VolumeInfo, error) {
 	if d.client == nil {
 		return nil, errNoClient
 	}
+	ctx, cancel := context.WithTimeout(context.Background(), callTimeout)
+	defer cancel()
 	ca := d.cache()
 	if ca == nil {
-		return d.client.Storage()
+		return d.client.Storage(ctx)
 	}
 	info := &storage.VolumeInfo{}
-	err := cache.FetchOrSave(context.Background(), ca, cacheKey, info, func() (any, error) {
-		return d.client.Storage()
+	err := cache.FetchOrSave(ctx, ca, cacheKey, info, func() (any, error) {
+		return d.client.Storage(ctx)
 	}, cacheTTL)
 	if err != nil {
 		return nil, err

--- a/src/pkg/systeminfo/imagestorage/registryctl/driver_test.go
+++ b/src/pkg/systeminfo/imagestorage/registryctl/driver_test.go
@@ -15,6 +15,7 @@
 package registryctl
 
 import (
+	"context"
 	"errors"
 	"testing"
 	"time"
@@ -31,13 +32,18 @@ type fakeClient struct {
 	info  *storage.VolumeInfo
 	err   error
 	calls int
+	block bool
 }
 
 func (f *fakeClient) Health() error                       { return nil }
 func (f *fakeClient) DeleteBlob(string) error             { return nil }
 func (f *fakeClient) DeleteManifest(string, string) error { return nil }
-func (f *fakeClient) Storage() (*storage.VolumeInfo, error) {
+func (f *fakeClient) Storage(ctx context.Context) (*storage.VolumeInfo, error) {
 	f.calls++
+	if f.block {
+		<-ctx.Done()
+		return nil, ctx.Err()
+	}
 	return f.info, f.err
 }
 
@@ -74,14 +80,27 @@ func TestUnreachableFallsBack(t *testing.T) {
 	require.NoError(t, err)
 	assert.False(t, got.Measured)
 	assert.Equal(t, uint64(10), got.Total)
+	assert.Equal(t, uint64(6), got.Used, "fallback derives used from total-free")
 	assert.Equal(t, "filesystem", got.Driver)
 }
 
-func TestUnsupportedDriverFallsBack(t *testing.T) {
+func TestUnsupportedDriverReportsRealDriver(t *testing.T) {
 	c := &fakeClient{info: &storage.VolumeInfo{Driver: "s3", Supported: false}}
 	got, err := newDriver(c, nil).Cap()
 	require.NoError(t, err)
 	assert.False(t, got.Measured)
+	assert.Equal(t, "s3", got.Driver)
+	assert.Zero(t, got.Total, "local disk numbers must not be attributed to the object store")
+}
+
+func TestHungRegistryctlFallsBackWithinTimeout(t *testing.T) {
+	c := &fakeClient{block: true}
+	d := newDriver(c, nil)
+	start := time.Now()
+	got, err := d.Cap()
+	require.NoError(t, err)
+	assert.False(t, got.Measured)
+	assert.Less(t, time.Since(start), callTimeout+2*time.Second)
 }
 
 func TestNoClient(t *testing.T) {

--- a/src/pkg/systeminfo/imagestorage/registryctl/driver_test.go
+++ b/src/pkg/systeminfo/imagestorage/registryctl/driver_test.go
@@ -1,0 +1,105 @@
+// Copyright Project Harbor Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package registryctl
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/goharbor/harbor/src/lib/cache"
+	_ "github.com/goharbor/harbor/src/lib/cache/memory"
+	storage "github.com/goharbor/harbor/src/pkg/systeminfo/imagestorage"
+)
+
+type fakeClient struct {
+	info  *storage.VolumeInfo
+	err   error
+	calls int
+}
+
+func (f *fakeClient) Health() error                       { return nil }
+func (f *fakeClient) DeleteBlob(string) error             { return nil }
+func (f *fakeClient) DeleteManifest(string, string) error { return nil }
+func (f *fakeClient) Storage() (*storage.VolumeInfo, error) {
+	f.calls++
+	return f.info, f.err
+}
+
+type fakeFallback struct{ capacity *storage.Capacity }
+
+func (fakeFallback) Name() string { return "filesystem" }
+func (f fakeFallback) Cap() (*storage.Capacity, error) {
+	return f.capacity, nil
+}
+
+func newDriver(c *fakeClient, ca cache.Cache) *driver {
+	return &driver{
+		client:   c,
+		fallback: fakeFallback{capacity: &storage.Capacity{Total: 10, Free: 4}},
+		cache:    func() cache.Cache { return ca },
+	}
+}
+
+func TestMeasured(t *testing.T) {
+	at := time.Now().UTC().Truncate(time.Second)
+	c := &fakeClient{info: &storage.VolumeInfo{Driver: "filesystem", Supported: true, Total: 100, Free: 40, Used: 60, MeasuredAt: at}}
+	got, err := newDriver(c, nil).Cap()
+	require.NoError(t, err)
+	assert.True(t, got.Measured)
+	assert.Equal(t, uint64(60), got.Used)
+	assert.Equal(t, uint64(100), got.Total)
+	assert.Equal(t, "filesystem", got.Driver)
+	assert.Equal(t, at, got.MeasuredAt)
+}
+
+func TestUnreachableFallsBack(t *testing.T) {
+	c := &fakeClient{err: errors.New("connection refused")}
+	got, err := newDriver(c, nil).Cap()
+	require.NoError(t, err)
+	assert.False(t, got.Measured)
+	assert.Equal(t, uint64(10), got.Total)
+	assert.Equal(t, "filesystem", got.Driver)
+}
+
+func TestUnsupportedDriverFallsBack(t *testing.T) {
+	c := &fakeClient{info: &storage.VolumeInfo{Driver: "s3", Supported: false}}
+	got, err := newDriver(c, nil).Cap()
+	require.NoError(t, err)
+	assert.False(t, got.Measured)
+}
+
+func TestNoClient(t *testing.T) {
+	d := &driver{cache: func() cache.Cache { return nil }}
+	got, err := d.Cap()
+	require.NoError(t, err)
+	assert.False(t, got.Measured)
+	assert.Zero(t, got.Total)
+}
+
+func TestCached(t *testing.T) {
+	ca, err := cache.New("memory")
+	require.NoError(t, err)
+	c := &fakeClient{info: &storage.VolumeInfo{Driver: "filesystem", Supported: true, Total: 100, Free: 1, Used: 99}}
+	d := newDriver(c, ca)
+	for range 5 {
+		_, err := d.Cap()
+		require.NoError(t, err)
+	}
+	assert.Equal(t, 1, c.calls)
+}

--- a/src/pkg/systeminfo/imagestorage/registryctl/errors.go
+++ b/src/pkg/systeminfo/imagestorage/registryctl/errors.go
@@ -1,0 +1,19 @@
+// Copyright Project Harbor Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package registryctl
+
+import "errors"
+
+var errNoClient = errors.New("registryctl client is not initialized")

--- a/src/pkg/systeminfo/systeminfo.go
+++ b/src/pkg/systeminfo/systeminfo.go
@@ -39,9 +39,3 @@ func Init() {
 		imagestorage.GlobalDriver = regctldriver.NewDriver(registryctl.RegistryCtlClient, local)
 	})
 }
-
-// ResetForTest discards the initialized driver so the next Init rebuilds it.
-func ResetForTest() {
-	initOnce = sync.Once{}
-	imagestorage.GlobalDriver = nil
-}

--- a/src/pkg/systeminfo/systeminfo.go
+++ b/src/pkg/systeminfo/systeminfo.go
@@ -16,16 +16,32 @@ package systeminfo
 
 import (
 	"os"
+	"sync"
 
+	"github.com/goharbor/harbor/src/common/registryctl"
 	"github.com/goharbor/harbor/src/pkg/systeminfo/imagestorage"
 	"github.com/goharbor/harbor/src/pkg/systeminfo/imagestorage/filesystem"
+	regctldriver "github.com/goharbor/harbor/src/pkg/systeminfo/imagestorage/registryctl"
 )
 
-// Init image storage driver
+var initOnce sync.Once
+
+// Init image storage driver: registryctl measures the registry's own volume
+// (harbor-next #839, theme B); core's local disk is only the fallback, kept
+// for Compose installs where both share the host's data directory.
 func Init() {
-	path := os.Getenv("IMAGE_STORE_PATH")
-	if len(path) == 0 {
-		path = "/data"
-	}
-	imagestorage.GlobalDriver = filesystem.NewDriver(path)
+	initOnce.Do(func() {
+		path := os.Getenv("IMAGE_STORE_PATH")
+		if len(path) == 0 {
+			path = "/data"
+		}
+		local := filesystem.NewDriver(path)
+		imagestorage.GlobalDriver = regctldriver.NewDriver(registryctl.RegistryCtlClient, local)
+	})
+}
+
+// ResetForTest discards the initialized driver so the next Init rebuilds it.
+func ResetForTest() {
+	initOnce = sync.Once{}
+	imagestorage.GlobalDriver = nil
 }

--- a/src/registryctl/api/registry/storage/storage.go
+++ b/src/registryctl/api/registry/storage/storage.go
@@ -1,0 +1,72 @@
+// Copyright Project Harbor Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package storage reports the registry's storage volume usage (harbor-next
+// #839, theme B). registryctl is the only Harbor component that shares the
+// registry's mount, so this is where a truthful statfs can run. Object-store
+// drivers expose no capacity API and are reported as unsupported.
+package storage
+
+import (
+	"net/http"
+	"time"
+
+	"github.com/goharbor/harbor/src/lib/log"
+	"github.com/goharbor/harbor/src/pkg/systeminfo/imagestorage"
+	"github.com/goharbor/harbor/src/pkg/systeminfo/imagestorage/filesystem"
+	"github.com/goharbor/harbor/src/registryctl/api"
+)
+
+const filesystemDriver = "filesystem"
+
+// NewHandler returns the handler for GET /api/registry/storage.
+func NewHandler(storageType, storageRoot string) http.Handler {
+	h := &handler{storageType: storageType, storageRoot: storageRoot}
+	if storageType == filesystemDriver {
+		h.fs = filesystem.NewDriver(storageRoot)
+	}
+	return h
+}
+
+type handler struct {
+	storageType string
+	storageRoot string
+	fs          imagestorage.Driver
+}
+
+func (h *handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		api.HandleNotMethodAllowed(w)
+		return
+	}
+	info := &imagestorage.VolumeInfo{Driver: h.storageType}
+	if h.fs != nil {
+		capacity, err := h.fs.Cap()
+		if err != nil {
+			log.Errorf("failed to measure storage volume %s: %v", h.storageRoot, err)
+			api.HandleInternalServerError(w, err)
+			return
+		}
+		info.Supported = true
+		info.Path = h.storageRoot
+		info.Total = capacity.Total
+		info.Free = capacity.Free
+		if capacity.Total >= capacity.Free {
+			info.Used = capacity.Total - capacity.Free
+		}
+		info.MeasuredAt = time.Now().UTC()
+	}
+	w.Header().Set("Content-Type", "application/json")
+	_ = api.WriteJSON(w, info)
+}

--- a/src/registryctl/api/registry/storage/storage.go
+++ b/src/registryctl/api/registry/storage/storage.go
@@ -19,7 +19,9 @@
 package storage
 
 import (
+	"fmt"
 	"net/http"
+	"os"
 	"time"
 
 	"github.com/goharbor/harbor/src/lib/log"
@@ -52,6 +54,13 @@ func (h *handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 	info := &imagestorage.VolumeInfo{Driver: h.storageType}
 	if h.fs != nil {
+		// filesystem.Cap reports zeros without an error for a missing path; that
+		// must not be advertised as a measurement of an empty volume.
+		if _, err := os.Stat(h.storageRoot); err != nil {
+			log.Errorf("registry storage root %s is not accessible: %v", h.storageRoot, err)
+			api.HandleInternalServerError(w, fmt.Errorf("registry storage root %s is not accessible: %w", h.storageRoot, err))
+			return
+		}
 		capacity, err := h.fs.Cap()
 		if err != nil {
 			log.Errorf("failed to measure storage volume %s: %v", h.storageRoot, err)

--- a/src/registryctl/api/registry/storage/storage_test.go
+++ b/src/registryctl/api/registry/storage/storage_test.go
@@ -1,0 +1,63 @@
+// Copyright Project Harbor Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package storage
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/goharbor/harbor/src/pkg/systeminfo/imagestorage"
+)
+
+func serve(t *testing.T, h http.Handler, method string) (*httptest.ResponseRecorder, *imagestorage.VolumeInfo) {
+	t.Helper()
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, httptest.NewRequest(method, "/api/registry/storage", nil))
+	info := &imagestorage.VolumeInfo{}
+	if rec.Code == http.StatusOK {
+		require.NoError(t, json.Unmarshal(rec.Body.Bytes(), info))
+	}
+	return rec, info
+}
+
+func TestFilesystemIsMeasured(t *testing.T) {
+	rec, info := serve(t, NewHandler("filesystem", t.TempDir()), http.MethodGet)
+	assert.Equal(t, http.StatusOK, rec.Code)
+	assert.Equal(t, "filesystem", info.Driver)
+	assert.True(t, info.Supported)
+	assert.NotEmpty(t, info.Path)
+	assert.Greater(t, info.Total, uint64(0))
+	assert.Equal(t, info.Total-info.Free, info.Used)
+	assert.False(t, info.MeasuredAt.IsZero())
+}
+
+func TestObjectStoreIsUnsupported(t *testing.T) {
+	rec, info := serve(t, NewHandler("s3", ""), http.MethodGet)
+	assert.Equal(t, http.StatusOK, rec.Code)
+	assert.Equal(t, "s3", info.Driver)
+	assert.False(t, info.Supported)
+	assert.Zero(t, info.Total)
+	assert.True(t, info.MeasuredAt.IsZero())
+}
+
+func TestMethodNotAllowed(t *testing.T) {
+	rec, _ := serve(t, NewHandler("filesystem", t.TempDir()), http.MethodDelete)
+	assert.Equal(t, http.StatusMethodNotAllowed, rec.Code)
+}

--- a/src/registryctl/api/registry/storage/storage_test.go
+++ b/src/registryctl/api/registry/storage/storage_test.go
@@ -57,6 +57,11 @@ func TestObjectStoreIsUnsupported(t *testing.T) {
 	assert.True(t, info.MeasuredAt.IsZero())
 }
 
+func TestMissingRootIsAnError(t *testing.T) {
+	rec, _ := serve(t, NewHandler("filesystem", "/definitely/not/here"), http.MethodGet)
+	assert.Equal(t, http.StatusInternalServerError, rec.Code)
+}
+
 func TestMethodNotAllowed(t *testing.T) {
 	rec, _ := serve(t, NewHandler("filesystem", t.TempDir()), http.MethodDelete)
 	assert.Equal(t, http.StatusMethodNotAllowed, rec.Code)

--- a/src/registryctl/client/client.go
+++ b/src/registryctl/client/client.go
@@ -15,6 +15,7 @@
 package client
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -42,8 +43,9 @@ type Client interface {
 	DeleteBlob(reference string) (err error)
 	// DeleteManifest deletes the specified manifest. The "reference" can be "tag" or "digest"
 	DeleteManifest(repository, reference string) (err error)
-	// Storage reports the registry's storage volume usage as measured by registryctl
-	Storage() (*imagestorage.VolumeInfo, error)
+	// Storage reports the registry's storage volume usage as measured by registryctl.
+	// The context bounds the call; callers on a request path must pass a deadline.
+	Storage(ctx context.Context) (*imagestorage.VolumeInfo, error)
 }
 
 type client struct {
@@ -112,8 +114,8 @@ func (c *client) DeleteManifest(repository, reference string) (err error) {
 }
 
 // Storage ...
-func (c *client) Storage() (*imagestorage.VolumeInfo, error) {
-	req, err := http.NewRequest(http.MethodGet, buildStorageURL(c.baseURL), nil)
+func (c *client) Storage(ctx context.Context) (*imagestorage.VolumeInfo, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, buildStorageURL(c.baseURL), nil)
 	if err != nil {
 		return nil, err
 	}

--- a/src/registryctl/client/client.go
+++ b/src/registryctl/client/client.go
@@ -15,6 +15,7 @@
 package client
 
 import (
+	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
@@ -25,6 +26,7 @@ import (
 	"github.com/goharbor/harbor/src/common/utils"
 	"github.com/goharbor/harbor/src/lib/errors"
 	"github.com/goharbor/harbor/src/pkg/registry/interceptor"
+	"github.com/goharbor/harbor/src/pkg/systeminfo/imagestorage"
 )
 
 // const definition
@@ -40,6 +42,8 @@ type Client interface {
 	DeleteBlob(reference string) (err error)
 	// DeleteManifest deletes the specified manifest. The "reference" can be "tag" or "digest"
 	DeleteManifest(repository, reference string) (err error)
+	// Storage reports the registry's storage volume usage as measured by registryctl
+	Storage() (*imagestorage.VolumeInfo, error)
 }
 
 type client struct {
@@ -107,6 +111,24 @@ func (c *client) DeleteManifest(repository, reference string) (err error) {
 	return nil
 }
 
+// Storage ...
+func (c *client) Storage() (*imagestorage.VolumeInfo, error) {
+	req, err := http.NewRequest(http.MethodGet, buildStorageURL(c.baseURL), nil)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := c.do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	info := &imagestorage.VolumeInfo{}
+	if err := json.NewDecoder(resp.Body).Decode(info); err != nil {
+		return nil, err
+	}
+	return info, nil
+}
+
 func (c *client) do(req *http.Request) (*http.Response, error) {
 	for _, interceptor := range c.interceptors {
 		if err := interceptor.Intercept(req); err != nil {
@@ -145,4 +167,8 @@ func buildManifestURL(endpoint, repository, reference string) string {
 
 func buildBlobURL(endpoint, reference string) string {
 	return fmt.Sprintf("%s/api/registry/blob/%s", endpoint, reference)
+}
+
+func buildStorageURL(endpoint string) string {
+	return fmt.Sprintf("%s/api/registry/storage", endpoint)
 }

--- a/src/registryctl/client/client_test.go
+++ b/src/registryctl/client/client_test.go
@@ -15,6 +15,7 @@
 package client
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"os"
@@ -66,16 +67,62 @@ func (c *clientTestSuite) TestStorage() {
 			Pattern: "/api/registry/storage",
 			Handler: test.Handler(&test.Response{
 				StatusCode: http.StatusOK,
-				Body:       []byte(`{"driver":"filesystem","supported":true,"path":"/storage","total":100,"free":40,"used":60}`),
+				Body:       []byte(`{"driver":"filesystem","supported":true,"path":"/storage","total":100,"free":40,"used":60,"measured_at":"2026-09-08T12:00:00Z"}`),
 			}),
 		})
 	defer server.Close()
 
-	info, err := NewClient(server.URL, &Config{}).Storage()
+	info, err := NewClient(server.URL, &Config{}).Storage(context.Background())
 	c.Require().Nil(err)
 	c.Equal("filesystem", info.Driver)
 	c.True(info.Supported)
+	c.Equal("/storage", info.Path)
+	c.Equal(uint64(100), info.Total)
+	c.Equal(uint64(40), info.Free)
 	c.Equal(uint64(60), info.Used)
+	c.Equal(2026, info.MeasuredAt.Year())
+}
+
+func (c *clientTestSuite) TestStorageErrors() {
+	// non-2xx
+	server := test.NewServer(
+		&test.RequestHandlerMapping{
+			Method:  "GET",
+			Pattern: "/api/registry/storage",
+			Handler: test.Handler(&test.Response{StatusCode: http.StatusInternalServerError, Body: []byte("boom")}),
+		})
+	_, err := NewClient(server.URL, &Config{}).Storage(context.Background())
+	c.Require().NotNil(err)
+	c.Contains(err.Error(), "boom")
+	server.Close()
+
+	// malformed body
+	server = test.NewServer(
+		&test.RequestHandlerMapping{
+			Method:  "GET",
+			Pattern: "/api/registry/storage",
+			Handler: test.Handler(&test.Response{StatusCode: http.StatusOK, Body: []byte("{not json")}),
+		})
+	_, err = NewClient(server.URL, &Config{}).Storage(context.Background())
+	c.Require().NotNil(err)
+	server.Close()
+
+	// transport failure: the server is gone
+	_, err = NewClient(server.URL, &Config{}).Storage(context.Background())
+	c.Require().NotNil(err)
+
+	// canceled context
+	server = test.NewServer(
+		&test.RequestHandlerMapping{
+			Method:  "GET",
+			Pattern: "/api/registry/storage",
+			Handler: test.Handler(&test.Response{StatusCode: http.StatusOK, Body: []byte("{}")}),
+		})
+	defer server.Close()
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	_, err = NewClient(server.URL, &Config{}).Storage(ctx)
+	c.Require().NotNil(err)
 }
 
 func (c *clientTestSuite) TestDeleteBlob() {

--- a/src/registryctl/client/client_test.go
+++ b/src/registryctl/client/client_test.go
@@ -59,6 +59,25 @@ func (c *clientTestSuite) TestDeleteManifest() {
 	c.Require().Nil(err)
 }
 
+func (c *clientTestSuite) TestStorage() {
+	server := test.NewServer(
+		&test.RequestHandlerMapping{
+			Method:  "GET",
+			Pattern: "/api/registry/storage",
+			Handler: test.Handler(&test.Response{
+				StatusCode: http.StatusOK,
+				Body:       []byte(`{"driver":"filesystem","supported":true,"path":"/storage","total":100,"free":40,"used":60}`),
+			}),
+		})
+	defer server.Close()
+
+	info, err := NewClient(server.URL, &Config{}).Storage()
+	c.Require().Nil(err)
+	c.Equal("filesystem", info.Driver)
+	c.True(info.Supported)
+	c.Equal(uint64(60), info.Used)
+}
+
 func (c *clientTestSuite) TestDeleteBlob() {
 	server := test.NewServer(
 		&test.RequestHandlerMapping{

--- a/src/registryctl/config/config.go
+++ b/src/registryctl/config/config.go
@@ -40,7 +40,14 @@ type Configuration struct {
 	} `yaml:"https_config,omitempty"`
 	RegistryConfig string                      `yaml:"registry_config"`
 	StorageDriver  storagedriver.StorageDriver `yaml:"-"`
+	// StorageType is the registry storage driver name, e.g. "filesystem" or "s3".
+	StorageType string `yaml:"-"`
+	// StorageRoot is the filesystem driver's rootdirectory; empty for other drivers.
+	StorageRoot string `yaml:"-"`
 }
+
+// defaultFilesystemRoot is distribution's default for the filesystem driver's rootdirectory.
+const defaultFilesystemRoot = "/var/lib/registry"
 
 // Load the configuration options from the specified yaml file.
 func (c *Configuration) Load(yamlFilePath string, detectEnv bool) error {
@@ -83,6 +90,16 @@ func (c *Configuration) setStorageDriver() error {
 		return err
 	}
 	c.StorageDriver = storageDriver
+	c.StorageType = rConf.Storage.Type()
+	c.StorageRoot = ""
+	if c.StorageType == "filesystem" {
+		c.StorageRoot = defaultFilesystemRoot
+		if root, ok := rConf.Storage.Parameters()["rootdirectory"]; ok {
+			if str := fmt.Sprint(root); str != "" {
+				c.StorageRoot = str
+			}
+		}
+	}
 	return nil
 }
 

--- a/src/registryctl/handlers/router.go
+++ b/src/registryctl/handlers/router.go
@@ -22,6 +22,7 @@ import (
 	"github.com/goharbor/harbor/src/registryctl/api"
 	"github.com/goharbor/harbor/src/registryctl/api/registry/blob"
 	"github.com/goharbor/harbor/src/registryctl/api/registry/manifest"
+	"github.com/goharbor/harbor/src/registryctl/api/registry/storage"
 	"github.com/goharbor/harbor/src/registryctl/config"
 )
 
@@ -33,5 +34,6 @@ func newRouter(conf config.Configuration) http.Handler {
 
 	rootRouter.Path("/api/registry/blob/{reference}").Methods(http.MethodDelete).Handler(blob.NewHandler(conf.StorageDriver))
 	rootRouter.Path("/api/registry/{name:.*}/manifests/{reference}").Methods(http.MethodDelete).Handler(manifest.NewHandler(conf.StorageDriver))
+	rootRouter.Path("/api/registry/storage").Methods(http.MethodGet).Handler(storage.NewHandler(conf.StorageType, conf.StorageRoot))
 	return rootRouter
 }

--- a/src/server/v2.0/handler/systeminfo.go
+++ b/src/server/v2.0/handler/systeminfo.go
@@ -67,13 +67,18 @@ func (s *sysInfoAPI) GetVolumes(ctx context.Context, _ systeminfo.GetVolumesPara
 	if err != nil {
 		return s.SendError(ctx, err)
 	}
+	st := &models.Storage{
+		Free:     c.Free,
+		Total:    c.Total,
+		Used:     c.Used,
+		Driver:   c.Driver,
+		Measured: c.Measured,
+	}
+	if c.Measured {
+		st.MeasuredAt = strfmt.DateTime(c.MeasuredAt)
+	}
 	return systeminfo.NewGetVolumesOK().WithPayload(&models.SystemInfo{
-		Storage: []*models.Storage{
-			{
-				Free:  c.Free,
-				Total: c.Total,
-			},
-		},
+		Storage: []*models.Storage{st},
 	})
 }
 

--- a/src/server/v2.0/handler/systeminfo.go
+++ b/src/server/v2.0/handler/systeminfo.go
@@ -75,7 +75,8 @@ func (s *sysInfoAPI) GetVolumes(ctx context.Context, _ systeminfo.GetVolumesPara
 		Measured: c.Measured,
 	}
 	if c.Measured {
-		st.MeasuredAt = strfmt.DateTime(c.MeasuredAt)
+		at := strfmt.DateTime(c.MeasuredAt)
+		st.MeasuredAt = &at
 	}
 	return systeminfo.NewGetVolumesOK().WithPayload(&models.SystemInfo{
 		Storage: []*models.Storage{st},


### PR DESCRIPTION
## Summary

Theme B of the decision record #839: Harbor learns the real size and usage of its registry storage volume. Stacked on #845 (theme A) because it installs the measurer that turns the global quota's usage from `accounted` into `measured`.

- registryctl gains `GET /api/registry/storage`: `statfs` of the registry's `rootdirectory` for the `filesystem` driver, `supported: false` for object stores. registryctl is the only component that shares the registry's mount, so this is the one place a truthful measurement can run.
- Core **pulls** it through the existing registryctl client (`Storage()`), cached for one minute via the shared cache, and degrades to its local disk with `measured: false` when registryctl is unreachable or the driver is unsupported. Core now initializes the registryctl client at startup.
- `GET /api/v2.0/systeminfo/volumes` returns `used`, `driver`, `measured`, `measured_at`; the swagger no longer claims it "only reflects local disk".
- Global quota: `systemquota.SetMeasurer(systeminfo.NewMeasurer())`, so `used_source` becomes `measured` and enforcement uses the physical value where available.
- Exporter gauges `harbor_storage_volume_bytes{kind,driver}` and `harbor_storage_volume_measured` (in-core mode).
- Docs: `docs/storage-usage-reporting.md`.

No Helm or Compose change: registryctl already mounts the volume and core already has `REGISTRY_CONTROLLER_URL` and the secret registryctl accepts.

## Related Issues

Implements #839 (theme B). Depends on #845.

## Type of Change

- [x] New feature (`feat:`)

## Release Notes

`GET /api/v2.0/systeminfo/volumes` now reports the **real registry storage volume** on Kubernetes and Compose installs using filesystem storage: total, free and used bytes measured by registryctl on the registry's own mount, with `measured: true`. Previously the numbers described the core container's disk. Where a global storage quota is set, its usage switches from Harbor's blob accounting to the measured value automatically. Object storage backends are not measured yet and keep reporting `measured: false`. New Prometheus gauges `harbor_storage_volume_bytes` and `harbor_storage_volume_measured` are exposed by the in-core exporter. Nothing needs to be configured. See `docs/storage-usage-reporting.md`.

## Testing

- [x] Unit tests added/updated (registryctl storage handler, registryctl client, core registryctl driver incl. fallback and caching, measurer adapter, exporter collector)
- [ ] Manual testing performed

Local runs: `go test` for all touched packages, `golangci-lint` (0 issues), spectral API lint (0 errors).

## Checklist

- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] Commits are signed off (`git commit -s`)
- [x] No new warnings introduced
