### PR TITLE
fix(scan): keep the last report when the raw report is empty

### DIFF
--- a/src/pkg/scan/postprocessors/report_converters.go
+++ b/src/pkg/scan/postprocessors/report_converters.go
@@ -56,14 +56,13 @@ func NewNativeToRelationalSchemaConverter() NativeScanReportConverter {
 // ToRelationalSchema converts the vulnerability report data present as JSON  to the new relational VulnerabilityRecord instance
 func (c *nativeToRelationalSchemaConverter) ToRelationalSchema(ctx context.Context, reportUUID string, registrationUUID string, digest string, reportData string) (string, string, error) {
 	if len(reportData) == 0 {
-		log.G(ctx).Infof("There is no vulnerability report to toSchema for report UUID : %s", reportUUID)
-		// The scan_report row is now reused across re-scans (#23310), so an empty result must still
-		// clear any vulnerability associations left by a previous scan; reconcile to the empty set.
-		// (The structured "clean image" case is already handled by toSchema -> SyncForReport below.)
-		if err := c.dao.SyncForReport(ctx, reportUUID); err != nil {
-			return "", "", errors.Wrap(err, "Error when clearing vulnerability records for empty report")
-		}
-		return reportUUID, "", nil
+		// An empty raw report is not a scan result. The scan_report row is reused across re-scans
+		// (#23310), so clearing associations here would leave the row half-updated (associations gone,
+		// severity counters and report column stale) while the job still fails on the empty report.
+		// Fail before touching the database so the last successful result stays intact. A clean image
+		// arrives as a structured report with an empty vulnerability list and is reconciled to zero by
+		// toSchema.
+		return "", "", errors.Errorf("empty vulnerability report for report UUID %s", reportUUID)
 	}
 	// parse the raw report with the V1 schema of the report to the normalized structures
 	rawReport := new(vuln.Report)

--- a/src/pkg/scan/postprocessors/report_converters_test.go
+++ b/src/pkg/scan/postprocessors/report_converters_test.go
@@ -497,6 +497,58 @@ func (suite *TestReportConverterSuite) TestGenericVulnReportSummaryAfterConversi
 	assert.Equal(suite.T(), 1, sevMapping[vuln.Medium])
 }
 
+// TestConvertEmptyReportKeepsLastResult verifies that an empty raw report is rejected before any
+// database write, so the previous scan result on the reused report row stays intact.
+func (suite *TestReportConverterSuite) TestConvertEmptyReportKeepsLastResult() {
+	ctx := suite.Context()
+	rp := &scan.Report{
+		Digest:           "d1002",
+		RegistrationUUID: suite.registrationID,
+		MimeType:         v1.MimeTypeNativeReport,
+		Report:           sampleReport,
+		StartTime:        time.Now(),
+		EndTime:          time.Now().Add(1000),
+		UUID:             "reportUUIDEmpty",
+	}
+	suite.create(rp)
+
+	// Leave the row the way a successful scan would: associations plus severity counters.
+	_, _, err := suite.rc.ToRelationalSchema(ctx, rp.UUID, rp.RegistrationUUID, rp.Digest, sampleReport)
+	require.NoError(suite.T(), err)
+
+	before, err := suite.vulnerabilityRecordDao.GetForReport(ctx, rp.UUID)
+	require.NoError(suite.T(), err)
+	require.NotEmpty(suite.T(), before, "expected the seeded scan to associate vulnerability records")
+
+	rptsBefore, err := suite.reportDao.List(ctx, q.New(q.KeyWords{"UUID": rp.UUID}))
+	require.NoError(suite.T(), err)
+	require.Equal(suite.T(), 1, len(rptsBefore))
+	require.Equal(suite.T(), int64(1), rptsBefore[0].LowCnt)
+
+	uuid, summary, err := suite.rc.ToRelationalSchema(ctx, rp.UUID, rp.RegistrationUUID, rp.Digest, "")
+	if assert.Error(suite.T(), err, "an empty raw report must be rejected") {
+		assert.Contains(suite.T(), err.Error(), "empty vulnerability report")
+	}
+	assert.Empty(suite.T(), uuid)
+	assert.Empty(suite.T(), summary)
+
+	after, err := suite.vulnerabilityRecordDao.GetForReport(ctx, rp.UUID)
+	require.NoError(suite.T(), err)
+	assert.Len(suite.T(), after, len(before), "vulnerability associations must survive an empty report")
+
+	rptsAfter, err := suite.reportDao.List(ctx, q.New(q.KeyWords{"UUID": rp.UUID}))
+	require.NoError(suite.T(), err)
+	require.Equal(suite.T(), 1, len(rptsAfter))
+	assert.Equal(suite.T(), rptsBefore[0].CriticalCnt, rptsAfter[0].CriticalCnt)
+	assert.Equal(suite.T(), rptsBefore[0].HighCnt, rptsAfter[0].HighCnt)
+	assert.Equal(suite.T(), rptsBefore[0].MediumCnt, rptsAfter[0].MediumCnt)
+	assert.Equal(suite.T(), rptsBefore[0].LowCnt, rptsAfter[0].LowCnt)
+	assert.Equal(suite.T(), rptsBefore[0].NoneCnt, rptsAfter[0].NoneCnt)
+	assert.Equal(suite.T(), rptsBefore[0].UnknownCnt, rptsAfter[0].UnknownCnt)
+	assert.Equal(suite.T(), rptsBefore[0].FixableCnt, rptsAfter[0].FixableCnt)
+	assert.Equal(suite.T(), rptsBefore[0].Report, rptsAfter[0].Report)
+}
+
 func (suite *TestReportConverterSuite) create(r *scan.Report) {
 	id, err := suite.reportDao.Create(orm.Context(), r)
 	require.NoError(suite.T(), err)

--- a/src/pkg/scan/postprocessors/report_converters_test.go
+++ b/src/pkg/scan/postprocessors/report_converters_test.go
@@ -497,6 +497,16 @@ func (suite *TestReportConverterSuite) TestGenericVulnReportSummaryAfterConversi
 	assert.Equal(suite.T(), 1, sevMapping[vuln.Medium])
 }
 
+// recordIDs returns the vulnerability record ids of the given records, so report associations
+// are compared by identity rather than by count.
+func recordIDs(records []*scan.VulnerabilityRecord) []int64 {
+	ids := make([]int64, 0, len(records))
+	for _, r := range records {
+		ids = append(ids, r.ID)
+	}
+	return ids
+}
+
 // TestConvertEmptyReportKeepsLastResult verifies that an empty raw report is rejected before any
 // database write, so the previous scan result on the reused report row stays intact.
 func (suite *TestReportConverterSuite) TestConvertEmptyReportKeepsLastResult() {
@@ -534,7 +544,7 @@ func (suite *TestReportConverterSuite) TestConvertEmptyReportKeepsLastResult() {
 
 	after, err := suite.vulnerabilityRecordDao.GetForReport(ctx, rp.UUID)
 	require.NoError(suite.T(), err)
-	assert.Len(suite.T(), after, len(before), "vulnerability associations must survive an empty report")
+	assert.ElementsMatch(suite.T(), recordIDs(before), recordIDs(after), "vulnerability associations must survive an empty report")
 
 	rptsAfter, err := suite.reportDao.List(ctx, q.New(q.KeyWords{"UUID": rp.UUID}))
 	require.NoError(suite.T(), err)


### PR DESCRIPTION
A re-scan that yields an empty raw report no longer wipes the artifact's vulnerability associations. The empty report is rejected before any database write, so the last successful result stays intact and the scan is marked failed.

## Problem

`ToRelationalSchema` has an early branch for an empty raw report. Since #259 it calls `SyncForReport` with no ids and returns a nil error. The `scan_report` row is now reused across re-scans, so that call clears every vulnerability association the previous scan left behind.

The branch returns before `updateReport`, so the severity counters and the `report` column keep the previous scan's values. The caller in `src/pkg/scan/job.go` then calls `handler.Update(uuid, "")`, and `UpdateReportData` rejects that with "missing report JSON data". The job fails regardless.

The net effect is a half updated row. Associations are gone, counters and report text are stale, and the task ends as Error. Security Hub's summary then disagrees with the vulnerability list it links to, which contradicts what #259 set out to guarantee.

The path is reachable only through a jobservice shutdown race. The per mime goroutine in `job.go` returns on `ctx.SystemContext().Done()` without recording an error, and `shouldStop` only inspects the OP command, so an empty entry in `rawReports` falls through to `PostScan`. For both vulnerability mime types `fetchScanReportFromScanner` already rejects an empty body through `ResolveData`.

## Solution

Reject an empty raw report before touching the database, returning an error instead of a nil error and a reused UUID. The job already fails on this input, so nothing that used to succeed starts failing.

A clean image is not affected. It arrives as a structured report with an empty `vulnerabilities` array, goes through `toSchema`, and reconciles to zero.

## What is the worst possible consequence of not fixing it?

When the path fires, the reused row ends up with its associations wiped while the severity counters and the `report` column still hold the previous scan, and the task is marked Error. The vulnerabilities tab and `/security/vul` then say the artifact has no findings, while `/security/summary` and the dangerous artifacts panel keep the old numbers. Two views of the same artifact contradict each other until the next successful scan.

An operator who trusts the empty vulnerability list treats a vulnerable image as clean. The pull-time gate is not affected, because it reads the task status, sees Error, and fails closed. The trigger is a jobservice shutdown while a job is waiting for its report, so a single hit is rare. A registry that restarts jobservice during a nightly Scan All can hit it on many artifacts at once, and every one of them reads as clean until it is scanned again.

## Benefits

A failed re-scan keeps the last good result visible, which is what #259 promised. Severity counters and the vulnerability list can no longer drift apart on this path, so the Security Hub summary stays consistent with the artifact detail view. The scan is reported as failed rather than silently degrading stored data.

## Related Issues

Follow-up to #259.

Addresses the review thread at https://github.com/container-registry/harbor-next/pull/259#discussion_r3355288098

The same diff is open upstream as goharbor/harbor#23319, where it has been applied as a separate commit on the existing branch.

## Type of Change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` / `fix!:`)
- [ ] Documentation (`docs:`)
- [ ] Refactoring (`refactor:`)
- [ ] CI/CD or build changes (`ci:` / `build:`)
- [ ] Upstream Harbor cherry-pick (`upstream:`)
- [ ] Dependencies update (`chore:`)
- [ ] Tests (`test:`)

## Release Notes

A re-scan that yields an empty raw report no longer clears the artifact's vulnerability associations while leaving its severity counters at the previous scan's values. The last successful result is kept and the scan is marked failed.

## Testing

- [x] Unit tests added/updated
- [ ] Manual testing performed

`TestConvertEmptyReportKeepsLastResult` seeds a report row through a real successful conversion, calls `ToRelationalSchema` with an empty report, and asserts the error plus unchanged associations, all seven severity counters and the `report` column. With the fix reverted the test fails on the association assertion while the counter assertions still pass, which is exactly the half updated row.

```
ok  	github.com/goharbor/harbor/src/pkg/scan/postprocessors	0.527s
ok  	github.com/goharbor/harbor/src/pkg/scan/vulnerability	0.405s
```

`go vet -tags db ./pkg/scan/...` is clean and `golangci-lint` v2.13.2 reports 0 issues on both packages.

## Checklist

- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] Commits are signed off (`git commit -s`)
- [x] No new warnings introduced

