### PR TITLE
perf(blob): Skip redundant blob Touch when blob is already StatusNone (backport #397)

### DIFF
--- a/src/server/middleware/blob/head_blob.go
+++ b/src/server/middleware/blob/head_blob.go
@@ -55,7 +55,15 @@ func handleHead(req *http.Request) error {
 	}
 
 	switch bb.Status {
-	case blob_models.StatusNone, blob_models.StatusDelete:
+	case blob_models.StatusNone:
+		if shouldTouchNone(bb) {
+			if err := blob.Ctl.Touch(req.Context(), bb); err != nil {
+				log.Errorf("failed to update blob: %s status to StatusNone, error:%v", blobInfo.Digest, err)
+				return errors.Wrapf(err, "the request id is: %s", req.Header.Get(requestid.HeaderXRequestID))
+			}
+		}
+	case blob_models.StatusDelete:
+		// GC marked this blob as a candidate: rescue it back to StatusNone.
 		if err := blob.Ctl.Touch(req.Context(), bb); err != nil {
 			log.Errorf("failed to update blob: %s status to StatusNone, error:%v", blobInfo.Digest, err)
 			return errors.Wrapf(err, "the request id is: %s", req.Header.Get(requestid.HeaderXRequestID))

--- a/src/server/middleware/blob/head_blob_test.go
+++ b/src/server/middleware/blob/head_blob_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 
 	beego_orm "github.com/beego/beego/v2/client/orm"
 	"github.com/stretchr/testify/suite"
@@ -58,6 +59,75 @@ func (suite *HeadBlobUploadMiddlewareTestSuite) TestHeadBlobStatusNone() {
 		suite.Nil(err)
 		suite.Equal(digest, blob.Digest)
 		suite.Equal(blob_models.StatusNone, blob.Status)
+	})
+}
+
+func (suite *HeadBlobUploadMiddlewareTestSuite) TestHeadBlobStatusNoneFreshSkipsTouch() {
+	suite.WithProject(func(projectID int64, projectName string) {
+		suite.T().Setenv("GC_TIME_WINDOW_HOURS", "2")
+		digest := suite.DigestString()
+
+		_, err := blob.Ctl.Ensure(suite.Context(), digest, "application/octet-stream", 512)
+		suite.Nil(err)
+		before, err := blob.Ctl.Get(suite.Context(), digest)
+		suite.Nil(err)
+
+		req := suite.makeRequest(projectName, digest)
+		res := httptest.NewRecorder()
+		next := suite.NextHandler(http.StatusOK, map[string]string{"Docker-Content-Digest": digest})
+		HeadBlobMiddleware()(next).ServeHTTP(res, req)
+		suite.Equal(http.StatusOK, res.Code)
+
+		after, err := blob.Ctl.Get(suite.Context(), digest)
+		suite.Nil(err)
+		suite.Equal(blob_models.StatusNone, after.Status)
+		suite.Equal(before.Version, after.Version, "fresh StatusNone blob must not be touched")
+	})
+}
+
+func (suite *HeadBlobUploadMiddlewareTestSuite) TestHeadBlobStatusNoneStaleTouches() {
+	suite.WithProject(func(projectID int64, projectName string) {
+		suite.T().Setenv("GC_TIME_WINDOW_HOURS", "2")
+		digest := suite.DigestString()
+
+		id, err := blob.Ctl.Ensure(suite.Context(), digest, "application/octet-stream", 512)
+		suite.Nil(err)
+		before, err := blob.Ctl.Get(suite.Context(), digest)
+		suite.Nil(err)
+		suite.Nil(backdateBlob(suite.Context(), id, 2*time.Hour))
+
+		req := suite.makeRequest(projectName, digest)
+		res := httptest.NewRecorder()
+		next := suite.NextHandler(http.StatusOK, map[string]string{"Docker-Content-Digest": digest})
+		HeadBlobMiddleware()(next).ServeHTTP(res, req)
+		suite.Equal(http.StatusOK, res.Code)
+
+		after, err := blob.Ctl.Get(suite.Context(), digest)
+		suite.Nil(err)
+		suite.Equal(blob_models.StatusNone, after.Status)
+		suite.Equal(before.Version+1, after.Version, "stale StatusNone blob must be touched to stay out of the GC window")
+	})
+}
+
+func (suite *HeadBlobUploadMiddlewareTestSuite) TestHeadBlobStatusDeleteRescued() {
+	suite.WithProject(func(projectID int64, projectName string) {
+		digest := suite.DigestString()
+
+		id, err := blob.Ctl.Ensure(suite.Context(), digest, "application/octet-stream", 512)
+		suite.Nil(err)
+
+		_, err = pkg_blob.Mgr.UpdateBlobStatus(suite.Context(), &blob_models.Blob{ID: id, Status: blob_models.StatusDelete})
+		suite.Nil(err)
+
+		req := suite.makeRequest(projectName, digest)
+		res := httptest.NewRecorder()
+		next := suite.NextHandler(http.StatusOK, map[string]string{"Docker-Content-Digest": digest})
+		HeadBlobMiddleware()(next).ServeHTTP(res, req)
+		suite.Equal(http.StatusOK, res.Code)
+
+		after, err := blob.Ctl.Get(suite.Context(), digest)
+		suite.Nil(err)
+		suite.Equal(blob_models.StatusNone, after.Status, "GC candidate must be rescued back to StatusNone")
 	})
 }
 

--- a/src/server/middleware/blob/put_blob_upload_test.go
+++ b/src/server/middleware/blob/put_blob_upload_test.go
@@ -21,6 +21,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/suite"
@@ -146,6 +147,57 @@ func (suite *PutBlobUploadMiddlewareTestSuite) TestBlobInDelete() {
 			suite.Equal(int64(512), blob.Size)
 			suite.Equal(blob_models.StatusNone, blob.Status)
 		}
+	})
+}
+
+func (suite *PutBlobUploadMiddlewareTestSuite) TestBlobFreshRePushSkipsTouch() {
+	suite.WithProject(func(projectID int64, projectName string) {
+		suite.T().Setenv("GC_TIME_WINDOW_HOURS", "2")
+		digest := suite.DigestString()
+
+		_, err := blob.Ctl.Ensure(suite.Context(), digest, "application/octet-stream", 512)
+		suite.Nil(err)
+		before, err := blob.Ctl.Get(suite.Context(), digest)
+		suite.Nil(err)
+
+		req := suite.NewRequest(http.MethodPut, fmt.Sprintf("/v2/%s/photon/blobs/uploads/%s?digest=%s", projectName, uuid.New().String(), digest), nil)
+		req.Header.Set("Content-Length", "512")
+		res := httptest.NewRecorder()
+
+		next := suite.NextHandler(http.StatusCreated, map[string]string{"Docker-Content-Digest": digest})
+		PutBlobUploadMiddleware()(next).ServeHTTP(res, req)
+		suite.Equal(http.StatusCreated, res.Code)
+
+		after, err := blob.Ctl.Get(suite.Context(), digest)
+		suite.Nil(err)
+		suite.Equal(blob_models.StatusNone, after.Status)
+		suite.Equal(before.Version, after.Version, "fresh StatusNone blob must not be touched")
+	})
+}
+
+func (suite *PutBlobUploadMiddlewareTestSuite) TestBlobStaleRePushTouches() {
+	suite.WithProject(func(projectID int64, projectName string) {
+		suite.T().Setenv("GC_TIME_WINDOW_HOURS", "2")
+		digest := suite.DigestString()
+
+		id, err := blob.Ctl.Ensure(suite.Context(), digest, "application/octet-stream", 512)
+		suite.Nil(err)
+		before, err := blob.Ctl.Get(suite.Context(), digest)
+		suite.Nil(err)
+		suite.Nil(backdateBlob(suite.Context(), id, 2*time.Hour))
+
+		req := suite.NewRequest(http.MethodPut, fmt.Sprintf("/v2/%s/photon/blobs/uploads/%s?digest=%s", projectName, uuid.New().String(), digest), nil)
+		req.Header.Set("Content-Length", "512")
+		res := httptest.NewRecorder()
+
+		next := suite.NextHandler(http.StatusCreated, map[string]string{"Docker-Content-Digest": digest})
+		PutBlobUploadMiddleware()(next).ServeHTTP(res, req)
+		suite.Equal(http.StatusCreated, res.Code)
+
+		after, err := blob.Ctl.Get(suite.Context(), digest)
+		suite.Nil(err)
+		suite.Equal(blob_models.StatusNone, after.Status)
+		suite.Equal(before.Version+1, after.Version, "stale StatusNone blob must be touched to stay out of the GC window")
 	})
 }
 

