### PR TITLE
fix(blob): Bound the Touch skip to a short staleness window

### DIFF
--- a/src/server/middleware/blob/util.go
+++ b/src/server/middleware/blob/util.go
@@ -26,18 +26,36 @@ import (
 	"github.com/goharbor/harbor/src/server/middleware/requestid"
 )
 
+// touchSkipMaxAge bounds how stale a blob's update_time may be before a Touch
+// is skipped. It is deliberately far below any usable GC window. The row-lock
+// contention the skip exists to remove comes from re-pushes of one digest
+// arriving within seconds of each other, so a few minutes captures nearly all
+// of it, while the liveness margin a skipped Touch leaves stays close to a
+// full GC window instead of collapsing to half of it.
+const touchSkipMaxAge = 5 * time.Minute
+
 // shouldTouchNone decides whether a blob that is already StatusNone still needs
 // a Touch. In that state Touch only bumps version/update_time to coordinate
 // with GC - a redundant single-row UPDATE that, under concurrent re-pushes of
 // the same digest, becomes a row-lock contention hot spot (the lock is held for
-// the whole request transaction on PUT manifest). Skip it while update_time is
-// fresh: GC only considers blobs older than the full time window, so anything
-// younger than half the window cannot become a candidate before this request
-// associates the blob. A non-positive window leaves no such safety margin, so
-// always touch then.
+// the whole request transaction on PUT manifest).
+//
+// Touch never makes a blob ineligible for GC; it only moves update_time
+// forward. GC collects an unassociated blob once
+// "update_time <= now() - window" (pkg/blob/dao.GetBlobsNotRefedByProjectBlob),
+// so skipping the Touch leaves the blob protected for window minus the row's
+// current age rather than for a full window. Bounding the skip to
+// touchSkipMaxAge keeps that margin at window - touchSkipMaxAge, which is the
+// same order as the unconditional-Touch behaviour it replaces. A window that is
+// not comfortably wider than touchSkipMaxAge leaves no margin worth having -
+// including the non-positive values GC_TIME_WINDOW_HOURS accepts without
+// validation - so always touch then.
 func shouldTouchNone(bb *models.Blob) bool {
 	window := time.Duration(config.GetGCTimeWindow()) * time.Hour
-	return window <= 0 || time.Since(bb.UpdateTime) > window/2
+	if window <= 2*touchSkipMaxAge {
+		return true
+	}
+	return time.Since(bb.UpdateTime) > touchSkipMaxAge
 }
 
 // probeBlob handles config/layer and manifest status in the PUT Blob & Manifest middleware, and update the status before it passed into proxy(distribution).

--- a/src/server/middleware/blob/util_test.go
+++ b/src/server/middleware/blob/util_test.go
@@ -19,6 +19,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/goharbor/harbor/src/pkg/blob/models"
 )
@@ -30,10 +31,16 @@ func TestShouldTouchNone(t *testing.T) {
 		updateTime time.Time
 		expected   bool
 	}{
-		{name: "fresh blob within half window", window: "2", updateTime: time.Now(), expected: false},
-		{name: "blob just inside half window", window: "2", updateTime: time.Now().Add(-59 * time.Minute), expected: false},
-		{name: "stale blob beyond half window", window: "2", updateTime: time.Now().Add(-61 * time.Minute), expected: true},
+		{name: "fresh blob inside the skip age", window: "2", updateTime: time.Now(), expected: false},
+		{name: "blob just inside the skip age", window: "2", updateTime: time.Now().Add(-4 * time.Minute), expected: false},
+		{name: "blob just beyond the skip age", window: "2", updateTime: time.Now().Add(-6 * time.Minute), expected: true},
+		// The skip age does not scale with the window: a blob half a window old
+		// is touched, so the margin a skip leaves never falls to window/2.
+		{name: "blob at half the window is still touched", window: "2", updateTime: time.Now().Add(-1 * time.Hour), expected: true},
 		{name: "blob older than full window", window: "2", updateTime: time.Now().Add(-3 * time.Hour), expected: true},
+		// The smallest window the hours-granular setting allows.
+		{name: "one hour window still skips a fresh blob", window: "1", updateTime: time.Now(), expected: false},
+		{name: "one hour window touches a blob past the skip age", window: "1", updateTime: time.Now().Add(-6 * time.Minute), expected: true},
 		{name: "zero window leaves no safety margin", window: "0", updateTime: time.Now(), expected: true},
 		{name: "negative window leaves no safety margin", window: "-1", updateTime: time.Now(), expected: true},
 	}
