### PR TITLE
fix(quota): Enable retry backoff on quota usage updates (backport #716)

### DIFF
--- a/src/controller/quota/controller.go
+++ b/src/controller/quota/controller.go
@@ -347,7 +347,18 @@ func (c *controller) updateUsageWithRetry(ctx context.Context, reference, refere
 
 	options := []retry.Option{
 		retry.Timeout(defaultRetryTimeout),
-		retry.Backoff(false),
+		// Exponential backoff with jitter (the retry package default). With
+		// backoff disabled, every optimistic-lock loser re-reads and re-CASes
+		// the same quota_usage row in a zero-delay loop for up to
+		// defaultRetryTimeout, so N concurrent pushes to one project turn a
+		// single conflict into a synchronized retry storm on the database.
+		retry.Backoff(true),
+		// Give up as soon as the request is gone. An aborted push already
+		// terminated on its next attempt (updateUsageByDB returns the
+		// context error wrapped in retry.Abort); the context additionally
+		// cancels an in-progress backoff sleep instead of letting it run
+		// out and paying one more wasted attempt.
+		retry.Context(ctx),
 		retry.Callback(func(err error, _ time.Duration) {
 			log.G(ctx).Debugf("failed to update the quota usage for %s %s, error: %v", reference, referenceID, err)
 		}),
@@ -456,7 +467,10 @@ func (c *controller) Update(ctx context.Context, u *quota.Quota) error {
 
 	options := []retry.Option{
 		retry.Timeout(defaultRetryTimeout),
-		retry.Backoff(false),
+		// See updateUsageWithRetry: backoff+jitter desynchronizes writers
+		// contending on the single quota row.
+		retry.Backoff(true),
+		retry.Context(ctx),
 	}
 
 	return retry.Retry(f, options...)

--- a/src/controller/quota/controller_test.go
+++ b/src/controller/quota/controller_test.go
@@ -18,11 +18,13 @@ import (
 	"context"
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/suite"
 
 	"github.com/goharbor/harbor/src/lib/orm"
+	"github.com/goharbor/harbor/src/lib/retry"
 	"github.com/goharbor/harbor/src/pkg/quota"
 	"github.com/goharbor/harbor/src/pkg/quota/driver"
 	"github.com/goharbor/harbor/src/pkg/quota/types"
@@ -95,6 +97,32 @@ func (suite *ControllerTestSuite) TestRefreshUsageExceed() {
 	referenceID := uuid.New().String()
 
 	suite.Error(suite.ctl.Refresh(ctx, suite.reference, referenceID))
+}
+
+func (suite *ControllerTestSuite) TestUpdateUsageRetriesWithBackoff() {
+	// regression test for the retry storm: optimistic-lock conflicts must
+	// go through the retry loop with a non-zero backoff sleep, so losers
+	// cannot re-CAS the contended quota_usage row in a zero-delay loop
+	suite.PrepareForUpdate(suite.quota, types.ResourceList{types.ResourceStorage: 1})
+	suite.quotaMgr.ExpectedCalls = nil
+	mock.OnAnything(suite.quotaMgr, "GetByRef").Return(suite.quota, nil)
+	mock.OnAnything(suite.quotaMgr, "Update").Return(orm.ErrOptimisticLock).Once()
+	mock.OnAnything(suite.quotaMgr, "Update").Return(nil).Once()
+
+	var sleeps []time.Duration
+	opts := []retry.Option{
+		retry.InitialInterval(time.Millisecond),
+		retry.MaxInterval(5 * time.Millisecond),
+		retry.Callback(func(_ error, sleep time.Duration) {
+			sleeps = append(sleeps, sleep)
+		}),
+	}
+
+	ctx := orm.NewContext(context.TODO(), &ormtesting.FakeOrmer{})
+	suite.Nil(suite.ctl.Refresh(ctx, suite.reference, uuid.New().String(), IgnoreLimitation(true), WithRetryOptions(opts)))
+
+	suite.Require().Len(sleeps, 1, "the optimistic-lock conflict must pass through the retry callback")
+	suite.Greater(sleeps[0], time.Duration(0), "optimistic-lock retries must back off, not spin")
 }
 
 func (suite *ControllerTestSuite) TestRefreshIgnoreLimitation() {


### PR DESCRIPTION
Backport of #716 to `release-2.15`. Cherry-pick is byte-identical to the commit on `main` (`3e29427716`).

## What

The optimistic-lock retry loops in `src/controller/quota/controller.go` stop passing `retry.Backoff(false)`, so they use the retry package's default exponential backoff with jitter.

## Why

Every loser of a version race on a `quota` row currently re-reads and re-writes with no delay at all, for up to five minutes per call. Concurrent pushes into the same project turn one hot row into a sustained write storm. The measured symptom on the incident this came from was RDS session saturation that took `/service/token` down with it — so the blast radius reached well past quota accounting.

`retry.Context` and the backoff defaults already exist on `release-2.15` at `src/lib/retry/retry.go:108`, so this is a 14-line change with no new dependencies.

## Risk

Low. Retry semantics are otherwise untouched: the same conditions are retried, the same five-minute ceiling applies, and no caller sees a different error. The observable change is that a contended update now takes slightly longer in the happy-path-after-contention case, in exchange for not melting the database.

Note that this softens the retry storm rather than removing the writes. #734 (`perf(quota): Skip usage reservation when hard limits are unlimited`) is the change that removes them, and I have deliberately **not** backported it — see the merge plan in the release report; it makes the usage figure eventually consistent and adds a background flusher, which is not patch-release-safe without a deliberate call.

## How verified

- `jj duplicate` onto `release-2.15` applied with no conflict; resulting diff byte-identical to `3e29427716`.
- The upstream change ships `controller_test.go` coverage (28 new lines) and it comes with the cherry-pick; CI on this PR runs it.