--- a/src/server/middleware/blob/util.go
+++ b/src/server/middleware/blob/util.go
@@ -26,6 +26,20 @@ import (
 	"github.com/goharbor/harbor/src/server/middleware/requestid"
 )
 
+// shouldTouchNone decides whether a blob that is already StatusNone still needs
+// a Touch. In that state Touch only bumps version/update_time to coordinate
+// with GC - a redundant single-row UPDATE that, under concurrent re-pushes of
+// the same digest, becomes a row-lock contention hot spot (the lock is held for
+// the whole request transaction on PUT manifest). Skip it while update_time is
+// fresh: GC only considers blobs older than the full time window, so anything
+// younger than half the window cannot become a candidate before this request
+// associates the blob. A non-positive window leaves no such safety margin, so
+// always touch then.
+func shouldTouchNone(bb *models.Blob) bool {
+	window := time.Duration(config.GetGCTimeWindow()) * time.Hour
+	return window <= 0 || time.Since(bb.UpdateTime) > window/2
+}
+
 // probeBlob handles config/layer and manifest status in the PUT Blob & Manifest middleware, and update the status before it passed into proxy(distribution).
 func probeBlob(r *http.Request, digest string) error {
 	logger := log.G(r.Context())
@@ -39,12 +53,26 @@ func probeBlob(r *http.Request, digest string) error {
 		return err
 	}
 
-	switch bb.Status {
-	case models.StatusNone, models.StatusDelete, models.StatusDeleteFailed:
+	// touch resets the blob to StatusNone, bumping version/update_time. Its only
+	// purpose is to coordinate with GC, so it is called only when it actually
+	// matters (see the switch below).
+	touch := func() error {
 		if err := blobController.Touch(r.Context(), bb); err != nil {
 			logger.Errorf("failed to update blob: %s status to StatusNone, error:%v", bb.Digest, err)
 			return errors.Wrapf(err, "the request id is: %s", r.Header.Get(requestid.HeaderXRequestID))
 		}
+		return nil
+	}
+
+	switch bb.Status {
+	case models.StatusNone:
+		if shouldTouchNone(bb) {
+			return touch()
+		}
+	case models.StatusDelete, models.StatusDeleteFailed:
+		// GC marked this blob for deletion but an incoming push needs it: pull it
+		// back to StatusNone (the version bump defeats GC's compare-and-swap).
+		return touch()
 	case models.StatusDeleting:
 		now := time.Now().UTC()
 		// if the deleting exceed 2 hours, marks the blob as StatusDeleteFailed

--- a/src/server/middleware/blob/util.go
+++ b/src/server/middleware/blob/util.go
@@ -26,18 +26,36 @@ import (
 	"github.com/goharbor/harbor/src/server/middleware/requestid"
 )
 
+// touchSkipMaxAge bounds how stale a blob's update_time may be before a Touch
+// is skipped. It is deliberately far below any usable GC window. The row-lock
+// contention the skip exists to remove comes from re-pushes of one digest
+// arriving within seconds of each other, so a few minutes captures nearly all
+// of it, while the liveness margin a skipped Touch leaves stays close to a
+// full GC window instead of collapsing to half of it.
+const touchSkipMaxAge = 5 * time.Minute
+
 // shouldTouchNone decides whether a blob that is already StatusNone still needs
 // a Touch. In that state Touch only bumps version/update_time to coordinate
 // with GC - a redundant single-row UPDATE that, under concurrent re-pushes of
 // the same digest, becomes a row-lock contention hot spot (the lock is held for
-// the whole request transaction on PUT manifest). Skip it while update_time is
-// fresh: GC only considers blobs older than the full time window, so anything
-// younger than half the window cannot become a candidate before this request
-// associates the blob. A non-positive window leaves no such safety margin, so
-// always touch then.
+// the whole request transaction on PUT manifest).
+//
+// Touch never makes a blob ineligible for GC; it only moves update_time
+// forward. GC collects an unassociated blob once
+// "update_time <= now() - window" (pkg/blob/dao.GetBlobsNotRefedByProjectBlob),
+// so skipping the Touch leaves the blob protected for window minus the row's
+// current age rather than for a full window. Bounding the skip to
+// touchSkipMaxAge keeps that margin at window - touchSkipMaxAge, which is the
+// same order as the unconditional-Touch behaviour it replaces. A window that is
+// not comfortably wider than touchSkipMaxAge leaves no margin worth having -
+// including the non-positive values GC_TIME_WINDOW_HOURS accepts without
+// validation - so always touch then.
 func shouldTouchNone(bb *models.Blob) bool {
 	window := time.Duration(config.GetGCTimeWindow()) * time.Hour
-	return window <= 0 || time.Since(bb.UpdateTime) > window/2
+	if window <= 2*touchSkipMaxAge {
+		return true
+	}
+	return time.Since(bb.UpdateTime) > touchSkipMaxAge
 }
 
 // probeBlob handles config/layer and manifest status in the PUT Blob & Manifest middleware, and update the status before it passed into proxy(distribution).

--- a/src/server/middleware/blob/util_db_test.go
+++ b/src/server/middleware/blob/util_db_test.go
@@ -1,0 +1,35 @@
+// Copyright Project Harbor Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build db
+
+package blob
+
+import (
+	"context"
+	"time"
+
+	"github.com/goharbor/harbor/src/lib/orm"
+)
+
+// backdateBlob rewinds a blob's update_time so tests can cross the GC
+// half-window staleness boundary checked by shouldTouchNone.
+func backdateBlob(ctx context.Context, id int64, age time.Duration) error {
+	o, err := orm.FromContext(ctx)
+	if err != nil {
+		return err
+	}
+	_, err = o.Raw("UPDATE blob SET update_time = ? WHERE id = ?", time.Now().Add(-age), id).Exec()
+	return err
+}

--- a/src/server/middleware/blob/util_test.go
+++ b/src/server/middleware/blob/util_test.go
@@ -1,0 +1,48 @@
+// Copyright Project Harbor Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package blob
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/goharbor/harbor/src/pkg/blob/models"
+)
+
+func TestShouldTouchNone(t *testing.T) {
+	cases := []struct {
+		name       string
+		window     string // GC_TIME_WINDOW_HOURS
+		updateTime time.Time
+		expected   bool
+	}{
+		{name: "fresh blob within half window", window: "2", updateTime: time.Now(), expected: false},
+		{name: "blob just inside half window", window: "2", updateTime: time.Now().Add(-59 * time.Minute), expected: false},
+		{name: "stale blob beyond half window", window: "2", updateTime: time.Now().Add(-61 * time.Minute), expected: true},
+		{name: "blob older than full window", window: "2", updateTime: time.Now().Add(-3 * time.Hour), expected: true},
+		{name: "zero window leaves no safety margin", window: "0", updateTime: time.Now(), expected: true},
+		{name: "negative window leaves no safety margin", window: "-1", updateTime: time.Now(), expected: true},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			t.Setenv("GC_TIME_WINDOW_HOURS", c.window)
+			bb := &models.Blob{Status: models.StatusNone, UpdateTime: c.updateTime}
+			assert.Equal(t, c.expected, shouldTouchNone(bb))
+		})
+	}
+}

