### PR TITLE
ci: Separate commercial feature blocks in release notes

### DIFF
--- a/.github/scripts/update-release-notes.sh
+++ b/.github/scripts/update-release-notes.sh
@@ -247,8 +247,10 @@ if [[ "${chart_mode}" == false && -f "${series}" ]]; then
       {
         echo "### ${feature_title}"
         echo
-        printf '%s' "${feature_entries}"
-        echo
+        # printf keeps the entries verbatim; the two newlines restore the one
+        # command substitution stripped plus the blank line that separates
+        # this block from whatever follows it.
+        printf '%s\n\n' "${feature_entries}"
       } >> "${patch_notes}"
     else
       unchanged_features+=("${feature_title}")


### PR DESCRIPTION
One-line spacing fix in the commercial-features renderer added by #843.

## What

`update-release-notes.sh` writes each feature block as:

```sh
echo "### ${feature_title}"
echo
printf '%s' "${feature_entries}"
echo
```

`feature_entries` comes from a command substitution, so its trailing newline is already gone. The bare `echo` restores exactly that one newline and nothing more, which means the next `### Feature` heading — and the trailing `_No changes this release: ..._` line — start on the line immediately after the last bullet.

Rendered against a branch set where two features have entries and one does not:

```
### Branding customization

- Custom login logos now survive an upgrade (#820)
  Previously the logo reset to the Harbor default.
### Federated Robot Accounts

- Renamed identity providers (#818)
_No changes this release: Commercial Feature Gate._
```

GitHub treats that last italic line as a lazy continuation of the preceding list item, so it renders inside the bullet instead of as its own paragraph.

`printf '%s\n\n'` emits the newline the substitution stripped plus the blank line that separates the block from whatever follows, and the trailing `echo` goes away.

## Why now

Not visible on any released page yet: the renderer only reaches this branch when a patch branch has changelog entries, and none of the `changelogs/<branch>.md` files are seeded. It would have surfaced on the first release after seeding.

Found while backporting #843 to `release-2.15` (#870), which carries the same fix so the two branches do not diverge.

## Risk

None beyond the notes themselves. The engine runs at release time only, and notes can be regenerated with the `Recreate Release Notes` workflow.

## How verified

Reproduced the unfixed output above against the current script, then confirmed the fix restores a blank line before each subsequent heading and before the trailing italic line. `bash -n` clean.
