### PR TITLE
ci: Disable Docker build record uploads

### DIFF
--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -125,6 +125,9 @@ jobs:
       - name: Build and push by digest
         id: build
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
+        env:
+          # Build traces can contain signed storage URLs.
+          DOCKER_BUILD_RECORD_UPLOAD: "false"
         with:
           context: .
           file: dockerfile/${{ matrix.component }}.dockerfile

--- a/.github/workflows/publish-images.yml
+++ b/.github/workflows/publish-images.yml
@@ -166,6 +166,9 @@ jobs:
       - name: Build and push by digest
         id: build
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
+        env:
+          # Build traces can contain signed storage URLs.
+          DOCKER_BUILD_RECORD_UPLOAD: "false"
         with:
           context: .
           file: dockerfile/${{ matrix.component }}.dockerfile


### PR DESCRIPTION
## Summary

Docker build records can contain signed storage URLs captured in build traces. Set `DOCKER_BUILD_RECORD_UPLOAD: "false"` on all 2 Docker build-action steps in `pr-ci.yml`, `publish-images.yml` to stop publishing these archives while keeping build summaries enabled.

## Type of Change

- [x] CI/CD or build changes (`ci:` / `build:`)

## Testing

- Parsed the workflows and verified every Docker build-action step disables record uploads.
- Verified the diff contains only the environment setting and its explanatory comment.
- `git diff --check` passed.
- Compared `actionlint` diagnostics with the base revision: no new findings; the same 21 existing runner-label, action-reference, and shellcheck findings remain.

## Checklist

- [x] PR title follows Conventional Commits.
- [x] Commits are signed off (DCO).
- [x] No new warnings introduced.