--- a/src/server/middleware/blob/util_test.go
+++ b/src/server/middleware/blob/util_test.go
@@ -19,6 +19,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/goharbor/harbor/src/pkg/blob/models"
 )
@@ -30,10 +31,16 @@ func TestShouldTouchNone(t *testing.T) {
 		updateTime time.Time
 		expected   bool
 	}{
-		{name: "fresh blob within half window", window: "2", updateTime: time.Now(), expected: false},
-		{name: "blob just inside half window", window: "2", updateTime: time.Now().Add(-59 * time.Minute), expected: false},
-		{name: "stale blob beyond half window", window: "2", updateTime: time.Now().Add(-61 * time.Minute), expected: true},
+		{name: "fresh blob inside the skip age", window: "2", updateTime: time.Now(), expected: false},
+		{name: "blob just inside the skip age", window: "2", updateTime: time.Now().Add(-4 * time.Minute), expected: false},
+		{name: "blob just beyond the skip age", window: "2", updateTime: time.Now().Add(-6 * time.Minute), expected: true},
+		// The skip age does not scale with the window: a blob half a window old
+		// is touched, so the margin a skip leaves never falls to window/2.
+		{name: "blob at half the window is still touched", window: "2", updateTime: time.Now().Add(-1 * time.Hour), expected: true},
 		{name: "blob older than full window", window: "2", updateTime: time.Now().Add(-3 * time.Hour), expected: true},
+		// The smallest window the hours-granular setting allows.
+		{name: "one hour window still skips a fresh blob", window: "1", updateTime: time.Now(), expected: false},
+		{name: "one hour window touches a blob past the skip age", window: "1", updateTime: time.Now().Add(-6 * time.Minute), expected: true},
 		{name: "zero window leaves no safety margin", window: "0", updateTime: time.Now(), expected: true},
 		{name: "negative window leaves no safety margin", window: "-1", updateTime: time.Now(), expected: true},
 	}
