### PR TITLE
ci: Emit PR release notes verbatim in the release summary

### DIFF
--- a/.github/scripts/extract-pr-summary.mjs
+++ b/.github/scripts/extract-pr-summary.mjs
@@ -83,13 +83,11 @@ function releaseNotesSection(body) {
 
 const entries = [];
 
-// Each section is emitted verbatim — no synthesized headings or PR titles.
-// Only the source PR number is appended; the blank line keeps it out of a
-// trailing list, blockquote, or code fence.
+// Each section is emitted verbatim: no headings, no PR titles, no PR number.
 for (const number of prNumbers) {
   const section = releaseNotesSection(fetchPullRequest(number)?.body);
   if (section) {
-    entries.push(`${section}\n\n(#${number})`);
+    entries.push(section);
   }
 }
 


### PR DESCRIPTION
The release summary appended `(#N)` to every section it pulled from a PR description. That number was added by the tooling, not by the PR author, so every release note carried a reference in a shape nobody chose.

## Problem

`extract-pr-summary.mjs` reads the `## Release Notes` section out of each PR in the release and emits it under `## Summary`. It also tacked the source PR number onto the end of every section:

```js
entries.push(`${section}\n\n(#${number})`);
```

The number is already in `## What's Changed`, where each entry links to its own PR. The summary repeated it, and the repetition was templated rather than written, so an author who wanted no PR reference in their notes had no way to get that.

## Solution

Emit the section exactly as written. The PR number is still used to fetch the description; it is no longer templated into the output.

```js
entries.push(section);
```

## Type of Change

- [ ] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` / `fix!:`)
- [ ] Documentation (`docs:`)
- [ ] Refactoring (`refactor:`)
- [x] CI/CD or build changes (`ci:` / `build:`)
- [ ] Upstream Harbor cherry-pick (`upstream:`)
- [ ] Dependencies update (`chore:`)
- [ ] Tests (`test:`)

## Testing

Ran the extractor against a stubbed `gh` with two PRs, one carrying a `## Release Notes` section and one without, plus an entry with no canonical PR reference.

Before:

```
## Summary

A re-scan that yields an empty raw report no longer clears the artifact's vulnerability associations.

- bullet one
- bullet two

(#863)
```

After:

```
## Summary

A re-scan that yields an empty raw report no longer clears the artifact's vulnerability associations.

- bullet one
- bullet two
```

Bullets, blank lines and inline markdown survive untouched. PRs with no `## Release Notes` section are still skipped, and a 404 on a non-PR reference is still tolerated.

## Notes

`extract-pr-summary.mjs` exists only on `main`; `release-2.15` has no summary extractor, so there is nothing to backport.

## Checklist

- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] Commits are signed off (`git commit -s`)
- [x] No new warnings introduced