@@ -43,6 +50,39 @@ func TestShouldTouchNone(t *testing.T) {
 			t.Setenv("GC_TIME_WINDOW_HOURS", c.window)
 			bb := &models.Blob{Status: models.StatusNone, UpdateTime: c.updateTime}
 			assert.Equal(t, c.expected, shouldTouchNone(bb))
+		})
+	}
+}
+
+// TestShouldTouchNoneLivenessMargin pins the property the skip has to preserve:
+// GC collects an unassociated blob once update_time <= now() - window, so a
+// skipped Touch must still leave enough margin for the push that skipped it.
+// The margin a skip leaves is window minus the row's age, and the bound on that
+// age is what this asserts - it must not scale with the window, or a small
+// window silently shrinks the margin to a fraction of itself.
+func TestShouldTouchNoneLivenessMargin(t *testing.T) {
+	for _, hours := range []string{"1", "2", "6", "24"} {
+		t.Run("window="+hours+"h", func(t *testing.T) {
+			t.Setenv("GC_TIME_WINDOW_HOURS", hours)
+
+			window, err := time.ParseDuration(hours + "h")
+			require.NoError(t, err)
+
+			// Walk the whole window a minute at a time and take the worst
+			// margin over every age the skip actually accepts.
+			worst := window
+			for age := time.Duration(0); age <= window; age += time.Minute {
+				bb := &models.Blob{Status: models.StatusNone, UpdateTime: time.Now().Add(-age)}
+				if shouldTouchNone(bb) {
+					continue // Touch runs, update_time is reset, margin is a full window.
+				}
+				if margin := window - age; margin < worst {
+					worst = margin
+				}
+			}
+
+			assert.GreaterOrEqual(t, worst, window-touchSkipMaxAge,
+				"skipping a Touch must not cost more than touchSkipMaxAge of GC liveness margin")
 		})
 	}
 }


### PR DESCRIPTION
Follow-up to #397. Found while backporting it to `release-2.15` (#869, since closed — 2.15.9 carries P0 fixes only), and confirmed against the GC path rather than the comment above the function.

## What

`shouldTouchNone` bounds the skip by a short absolute age (`touchSkipMaxAge = 5m`) instead of `window/2`, and always touches when the window is not comfortably wider than that age.

## Why

`Touch` never makes a blob ineligible for GC. Its only effect on the candidate query — `pkg/blob/dao.GetBlobsNotRefedByProjectBlob`, `src/pkg/blob/dao/dao.go:413` — is moving `update_time` forward:

```sql
SELECT b.id, b.digest, b.content_type, b.status, b.version, b.size
FROM blob AS b LEFT JOIN project_blob pb ON b.id = pb.blob_id
WHERE pb.id IS NULL AND b.update_time <= now() - interval '%d hours';
```

So with `W` = window and `s` = the row's age at `probeBlob`:

| | margin before GC can collect an unassociated blob |
|---|---|
| before #397 | `W` (unconditional `Touch` resets `update_time`) |
| with #397 | `W − s`, and the skip requires `s ≤ W/2`, so a floor of **`W/2`** |
| with this PR | `W − 5m` |

At the default `W = 2h` the floor is 1h; at the smallest value the hours-granular `GC_TIME_WINDOW_HOURS` allows, 30 minutes. `GC_TIME_WINDOW_HOURS` is env-only and unvalidated — it has no entry in `src/common/config/metadata/`, so nothing stops a small value.

The widest exposure is **`head_blob.go`**, not `put_manifest.go`. nginx caps a single request at `proxy_read_timeout 900`, but a HEAD fires at the start of a `docker push` while the manifest association lands at the end, so there the protection has to span the whole push.

To be clear about what this is and is not: **#397 introduced no new failure mode.** A push outliving its blob's liveness timer was reachable beforehand for any push longer than `W`. #397 halved the timer; this restores its length.

The contention win is kept. The row-lock hot spot comes from concurrent re-pushes of one digest arriving seconds apart, so a five-minute skip absorbs the burst that produced it. The skips given up — a push arriving 40 minutes after the last one — were not contending with anything.

## How verified

**The GC predicate, against a real Postgres.** Seeded unassociated `StatusNone` blobs at five-minute intervals and ran the exact SQL from `dao.go:413`:

| window | youngest eligible blob |
|---|---|
| 1h | 60 min |
| 2h | 120 min |
| 4h | 240 min |

The boundary is exactly `update_time <= now() - window`. A 30-day-old blob **with** a `project_blob` row returns 0 rows, confirming association is total immunity — which is why the time window only has to bridge the gap until association.

**A property test that fails on the current code.** `TestShouldTouchNoneLivenessMargin` walks every age across several windows and asserts the worst margin any accepted skip can leave, rather than pinning specific arithmetic. Against `main` as it stands today:

```
window=1h:  "31m0s"    is not greater than or equal to "55m0s"
window=2h:  "1h1m0s"   is not greater than or equal to "1h55m0s"
window=6h:  "3h1m0s"   is not greater than or equal to "5h55m0s"
window=24h: "12h1m0s"  is not greater than or equal to "23h55m0s"
```

It passes with the fix. `go vet` and the full `./server/middleware/blob/` suite pass.

## Risk

Low. The change is one predicate plus its tests, confined to the `StatusNone` branch. The `StatusDelete` / `StatusDeleteFailed` rescue path still touches unconditionally, so the mark→sweep CAS (`version = ?` in `UpdateBlobStatus`) is untouched and remains the second line of defence. The direction of the change is strictly toward touching more often, so the worst case is giving back some of #397's contention win, not losing a blob.

## Note

`release-2.15` does **not** have #397 at all — the backport was closed — so there is nothing to keep in sync there.