@@ -43,6 +50,39 @@ func TestShouldTouchNone(t *testing.T) {
 			t.Setenv("GC_TIME_WINDOW_HOURS", c.window)
 			bb := &models.Blob{Status: models.StatusNone, UpdateTime: c.updateTime}
 			assert.Equal(t, c.expected, shouldTouchNone(bb))
+		})
+	}
+}
+
+// TestShouldTouchNoneLivenessMargin pins the property the skip has to preserve:
+// GC collects an unassociated blob once update_time <= now() - window, so a
+// skipped Touch must still leave enough margin for the push that skipped it.
+// The margin a skip leaves is window minus the row's age, and the bound on that
+// age is what this asserts - it must not scale with the window, or a small
+// window silently shrinks the margin to a fraction of itself.
+func TestShouldTouchNoneLivenessMargin(t *testing.T) {
+	for _, hours := range []string{"1", "2", "6", "24"} {
+		t.Run("window="+hours+"h", func(t *testing.T) {
+			t.Setenv("GC_TIME_WINDOW_HOURS", hours)
+
+			window, err := time.ParseDuration(hours + "h")
+			require.NoError(t, err)
+
+			// Walk the whole window a minute at a time and take the worst
+			// margin over every age the skip actually accepts.
+			worst := window
+			for age := time.Duration(0); age <= window; age += time.Minute {
+				bb := &models.Blob{Status: models.StatusNone, UpdateTime: time.Now().Add(-age)}
+				if shouldTouchNone(bb) {
+					continue // Touch runs, update_time is reset, margin is a full window.
+				}
+				if margin := window - age; margin < worst {
+					worst = margin
+				}
+			}
+
+			assert.GreaterOrEqual(t, worst, window-touchSkipMaxAge,
+				"skipping a Touch must not cost more than touchSkipMaxAge of GC liveness margin")
 		})
 	}
 }


