### PR TITLE
fix(scan): Keep the last report when the raw report is empty (backport #863)

### DIFF
--- a/src/pkg/scan/postprocessors/report_converters.go
+++ b/src/pkg/scan/postprocessors/report_converters.go
@@ -56,14 +56,13 @@ func NewNativeToRelationalSchemaConverter() NativeScanReportConverter {
 // ToRelationalSchema converts the vulnerability report data present as JSON  to the new relational VulnerabilityRecord instance
 func (c *nativeToRelationalSchemaConverter) ToRelationalSchema(ctx context.Context, reportUUID string, registrationUUID string, digest string, reportData string) (string, string, error) {
 	if len(reportData) == 0 {
-		log.G(ctx).Infof("There is no vulnerability report to toSchema for report UUID : %s", reportUUID)
-		// The scan_report row is now reused across re-scans (#23310), so an empty result must still
-		// clear any vulnerability associations left by a previous scan; reconcile to the empty set.
-		// (The structured "clean image" case is already handled by toSchema -> SyncForReport below.)
-		if err := c.dao.SyncForReport(ctx, reportUUID); err != nil {
-			return "", "", errors.Wrap(err, "Error when clearing vulnerability records for empty report")
-		}
-		return reportUUID, "", nil
+		// An empty raw report is not a scan result. The scan_report row is reused across re-scans
+		// (#23310), so clearing associations here would leave the row half-updated (associations gone,
+		// severity counters and report column stale) while the job still fails on the empty report.
+		// Fail before touching the database so the last successful result stays intact. A clean image
+		// arrives as a structured report with an empty vulnerability list and is reconciled to zero by
+		// toSchema.
+		return "", "", errors.Errorf("empty vulnerability report for report UUID %s", reportUUID)
 	}
 	// parse the raw report with the V1 schema of the report to the normalized structures
 	rawReport := new(vuln.Report)

--- a/src/pkg/scan/postprocessors/report_converters_test.go
+++ b/src/pkg/scan/postprocessors/report_converters_test.go
@@ -497,6 +497,68 @@ func (suite *TestReportConverterSuite) TestGenericVulnReportSummaryAfterConversi
 	assert.Equal(suite.T(), 1, sevMapping[vuln.Medium])
 }
 
+// recordIDs returns the vulnerability record ids of the given records, so report associations
+// are compared by identity rather than by count.
+func recordIDs(records []*scan.VulnerabilityRecord) []int64 {
+	ids := make([]int64, 0, len(records))
+	for _, r := range records {
+		ids = append(ids, r.ID)
+	}
+	return ids
+}
+
+// TestConvertEmptyReportKeepsLastResult verifies that an empty raw report is rejected before any
+// database write, so the previous scan result on the reused report row stays intact.
+func (suite *TestReportConverterSuite) TestConvertEmptyReportKeepsLastResult() {
+	ctx := suite.Context()
+	rp := &scan.Report{
+		Digest:           "d1002",
+		RegistrationUUID: suite.registrationID,
+		MimeType:         v1.MimeTypeNativeReport,
+		Report:           sampleReport,
+		StartTime:        time.Now(),
+		EndTime:          time.Now().Add(1000),
+		UUID:             "reportUUIDEmpty",
+	}
+	suite.create(rp)
+
+	// Leave the row the way a successful scan would: associations plus severity counters.
+	_, _, err := suite.rc.ToRelationalSchema(ctx, rp.UUID, rp.RegistrationUUID, rp.Digest, sampleReport)
+	require.NoError(suite.T(), err)
+
+	before, err := suite.vulnerabilityRecordDao.GetForReport(ctx, rp.UUID)
+	require.NoError(suite.T(), err)
+	require.NotEmpty(suite.T(), before, "expected the seeded scan to associate vulnerability records")
+
+	rptsBefore, err := suite.reportDao.List(ctx, q.New(q.KeyWords{"UUID": rp.UUID}))
+	require.NoError(suite.T(), err)
+	require.Equal(suite.T(), 1, len(rptsBefore))
+	require.Equal(suite.T(), int64(1), rptsBefore[0].LowCnt)
+
+	uuid, summary, err := suite.rc.ToRelationalSchema(ctx, rp.UUID, rp.RegistrationUUID, rp.Digest, "")
+	if assert.Error(suite.T(), err, "an empty raw report must be rejected") {
+		assert.Contains(suite.T(), err.Error(), "empty vulnerability report")
+	}
+	assert.Empty(suite.T(), uuid)
+	assert.Empty(suite.T(), summary)
+
+	after, err := suite.vulnerabilityRecordDao.GetForReport(ctx, rp.UUID)
+	require.NoError(suite.T(), err)
+	assert.ElementsMatch(suite.T(), recordIDs(before), recordIDs(after), "vulnerability associations must survive an empty report")
+
+	rptsAfter, err := suite.reportDao.List(ctx, q.New(q.KeyWords{"UUID": rp.UUID}))
+	require.NoError(suite.T(), err)
+	require.Equal(suite.T(), 1, len(rptsAfter))
+	assert.Equal(suite.T(), rptsBefore[0].CriticalCnt, rptsAfter[0].CriticalCnt)
+	assert.Equal(suite.T(), rptsBefore[0].HighCnt, rptsAfter[0].HighCnt)
+	assert.Equal(suite.T(), rptsBefore[0].MediumCnt, rptsAfter[0].MediumCnt)
+	assert.Equal(suite.T(), rptsBefore[0].LowCnt, rptsAfter[0].LowCnt)
+	assert.Equal(suite.T(), rptsBefore[0].NoneCnt, rptsAfter[0].NoneCnt)
+	assert.Equal(suite.T(), rptsBefore[0].UnknownCnt, rptsAfter[0].UnknownCnt)
+	assert.Equal(suite.T(), rptsBefore[0].FixableCnt, rptsAfter[0].FixableCnt)
+	assert.Equal(suite.T(), rptsBefore[0].Report, rptsAfter[0].Report)
+}
+
 func (suite *TestReportConverterSuite) create(r *scan.Report) {
 	id, err := suite.reportDao.Create(orm.Context(), r)
 	require.NoError(suite.T(), err)


### PR DESCRIPTION
Backport of #863 to `release-2.15`. Cherry-pick is byte-identical to the commit on `main` (`ba5ef5ce38`); original author Vadim Bauer.

## What

`nativeToRelationalSchemaConverter.ToRelationalSchema` rejects an empty raw report before it touches the database, marks the scan failed, and leaves the previous report alone.

## Why

On `release-2.15` today, a re-scan that comes back with an empty raw report still calls `SyncForReport` with an empty vulnerability set. Because the `scan_report` row is reused across re-scans, that deletes every `report_vulnerability_record` row for the report — the artifact then shows no vulnerabilities at all until the next successful scan. A transient scanner hiccup silently erases a good result, and the UI shows a clean image rather than a failed scan.

The code path is present on `release-2.15` unchanged: `src/pkg/scan/postprocessors/report_converters.go` differs from `main` by exactly this commit.

## Risk

Low. The change is a guard at the top of one function plus its tests. The behaviour it removes is the destructive one; the case it adds (empty report, no write) is the same case the structured "clean image" path already handles through `toSchema`.

## How verified

- `jj duplicate` onto `release-2.15` applied with no conflict, and the resulting diff is byte-identical to `ba5ef5ce38` (`jj diff --git` compared against the original).
- The upstream change ships its own tests in `report_converters_test.go` (62 new lines) and they come with the cherry-pick; CI on this PR runs them.