### PR DESCRIPTION
Two commits. The first is the backport of #397 to `release-2.15`, byte-identical to the commit on `main` (`2004d1981d`); original author Bojan Zelic. The second is a review follow-up that bounds the skip — see "Review follow-up" below.

**Reviewers: this is the one backport in the 2.15.9 set that I want a second opinion on.** It is labelled `perf`, but it changes GC interaction, and a mistake there means collecting a live blob. Please check the reasoning below rather than just the tests.

> **Update:** cubic raised a P1 on exactly that, and it held up in part. The second commit fixes it; [full analysis and reproduction here](https://github.com/container-registry/harbor-next/pull/869#issuecomment-5631456473). The "Risk" section below is superseded by "Review follow-up".

## What

`probeBlob` skips the `Touch` call when the blob row is already `StatusNone` and its `update_time` is newer than half the GC time window. If the window is unset or non-positive, the old unconditional `Touch` is kept.

## Why

Every `PUT manifest` currently calls `Touch` on the manifest blob even when the row is already `StatusNone`. `Touch` is a single-row `UPDATE blob SET version = version + 1, update_time = now(), status = 'none' ...` that takes a row lock, so pushes that share a manifest blob serialise behind each other. On a busy registry this showed up as a manifest-PUT P99 in the tens of minutes.

`config.GetGCTimeWindow` and the `config`/`time` imports already exist on `release-2.15` in `src/server/middleware/blob/util.go`, so the change applies unmodified.

## Risk

This is the judgement call. The safety argument is that GC only considers blobs older than the **full** `GC_TIME_WINDOW_HOURS` window, while the skip only applies to blobs touched within **half** that window — so there is a full half-window of margin between "we declined to refresh this row" and "GC would consider it". The `window <= 0` branch preserves today's behaviour when the window is unconfigured.

If that margin argument does not hold in some deployment (for instance a very short configured window combined with a long-running push), the failure mode is severe: a live blob becoming GC-eligible. I read the logic and believe it holds, but it deserves someone who knows the GC path.

The conservative alternative is to defer this one to 2.16 and ship 2.15.9 with only #867 and #868. That costs nothing except leaving the push-latency pathology in place for 2.15 users.

## How verified

- `jj duplicate` onto `release-2.15` applied with no conflict; resulting diff byte-identical to `2004d1981d`.
- The upstream change ships 205 lines of new tests across `head_blob_test.go`, `put_blob_upload_test.go`, `util_test.go` and `util_db_test.go`, including the skip/no-skip boundary; they come with the cherry-pick and CI on this PR runs them.

## Review follow-up (commit 2)

`Touch` never makes a blob ineligible for GC — its only effect on the candidate query

```sql
WHERE pb.id IS NULL AND b.update_time <= now() - interval 'N hours'
```

is moving `update_time` forward. So the pre-#397 behaviour was a timer of length `window` started at `probeBlob`, not protection-until-association, and #397 replaced it with a timer whose floor is `window/2`. Halved margin, not a new failure mode.

The follow-up bounds the skip by a short absolute age (`touchSkipMaxAge = 5m`) instead of `window/2`, so the margin is `window - 5m` and no longer shrinks with the window. The contention win survives because concurrent re-pushes of one digest arrive seconds apart.

Verified three ways:

1. **The GC predicate, against a real Postgres.** Seeded unassociated `StatusNone` blobs at 5-minute intervals and ran the exact SQL from `dao.go:413`. Youngest eligible blob: 60 min at a 1h window, 120 min at 2h, 240 min at 4h — the boundary is exactly `update_time <= now() - window`. A 30-day-old blob *with* a `project_blob` row returns 0 rows, confirming association is total immunity.
2. **A property test that fails on the unfixed code.** `TestShouldTouchNoneLivenessMargin` walks every age across several windows and asserts the worst margin an accepted skip can leave. Against unmodified #397 it reports `31m0s` vs `55m0s` at 1h and `1h1m0s` vs `1h55m0s` at 2h; it passes with the fix.
3. `go vet` and the full `./server/middleware/blob/` package suite pass.

Two details of the P1 that did not hold, recorded so they are not re-raised: the association is **not** post-response (`middleware.AfterResponse` buffers and can `Reset()`, so a failure surfaces as a retryable push error, not a 201 over a missing blob); and "keep the blob protected until association" describes a mechanism upstream does not have — the GC time window *is* Harbor's entire answer to that gap.

**If you would rather ship 2.15.9 without any of this**, dropping the PR costs only leaving the push-latency pathology in place; nothing else in the release depends on it.

## Note for `main`

`main` carries the unmodified #397 logic and has the same halved margin. If this approach is accepted here I will open the equivalent one-commit PR against `main` so the two lines do not diverge.